### PR TITLE
chore(brand-profile): remove duplicate Factual Ground tip card

### DIFF
--- a/src/components/views/BrandProfile.tsx
+++ b/src/components/views/BrandProfile.tsx
@@ -237,37 +237,6 @@ export function BrandProfile() {
         </div>
       )}
 
-      {/* Factual Ground discovery tip — surface the override path so users don't suffer in silence */}
-      <div style={{
-        padding: '12px 16px',
-        marginBottom: 16,
-        background: 'rgba(20, 184, 166, 0.06)',
-        border: '1px solid rgba(20, 184, 166, 0.25)',
-        borderRadius: 10,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        fontSize: 13,
-        lineHeight: 1.55
-      }}>
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#14B8A6" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
-          <circle cx="12" cy="12" r="10"/>
-          <path d="M12 16v-4"/>
-          <path d="M12 8h.01"/>
-        </svg>
-        <div style={{ color: '#334155' }}>
-          Something look off? Anything you add to{' '}
-          <a
-            href="/app/brand-settings#factual-ground"
-            onClick={e => { e.preventDefault(); navigate('/app/brand-settings#factual-ground'); }}
-            style={{ color: '#0d9488', fontWeight: 600, textDecoration: 'underline', cursor: 'pointer' }}
-          >
-            Factual Ground
-          </a>{' '}
-          is used <strong>verbatim</strong> in every generated article — use it to override anything the profile got wrong.
-        </div>
-      </div>
-
       <div className="profile-tabs">
         <button
           className={`tab-button ${activeTab === 'facts' ? 'active' : ''}`}


### PR DESCRIPTION
## Summary

Removes a duplicate guidance card on the Brand Profile page.

The teal info card above the profile tabs ("Something look off? Anything you add to **Factual Ground** is used **verbatim** in every generated article — use it to override anything the profile got wrong.") repeated the same message already provided by the in-tab `facts-intro-banner` ("Anything wrong here? Correct it in **Factual Ground** — then re-run the analysis.").

The in-tab banner is the canonical override CTA because it sits inside the Brand Facts tab where users are actually reviewing the wrong facts. The floating card above the tabs was just noise.

## What changed

- `src/components/views/BrandProfile.tsx`: deleted the 31-line floating tip card (lines 240–269 on main).
- The `useNavigate` import stays — the Brand Facts banner's "Correct these? →" button still uses it.

## What did NOT change

- The `facts-intro-banner` inside the Brand Facts tab — preserved.
- The smaller per-card hints ("If any of these are wrong, fix them in Factual Ground's Competitors field…") — preserved.

## Build

`npm run build` passes. JS bundle dropped ~250 bytes gzipped.

## Test plan

- [ ] Open `/app/context-hub` with a complete brand profile → confirm the teal "Something look off?" card no longer renders between the profile header (and Deploy This Brain section) and the tabs.
- [ ] Click the **Brand Facts** tab → confirm the "Double-check what Forge learned" banner with the **Correct these? →** button still appears and routes to `/app/brand-settings`.
- [ ] Confirm no visual gap or stranded margin where the removed card used to live.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_