### PR TITLE
feat(quick-start): no-website onramp + partner-agnostic Deploy card

### DIFF
--- a/server.js
+++ b/server.js
@@ -3710,8 +3710,209 @@ app.post('/api/domain/check', async (req, res) => {
   }
 });
 
+// ── Quick Start: synthesize a brand profile from a Founder Brief ──────────
+// Used when the founder has no marketing website (typical Lovable / vibe-coding
+// audience). We skip Firecrawl, Sonar, and the cache check; Claude generates
+// the full BrandProfile JSON from the structured Founder Brief alone.
+//
+// Each Quick Start gets a synthetic brand_url ("quickstart://<uuid>") so the
+// `idx_bp_active_url` unique-by-active index never collides with real domains
+// and so /app/context-hub re-analyze never tries to re-scrape a non-existent
+// site. Anonymous-session semantics (24h expiry, onboard_session_id) match the
+// URL-based flow exactly so Clerk signup can later claim these rows.
+function quickStartTruncate(value, maxLength) {
+  if (typeof value !== 'string') return '';
+  return value.length > maxLength ? value.slice(0, maxLength).trim() + '…' : value;
+}
+
+async function handleQuickStartSynthesis(req, res) {
+  const startTime = Date.now();
+  try {
+    const fg = req.body.factualGround || {};
+    const required = ['brandName', 'whatWeDo', 'whatWeDoNot', 'competitors'];
+    for (const k of required) {
+      if (typeof fg[k] !== 'string' || fg[k].trim().length === 0) {
+        return res.status(400).json({ success: false, error: `factualGround.${k} is required` });
+      }
+    }
+
+    const brandName = fg.brandName.trim();
+    const sessionId = req.body.sessionId || null;
+    const syntheticBrandUrl = `quickstart://${randomUUID()}`;
+
+    const briefLines = [
+      `**Brand Name:** ${brandName}`,
+      ``,
+      `**What we actually do (founder's own words):**`,
+      quickStartTruncate(fg.whatWeDo, 2000),
+      ``,
+      `**What we explicitly do NOT do (out of scope, common misconceptions):**`,
+      quickStartTruncate(fg.whatWeDoNot, 2000),
+      ``,
+      `**Competitors / who buyers also evaluate:**`,
+      quickStartTruncate(fg.competitors, 1500),
+    ];
+    if (fg.foundingStory && fg.foundingStory.trim()) {
+      briefLines.push('', `**Founding story:**`, quickStartTruncate(fg.foundingStory, 1500));
+    }
+    if (fg.methodology && fg.methodology.trim()) {
+      briefLines.push('', `**Methodology / approach:**`, quickStartTruncate(fg.methodology, 1500));
+    }
+    if (fg.teamComposition && fg.teamComposition.trim()) {
+      briefLines.push('', `**Team composition:**`, quickStartTruncate(fg.teamComposition, 1000));
+    }
+    if (fg.quotablePositions && fg.quotablePositions.trim()) {
+      briefLines.push('', `**Quotable positions / hot takes:**`, quickStartTruncate(fg.quotablePositions, 1500));
+    }
+    if (fg.namedAuthors && fg.namedAuthors.trim()) {
+      briefLines.push('', `**Named authors (real humans to attribute):**`, quickStartTruncate(fg.namedAuthors, 800));
+    }
+    const founderBrief = briefLines.join('\n');
+
+    const prompt = `You are the Forge Intelligence Context Agent — Stage 1 of an 8-stage Brand Intelligence platform.
+
+The following brand context was provided DIRECTLY by the founder via a Quick Start form. There is no website to scrape and no third-party signals. Generate a complete brand profile using ONLY the provided information.
+
+CRITICAL RULES:
+- Do NOT hallucinate details not present in the Founder Brief. If you don't know something, say so or omit it — never invent personas, competitors, or positioning that isn't supported by the brief.
+- The "What we explicitly do NOT do" content is INTENTIONAL — those non-actions surface as strategicMoats, NOT as competitiveGaps. competitiveGaps should be derived from what the brand CAN compete on but isn't yet talking about.
+- discoveredCompetitors must come from the founder's competitors list verbatim. Do not invent additional competitors.
+- For visualStyle / accentColor: with no website to inspect, use conservative defaults grounded in the brand category. Mark accentColor as a descriptor like 'neutral slate' or 'deep indigo' rather than guessing a hex.
+
+## FOUNDER BRIEF
+
+${founderBrief}
+
+Return ONLY valid JSON (no markdown, no explanation, no newlines inside string values — use spaces instead):
+{
+  "brandName": "${brandName.replace(/"/g, '\\"')}",
+  "voiceProfile": {
+    "summary": "string",
+    "toneAttributes": [{ "attribute": "string", "score": 0-100, "description": "string" }],
+    "writingStyle": "string",
+    "keyPhrases": ["string"],
+    "industry": "string",
+    "positioning": "string — one tight sentence: what they do, for whom, why they win",
+    "targetPersona": "string — primary buyer in plain language",
+    "visualStyle": "string — conservative descriptor since there's no site to inspect",
+    "accentColor": "string — descriptor like 'deep indigo' or 'neutral slate', not a guessed hex"
+  },
+  "personas": [{
+    "id": "string", "name": "string", "role": "string",
+    "painPoints": ["string"], "triggers": ["string"],
+    "skepticism": "string", "motivations": ["string"]
+  }],
+  "thirdPartySignals": [],
+  "competitiveGaps": [{ "topic": "string", "ownedBy": "string or null", "whitespaceOpportunity": "string", "priority": "high|medium|low" }],
+  "strategicMoats": [{ "capability": "string — drawn directly from 'What we do NOT do'", "rationale": "string", "protects": "string" }],
+  "strategicRecommendations": [{ "id": "string", "category": "string", "title": "string", "description": "string", "impact": "high|medium|low", "effort": "high|medium|low" }],
+  "campaignArcs": [{ "id": "string", "title": "string", "thesis": "string", "acts": [{ "actNumber": 1, "actTitle": "string", "actPremise": "string" }], "recommendedLength": "number 3-8", "targetPersona": "string" }],
+  "businessProfile": {
+    "whatTheyDo": "string — drawn from 'What we actually do'",
+    "productsOrServices": ["string"],
+    "revenueModel": "string",
+    "targetBuyer": "string",
+    "companyScale": "string",
+    "geography": "string"
+  },
+  "discoveredCompetitors": ["string — verbatim from founder's competitors list"],
+  "marketCategory": "string"
+}
+Requirements: 5 toneAttributes, 2-3 personas, 0 thirdPartySignals (no website to inspect), 3-5 competitiveGaps (real missed opportunities), 1-4 strategicMoats (one per item in 'What we do NOT do'), 4-6 strategicRecommendations, 2-4 campaignArcs, 1 businessProfile (all fields required). Ground every field in the Founder Brief.`;
+
+    let profileData;
+    let lastErr;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const message = await anthropic.messages.create({
+          model: 'claude-opus-4-6',
+          max_tokens: 8192,
+          messages: [{ role: 'user', content: prompt }]
+        });
+        const raw = message.content[0].text;
+        const jsonMatch = raw.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) { lastErr = new Error('Claude returned no valid JSON'); continue; }
+        try {
+          profileData = safeParseLLM(jsonMatch[0], 'object', 'quick-start');
+          break;
+        } catch (parseErr) {
+          const fixed = jsonMatch[0].replace(/:\s*"([\s\S]*?)"/g, (m, val) => ': "' + val.replace(/\n/g, ' ').replace(/\r/g, ' ') + '"');
+          profileData = JSON.parse(fixed);
+          break;
+        }
+      } catch (e) { lastErr = e; }
+    }
+    if (!profileData) {
+      console.error('[QUICK-START] Claude synthesis failed:', lastErr?.message);
+      return res.status(502).json({ success: false, error: 'Synthesis failed', details: lastErr?.message || 'Unknown error' });
+    }
+
+    // Stamp Quick Start provenance into the JSONB so downstream tooling can
+    // distinguish profiles built from a Founder Brief vs. ones built from a
+    // real website scan, without requiring a schema migration.
+    profileData.source = 'quick-start';
+    profileData.factualGround = {
+      brandName,
+      whatWeDo: quickStartTruncate(fg.whatWeDo, 4000),
+      whatWeDoNot: quickStartTruncate(fg.whatWeDoNot, 4000),
+      competitors: quickStartTruncate(fg.competitors, 2000),
+      foundingStory: quickStartTruncate(fg.foundingStory || '', 4000),
+      methodology: quickStartTruncate(fg.methodology || '', 3000),
+      teamComposition: quickStartTruncate(fg.teamComposition || '', 2000),
+      quotablePositions: quickStartTruncate(fg.quotablePositions || '', 3000),
+      namedAuthors: quickStartTruncate(fg.namedAuthors || '', 1500),
+      logoUrl: typeof fg.logoUrl === 'string' ? fg.logoUrl.slice(0, 500) : '',
+    };
+
+    const id = randomUUID();
+    const logoUrl = typeof fg.logoUrl === 'string' && fg.logoUrl.trim() ? fg.logoUrl.trim() : '';
+    const expiresClause = req.userId ? 'NULL' : "NOW() + INTERVAL '24 hours'";
+    const inserted = await pool.query(
+      `INSERT INTO brand_profiles
+         (id, brand_url, brand_name, version, is_active, cache_status, profile_data, logo_url, clerk_user_id, onboard_session_id, expires_at, created_at, updated_at)
+       VALUES ($1, $2, $3, 1, true, 'fresh', $4, $5, $6, $7, ${expiresClause}, NOW(), NOW())
+       RETURNING *`,
+      [id, syntheticBrandUrl, brandName, JSON.stringify(profileData), logoUrl, req.userId || null, sessionId]
+    );
+    const r = inserted.rows[0];
+    const latencyMs = Date.now() - startTime;
+    console.log(`[QUICK-START] Created brand ${r.id} for "${brandName}" in ${latencyMs}ms`);
+
+    return res.json({
+      success: true,
+      cached: false,
+      data: {
+        id: r.id,
+        brandUrl: r.brand_url,
+        brandName: r.brand_name,
+        version: r.version,
+        isActive: r.is_active,
+        cacheStatus: r.cache_status,
+        latencyMs,
+        discoveredCompetitors: Array.isArray(profileData.discoveredCompetitors) ? profileData.discoveredCompetitors : [],
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+        ...profileData,
+      },
+    });
+  } catch (err) {
+    console.error('[QUICK-START]', err.message);
+    return res.status(500).json({ success: false, error: 'Internal error', details: err.message });
+  }
+}
+
 app.post('/api/context-hub/analyze', softAuth, async (req, res) => {
   const { brandUrl, competitorUrls = [], audienceNotes = '', strategicNotes = '', checkBrainFirst = true, saveToBrain = true } = req.body;
+
+  // ── Quick Start branch ────────────────────────────────────────────────────
+  // No website to scrape — the founder gave us a structured Founder Brief
+  // (factualGround) and we synthesize a profile from those fields alone.
+  // Skips Firecrawl, Sonar, and cache check (each Quick Start run gets a
+  // synthetic unique brand_url so it never collides with a real domain).
+  if (!brandUrl && req.body.factualGround && typeof req.body.factualGround === 'object') {
+    return handleQuickStartSynthesis(req, res);
+  }
+
   if (!brandUrl) {
     return res.status(400).json({ success: false, error: 'brandUrl is required' });
   }

--- a/src/components/BuildWithPartnerButton.tsx
+++ b/src/components/BuildWithPartnerButton.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useAuth } from '@clerk/clerk-react';
 import { Rocket, ExternalLink, Copy, Loader2, Info } from 'lucide-react';
+import { activePartner } from '../config/deployPartner';
 
 type Phase = 'idle' | 'loading' | 'fallback' | 'error';
 
-interface BuildWithLovableButtonProps {
+interface BuildWithPartnerButtonProps {
   brandProfileId: string;
   brandName?: string;
   appType?: string;
@@ -15,7 +16,7 @@ interface BuildWithLovableButtonProps {
 interface PromptPackResponse {
   success: boolean;
   data?: {
-    platform: 'lovable';
+    platform: string;
     brandProfileId: string;
     appType: string;
     recommendedAppName: string;
@@ -39,19 +40,20 @@ const EXTERNAL = (
   <ExternalLink size={14} strokeWidth={1.5} aria-hidden="true" />
 );
 
-export function BuildWithLovableButton({
+export function BuildWithPartnerButton({
   brandProfileId,
   brandName,
   appType = 'content-command-center',
   variant = 'primary',
   disabled = false,
-}: BuildWithLovableButtonProps) {
+}: BuildWithPartnerButtonProps) {
   const { getToken } = useAuth();
   const [phase, setPhase] = useState<Phase>('idle');
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [fallbackPrompt, setFallbackPrompt] = useState<string>('');
   const [copyStatus, setCopyStatus] = useState<string>('');
 
+  const partner = activePartner;
   const isDisabled = disabled || phase === 'loading';
 
   const handleClick = async () => {
@@ -61,7 +63,7 @@ export function BuildWithLovableButton({
     setCopyStatus('');
     try {
       const token = await getToken();
-      const res = await fetch('/api/forge/prompt-pack/lovable', {
+      const res = await fetch(partner.endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -86,7 +88,7 @@ export function BuildWithLovableButton({
       // user gets every byte of context, not the truncated compact version.
       let promptForFallback = pack.prompt;
       try {
-        const fullRes = await fetch('/api/forge/prompt-pack/lovable', {
+        const fullRes = await fetch(partner.endpoint, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -102,7 +104,7 @@ export function BuildWithLovableButton({
       setFallbackPrompt(promptForFallback);
       setPhase('fallback');
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : 'Could not generate Lovable prompt. Try again.';
+      const msg = e instanceof Error ? e.message : `Could not generate ${partner.name} prompt. Try again.`;
       setErrorMsg(msg);
       setPhase('error');
     }
@@ -112,14 +114,14 @@ export function BuildWithLovableButton({
     if (!fallbackPrompt) return;
     try {
       await navigator.clipboard.writeText(fallbackPrompt);
-      setCopyStatus('Copied. Paste into Lovable’s prompt box.');
+      setCopyStatus(`Copied. Paste into ${partner.name}’s prompt box.`);
     } catch {
       setCopyStatus('Clipboard blocked by browser. Select the prompt manually and copy.');
     }
   };
 
-  const handleOpenLovable = () => {
-    window.open('https://lovable.dev/', '_blank', 'noopener,noreferrer');
+  const handleOpenPartner = () => {
+    window.open(partner.homepageUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleDismissFallback = () => {
@@ -154,8 +156,12 @@ export function BuildWithLovableButton({
     opacity: isDisabled ? 0.6 : 1,
   };
 
-  const label = phase === 'loading' ? 'Packing brand brain…' : 'Build with Lovable';
+  const label = phase === 'loading' ? 'Packing brand brain…' : partner.ctaLabel;
   const icon = phase === 'loading' ? <Loader2 size={16} strokeWidth={1.5} aria-hidden="true" style={{ animation: 'forge-spin 1s linear infinite' }} /> : ROCKET;
+  const firstUseHint = `First time? ${partner.name} will ask you to sign in — your brand prompt is preserved and the app starts building right after.`;
+  const subtitle = brandName
+    ? `Turn ${brandName}’s Brand Brain into a working product. Your brand brain becomes the foundation.`
+    : 'Turn this Brand Brain into a working product. Your brand brain becomes the foundation.';
 
   return (
     <section
@@ -178,13 +184,11 @@ export function BuildWithLovableButton({
             Deploy This Brain
           </h3>
           <p style={{ margin: '4px 0 0', fontSize: 13, color: '#64748b', lineHeight: 1.5 }}>
-            Turn {brandName ? `${brandName}’s` : 'this'} Brand Brain into a working app.
+            {subtitle}
           </p>
           <p style={{ display: 'flex', alignItems: 'flex-start', gap: 6, margin: '6px 0 0', fontSize: 12, color: '#94a3b8', lineHeight: 1.45 }}>
             <Info size={13} strokeWidth={1.5} aria-hidden="true" style={{ flexShrink: 0, marginTop: 1 }} />
-            <span>
-              First time? Lovable will ask you to sign in — your brand prompt is preserved and the app starts building right after.
-            </span>
+            <span>{firstUseHint}</span>
           </p>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
@@ -193,7 +197,7 @@ export function BuildWithLovableButton({
             onClick={handleClick}
             disabled={isDisabled}
             aria-busy={phase === 'loading'}
-            title={disabled ? 'Brand profile is incomplete — run a full analysis first' : 'Opens Lovable in a new tab with this Brand Brain pre-loaded. On first use, Lovable will ask you to sign in — your prompt is preserved and building starts automatically after auth.'}
+            title={disabled ? 'Brand profile is incomplete — run a full analysis first' : partner.tooltip}
             style={primaryStyle}
           >
             <span style={{ display: 'inline-flex', alignItems: 'center' }}>{icon}</span>
@@ -204,7 +208,7 @@ export function BuildWithLovableButton({
           </button>
           {phase === 'error' && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: '#B91C1C' }}>
-              <span>{errorMsg || 'Could not generate Lovable prompt.'}</span>
+              <span>{errorMsg || `Could not generate ${partner.name} prompt.`}</span>
               <button
                 type="button"
                 onClick={handleRetry}
@@ -240,7 +244,7 @@ export function BuildWithLovableButton({
           }}
         >
           <div style={{ fontSize: 13, color: '#0F172A', marginBottom: 8, lineHeight: 1.5 }}>
-            This Brand Brain is too rich for a safe one-click URL. Copy the prompt and paste it into Lovable.
+            This Brand Brain is too rich for a safe one-click URL. Copy the prompt and paste it into {partner.name}.
           </div>
           <textarea
             readOnly
@@ -286,7 +290,7 @@ export function BuildWithLovableButton({
             </button>
             <button
               type="button"
-              onClick={handleOpenLovable}
+              onClick={handleOpenPartner}
               style={{
                 display: 'inline-flex',
                 alignItems: 'center',
@@ -304,7 +308,7 @@ export function BuildWithLovableButton({
                 lineHeight: 1,
               }}
             >
-              <ExternalLink size={14} strokeWidth={1.5} aria-hidden="true" /> Open Lovable
+              <ExternalLink size={14} strokeWidth={1.5} aria-hidden="true" /> Open {partner.name}
             </button>
             <button
               type="button"
@@ -336,4 +340,4 @@ export function BuildWithLovableButton({
   );
 }
 
-export default BuildWithLovableButton;
+export default BuildWithPartnerButton;

--- a/src/components/views/BrandProfile.tsx
+++ b/src/components/views/BrandProfile.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { useAuth } from '@clerk/clerk-react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../../context/AppContext';
-import { BuildWithLovableButton } from '../BuildWithLovableButton';
+import { BuildWithPartnerButton } from '../BuildWithPartnerButton';
 import './BrandProfile.css';
 
 // Lucide-style icons
@@ -218,7 +218,7 @@ export function BrandProfile() {
         </div>
       </div>
 
-      <BuildWithLovableButton
+      <BuildWithPartnerButton
         brandProfileId={brandProfile.id}
         brandName={brandProfile.brandName}
         disabled={!brandProfile.voiceProfile || !brandProfile.voiceProfile.summary}

--- a/src/components/views/NewAnalysis.tsx
+++ b/src/components/views/NewAnalysis.tsx
@@ -142,6 +142,15 @@ export function NewAnalysis() {
                 <button onClick={() => setScanError("")} style={{ background: 'none', border: 'none', color: 'inherit', textDecoration: 'underline', cursor: 'pointer', fontSize: 'inherit', padding: 0, fontFamily: 'inherit' }}>Try again</button>
               </p>
             )}
+            <p style={{ fontSize: '0.8125rem', color: '#64748b', margin: '8px 0 0', lineHeight: 1.5 }}>
+              No website yet?{' '}
+              <a
+                href="/app/quick-start"
+                style={{ color: '#4F46E5', fontWeight: 500, textDecoration: 'underline', textUnderlineOffset: 2 }}
+              >
+                Build a Brand Brain from a Founder Brief instead →
+              </a>
+            </p>
             <div className="auto-discover-hint">
               <span className="hint-pipeline">
                 <span className="hint-step">

--- a/src/config/deployPartner.ts
+++ b/src/config/deployPartner.ts
@@ -1,0 +1,36 @@
+// Deploy partner config — swap the vibe-coding partner via VITE_DEPLOY_PARTNER
+// without touching component code. Each partner entry drives the display copy
+// on the "Deploy This Brain" card and points the button at the partner's
+// prompt-pack endpoint. Adding a new partner = adding an entry below + a
+// matching server endpoint at /api/forge/prompt-pack/<key>.
+
+export interface DeployPartner {
+  key: string;
+  name: string;
+  endpoint: string;
+  homepageUrl: string;
+  tooltip: string;
+  ctaLabel: string;
+}
+
+const partners: Record<string, DeployPartner> = {
+  lovable: {
+    key: 'lovable',
+    name: 'Lovable',
+    endpoint: '/api/forge/prompt-pack/lovable',
+    homepageUrl: 'https://lovable.dev/',
+    tooltip: 'Opens Lovable in a new tab with this Brand Brain pre-loaded. On first use, Lovable will ask you to sign in — your prompt is preserved and building starts automatically after auth.',
+    ctaLabel: 'Build with Lovable',
+  },
+  bolt: {
+    key: 'bolt',
+    name: 'Bolt',
+    endpoint: '/api/forge/prompt-pack/bolt',
+    homepageUrl: 'https://bolt.new/',
+    tooltip: 'Opens Bolt in a new tab with this Brand Brain pre-loaded. On first use, Bolt will ask you to sign in — your prompt is preserved and building starts automatically after auth.',
+    ctaLabel: 'Build with Bolt',
+  },
+};
+
+const partnerKey = (import.meta.env.VITE_DEPLOY_PARTNER as string | undefined) || 'lovable';
+export const activePartner: DeployPartner = partners[partnerKey] || partners.lovable;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,6 +30,7 @@ import PrivacyPage from './pages/PrivacyPage';
 import TermsPage from './pages/TermsPage';
 import AcceptableUsePage from './pages/AcceptableUsePage';
 import EmailCampaignPage from './pages/EmailCampaignPage';
+import QuickStartPage from './pages/QuickStartPage';
 import './index.css';
 
 
@@ -84,6 +85,12 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/product" element={<Product />} />
           <Route path="/faq" element={<Faq />} />
         <Route path="/welcome" element={<WelcomePage />} />
+
+        {/* Public Quick Start onramp — no Clerk gate, no AppProvider. Founders
+            without a marketing website fill the Founder Brief here; submission
+            stashes the brief in sessionStorage and redirects to /app/context-hub
+            which handles the synthesis + brand-profile transition. */}
+        <Route path="/app/quick-start" element={<QuickStartPage />} />
 
         {/* App — all product routes live under /app/ */}
         <Route

--- a/src/pages/ContextAgentPage.tsx
+++ b/src/pages/ContextAgentPage.tsx
@@ -93,6 +93,100 @@ function ContextAgentPage() {
       });
   }, []);
 
+  // Quick Start handoff — founder filled the Founder Brief at /app/quick-start
+  // (no website to scrape) and we picked up the brief from sessionStorage.
+  // Mirrors the URL onboarding flow above: same 5-stage animation, same final
+  // setBrandProfile + ?brand= URL rewrite, just hits the analyze endpoint with
+  // { factualGround, sessionId } instead of { brandUrl }.
+  useEffect(() => {
+    if (firedRef.current) return;
+    const briefJson = sessionStorage.getItem('forge_onboard_factual_ground');
+    if (!briefJson) return;
+    firedRef.current = true;
+    sessionStorage.removeItem('forge_onboard_factual_ground');
+
+    let factualGround: Record<string, string> | null = null;
+    try { factualGround = JSON.parse(briefJson); } catch { return; }
+    if (!factualGround) return;
+
+    // Preserve the anonymous session token so a later Clerk signup can claim
+    // the profile (the server stamped this same token onto onboard_session_id).
+    let sessionId: string;
+    try {
+      sessionId = localStorage.getItem('forge_quick_start_session')
+        || (crypto.randomUUID ? crypto.randomUUID() : `qs-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      localStorage.setItem('forge_quick_start_session', sessionId);
+    } catch {
+      sessionId = `qs-${Date.now()}`;
+    }
+
+    setCurrentView('active-run');
+    setIsProcessing(true);
+
+    const stageTimings = [12500, 15500, 19000, 15500, 12500];
+    let cancelled = false;
+    let stages: ProcessingStage[] = initialProcessingStages.map(s => ({ ...s, status: 'pending' as const }));
+
+    const driveStages = async () => {
+      for (let i = 0; i < stageTimings.length; i++) {
+        if (cancelled) break;
+        stages = stages.map((s, idx) =>
+          idx === i ? { ...s, status: 'running' as const, startTime: Date.now() } : s
+        );
+        setProcessingStages([...stages]);
+        await new Promise(r => setTimeout(r, stageTimings[i]));
+        if (cancelled) break;
+        stages = stages.map((s, idx) =>
+          idx === i ? { ...s, status: 'complete' as const, endTime: Date.now() } : s
+        );
+        setProcessingStages([...stages]);
+      }
+    };
+
+    driveStages();
+
+    fetch('/api/context-hub/analyze', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ factualGround, sessionId, source: 'quick-start' }),
+    })
+      .then(r => r.json())
+      .then(d => {
+        cancelled = true;
+        if (d.success && d.data) {
+          setProcessingStages(initialProcessingStages.map(s => ({ ...s, status: 'complete' as const })));
+          setBrandProfile(d.data);
+
+          const activeBrand = {
+            id: d.data.id,
+            brandUrl: d.data.brandUrl,
+            brandName: d.data.brandName,
+            expiresAt: d.data.expiresAt || null,
+            isPaid: d.data.isPaid || false,
+          };
+          try { localStorage.setItem('forge_active_brand', JSON.stringify(activeBrand)); } catch(e) {}
+          try { localStorage.setItem('forge_active_brand_id', d.data.id); } catch(e) {}
+          window.history.replaceState({}, '', `/app/context-hub?brand=${d.data.id}`);
+          setIsProcessing(false);
+          setCurrentView('brand-profile');
+        } else {
+          setIsProcessing(false);
+          setCurrentView('new-analysis');
+          window.dispatchEvent(new CustomEvent('forge:scan-error', {
+            detail: { message: d?.error || d?.details || 'Synthesis failed. Please try again.' }
+          }));
+        }
+      })
+      .catch((err) => {
+        cancelled = true;
+        setIsProcessing(false);
+        setCurrentView('new-analysis');
+        window.dispatchEvent(new CustomEvent('forge:scan-error', {
+          detail: { message: err?.message || 'Synthesis failed. Please try again.' }
+        }));
+      });
+  }, []);
+
   // Seed URL from active brand when landing on new-analysis with no pending onboard URL
   // This covers the full-page-reload path (window.location.href navigation)
   useEffect(() => {

--- a/src/pages/QuickStartPage.css
+++ b/src/pages/QuickStartPage.css
@@ -1,0 +1,229 @@
+.quick-start-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fafc 0%, #ffffff 100%);
+  padding: 48px 24px 96px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  color: #0f172a;
+}
+
+.qs-header {
+  max-width: 720px;
+  margin: 0 auto 36px;
+  text-align: center;
+}
+
+.qs-eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #4f46e5;
+  margin-bottom: 12px;
+}
+
+.qs-headline {
+  font-size: 36px;
+  line-height: 1.12;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 12px;
+  color: #0f172a;
+}
+
+.qs-subhead {
+  font-size: 17px;
+  line-height: 1.5;
+  color: #475569;
+  margin: 0;
+  max-width: 560px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.qs-form {
+  max-width: 720px;
+  margin: 0 auto;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 4px 16px rgba(15, 23, 42, 0.04);
+}
+
+.qs-section-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 20px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.qs-field {
+  margin-bottom: 20px;
+}
+
+.qs-field label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 6px;
+  line-height: 1.4;
+}
+
+.qs-field label em {
+  font-style: normal;
+  text-decoration: underline;
+  text-decoration-color: #f97316;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
+
+.qs-req {
+  color: #ef4444;
+  font-weight: 700;
+  margin-left: 2px;
+}
+
+.qs-optional {
+  color: #94a3b8;
+  font-weight: 400;
+  font-size: 12px;
+  margin-left: 4px;
+}
+
+.qs-field input,
+.qs-field textarea {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #0f172a;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-sizing: border-box;
+  line-height: 1.5;
+}
+
+.qs-field textarea {
+  resize: vertical;
+  min-height: 64px;
+}
+
+.qs-field input::placeholder,
+.qs-field textarea::placeholder {
+  color: #94a3b8;
+}
+
+.qs-field input:focus,
+.qs-field textarea:focus {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.12);
+}
+
+.qs-helper {
+  font-size: 12px;
+  color: #64748b;
+  line-height: 1.5;
+  margin: 6px 0 0;
+}
+
+.qs-helper strong {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.qs-advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 0 20px;
+  padding: 8px 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: #4f46e5;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.qs-advanced-toggle:hover {
+  color: #3730a3;
+}
+
+.qs-advanced {
+  padding-top: 8px;
+  border-top: 1px dashed #e2e8f0;
+  margin-bottom: 24px;
+}
+
+.qs-actions {
+  margin-top: 28px;
+  padding-top: 24px;
+  border-top: 1px solid #f1f5f9;
+}
+
+.qs-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  height: 48px;
+  padding: 0 24px;
+  font-size: 15px;
+  font-weight: 600;
+  border-radius: 10px;
+  background: #4f46e5;
+  color: #fff;
+  border: 1px solid #4f46e5;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+  box-sizing: border-box;
+  transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.qs-submit:hover:not(:disabled) {
+  background: #4338ca;
+  border-color: #4338ca;
+}
+
+.qs-submit:disabled {
+  background: #cbd5e1;
+  border-color: #cbd5e1;
+  color: #f8fafc;
+  cursor: not-allowed;
+}
+
+.qs-loading-note {
+  font-size: 12px;
+  color: #94a3b8;
+  margin: 12px 0 0;
+  text-align: center;
+  line-height: 1.5;
+}
+
+@media (max-width: 600px) {
+  .quick-start-page {
+    padding: 24px 16px 64px;
+  }
+  .qs-form {
+    padding: 20px;
+    border-radius: 12px;
+  }
+  .qs-headline {
+    font-size: 28px;
+  }
+  .qs-subhead {
+    font-size: 15px;
+  }
+}

--- a/src/pages/QuickStartPage.tsx
+++ b/src/pages/QuickStartPage.tsx
@@ -1,0 +1,242 @@
+import { useState, FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronDown, ChevronUp, Rocket } from 'lucide-react';
+import './QuickStartPage.css';
+
+interface FounderBrief {
+  brandName: string;
+  whatWeDo: string;
+  whatWeDoNot: string;
+  competitors: string;
+  foundingStory: string;
+  methodology: string;
+  teamComposition: string;
+  quotablePositions: string;
+  namedAuthors: string;
+  logoUrl: string;
+}
+
+const emptyBrief: FounderBrief = {
+  brandName: '',
+  whatWeDo: '',
+  whatWeDoNot: '',
+  competitors: '',
+  foundingStory: '',
+  methodology: '',
+  teamComposition: '',
+  quotablePositions: '',
+  namedAuthors: '',
+  logoUrl: '',
+};
+
+const REQUIRED_KEYS: Array<keyof FounderBrief> = ['brandName', 'whatWeDo', 'whatWeDoNot', 'competitors'];
+
+function genSessionId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  } catch { /* fall through */ }
+  return `qs-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export default function QuickStartPage() {
+  const navigate = useNavigate();
+  const [brief, setBrief] = useState<FounderBrief>(emptyBrief);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = REQUIRED_KEYS.every(k => brief[k].trim().length > 0) && !submitting;
+
+  const update = (k: keyof FounderBrief) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setBrief(b => ({ ...b, [k]: e.target.value }));
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+
+    // Trim everything; only send non-empty optional fields to keep the payload tight.
+    const trimmed: Partial<FounderBrief> = {};
+    (Object.keys(brief) as Array<keyof FounderBrief>).forEach(k => {
+      const v = brief[k].trim();
+      if (v) trimmed[k] = v;
+    });
+
+    // Anonymous session token — survives until the founder signs up via Clerk,
+    // at which point the server can claim profiles owned by this session.
+    let sessionId: string;
+    try {
+      sessionId = localStorage.getItem('forge_quick_start_session') || genSessionId();
+      localStorage.setItem('forge_quick_start_session', sessionId);
+    } catch {
+      sessionId = genSessionId();
+    }
+
+    try {
+      sessionStorage.setItem('forge_onboard_factual_ground', JSON.stringify(trimmed));
+    } catch {
+      // sessionStorage blocked — fall back to URL state? For MVP, surface a
+      // browser-level error rather than silently dropping the brief.
+      setSubmitting(false);
+      alert('Your browser is blocking sessionStorage, which Forge needs to hand off your brief. Try a different browser or enable storage for this site.');
+      return;
+    }
+
+    navigate('/app/context-hub');
+  };
+
+  return (
+    <div className="quick-start-page">
+      <header className="qs-header">
+        <div className="qs-eyebrow">Forge Intelligence · Quick Start</div>
+        <h1 className="qs-headline">Tell us what your product actually does.</h1>
+        <p className="qs-subhead">
+          We'll build the brand brain. Then you build the product.
+        </p>
+      </header>
+
+      <form className="qs-form" onSubmit={handleSubmit} noValidate>
+        <div className="qs-section-label">The Founder Brief</div>
+
+        <div className="qs-field">
+          <label htmlFor="brandName">Brand Name <span className="qs-req">*</span></label>
+          <input
+            id="brandName"
+            type="text"
+            value={brief.brandName}
+            onChange={update('brandName')}
+            placeholder="What's it called?"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+
+        <div className="qs-field">
+          <label htmlFor="whatWeDo">What we actually do <span className="qs-req">*</span></label>
+          <textarea
+            id="whatWeDo"
+            value={brief.whatWeDo}
+            onChange={update('whatWeDo')}
+            placeholder="In plain language — what does your product do and for whom?"
+            rows={4}
+          />
+        </div>
+
+        <div className="qs-field">
+          <label htmlFor="whatWeDoNot">What we do <em>NOT</em> do <span className="qs-req">*</span></label>
+          <textarea
+            id="whatWeDoNot"
+            value={brief.whatWeDoNot}
+            onChange={update('whatWeDoNot')}
+            placeholder="What do people assume you do that you don't? What's explicitly out of scope?"
+            rows={3}
+          />
+          <p className="qs-helper">These non-actions become your <strong>strategic moats</strong> — they protect your positioning, not your competitive gaps.</p>
+        </div>
+
+        <div className="qs-field">
+          <label htmlFor="competitors">Competitors <span className="qs-req">*</span></label>
+          <textarea
+            id="competitors"
+            value={brief.competitors}
+            onChange={update('competitors')}
+            placeholder="Who are you most often compared to? Who would a buyer also evaluate?"
+            rows={3}
+          />
+        </div>
+
+        <div className="qs-field">
+          <label htmlFor="foundingStory">Founding story <span className="qs-optional">(optional)</span></label>
+          <textarea
+            id="foundingStory"
+            value={brief.foundingStory}
+            onChange={update('foundingStory')}
+            placeholder="Why does this exist? What happened that made you build it?"
+            rows={3}
+          />
+        </div>
+
+        <button
+          type="button"
+          className="qs-advanced-toggle"
+          onClick={() => setAdvancedOpen(o => !o)}
+          aria-expanded={advancedOpen}
+        >
+          {advancedOpen ? <ChevronUp size={16} strokeWidth={1.5} /> : <ChevronDown size={16} strokeWidth={1.5} />}
+          <span>{advancedOpen ? 'Hide additional context' : 'Add more context'}</span>
+        </button>
+
+        {advancedOpen && (
+          <div className="qs-advanced">
+            <div className="qs-field">
+              <label htmlFor="methodology">Methodology / Approach</label>
+              <textarea
+                id="methodology"
+                value={brief.methodology}
+                onChange={update('methodology')}
+                placeholder="How do you do what you do differently than everyone else?"
+                rows={3}
+              />
+            </div>
+
+            <div className="qs-field">
+              <label htmlFor="teamComposition">Team composition</label>
+              <textarea
+                id="teamComposition"
+                value={brief.teamComposition}
+                onChange={update('teamComposition')}
+                placeholder="Who's building this? Relevant backgrounds, expertise."
+                rows={2}
+              />
+            </div>
+
+            <div className="qs-field">
+              <label htmlFor="quotablePositions">Quotable positions</label>
+              <textarea
+                id="quotablePositions"
+                value={brief.quotablePositions}
+                onChange={update('quotablePositions')}
+                placeholder="Hot takes, beliefs, contrarian stances your brand owns."
+                rows={3}
+              />
+            </div>
+
+            <div className="qs-field">
+              <label htmlFor="namedAuthors">Named Authors</label>
+              <textarea
+                id="namedAuthors"
+                value={brief.namedAuthors}
+                onChange={update('namedAuthors')}
+                placeholder="Real humans who should be attributed as thought leaders."
+                rows={2}
+              />
+            </div>
+
+            <div className="qs-field">
+              <label htmlFor="logoUrl">Logo URL</label>
+              <input
+                id="logoUrl"
+                type="url"
+                value={brief.logoUrl}
+                onChange={update('logoUrl')}
+                placeholder="https://..."
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="qs-actions">
+          <button type="submit" className="qs-submit" disabled={!canSubmit}>
+            <Rocket size={16} strokeWidth={1.5} aria-hidden="true" />
+            <span>{submitting ? 'Building your brand brain…' : 'Build My Brand Brain →'}</span>
+          </button>
+          <p className="qs-loading-note">
+            This takes about 60 seconds. We're synthesizing your positioning, voice, personas, and competitive whitespace.
+          </p>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements `docs/QUICK_START_ROUTE.md` as a single PR. Adds `/app/quick-start` — a public, unauthenticated entry point that lets founders **without a marketing website** build a Brand Brain from a structured Founder Brief.

Also folds in the partner-config refactor from the same spec — `BuildWithLovableButton` is renamed to `BuildWithPartnerButton` and driven by `VITE_DEPLOY_PARTNER`, with Lovable as the default and Bolt scaffolded.

## Flow

```
/app/quick-start  →  Founder Brief form  →  "Build My Brand Brain →"
                                  │
                                  ▼
        sessionStorage.forge_onboard_factual_ground = {...}
        localStorage.forge_quick_start_session = <UUID>
                                  │
                                  ▼
                navigate to /app/context-hub
                                  │
                                  ▼
ContextAgentPage picks up the brief, runs the existing 5-stage
processing animation, POSTs to /api/context-hub/analyze with
{ factualGround, sessionId, source: 'quick-start' }
                                  │
                                  ▼
Server skips Firecrawl + Sonar + cache check, synthesizes the
BrandProfile JSON from the Founder Brief alone via claude-opus-4-6.
Persists with a synthetic brand_url ("quickstart://<uuid>") so the
unique-by-active index never collides with real domains.
                                  │
                                  ▼
User lands on /app/context-hub?brand=<id> with the rendered
Brand Profile and the "Deploy This Brain" CTA — ready to click
"Build with Lovable" with zero auth gates so far.
```

The Stage 2+ paywall still fires on GEO Strategist / pipeline nav — unchanged.

## What changed

### Backend (`server.js`)
- New `handleQuickStartSynthesis()` routed via the existing `/api/context-hub/analyze` endpoint when `brandUrl` is null and `factualGround` is provided. Reuses anonymous-session plumbing (`onboard_session_id`, 24h `expires_at`) and the same response shape — `ContextAgentPage` doesn't need a separate code path.
- Synthetic `brand_url = "quickstart://<uuid>"` per row, so the `idx_bp_active_url` unique-by-active index never collides with real domains and re-analyze never tries to re-scrape a non-existent site.
- Anti-hallucination guardrails in the prompt: don't invent competitors, "What we do NOT do" feeds `strategicMoats` (not gaps), `visualStyle` / `accentColor` stay as conservative descriptors since there's no site to inspect.
- Founder Brief stamped into `profile_data.factualGround` + `profile_data.source = 'quick-start'` so downstream tools can distinguish synthesized profiles without a schema migration.

### Frontend
- `src/pages/QuickStartPage.tsx` + `.css` — Founder Brief form (5 core fields + 5 advanced accordion). Required-field gate. SessionStorage handoff. Anonymous session UUID via `crypto.randomUUID` written to `localStorage.forge_quick_start_session`.
- `src/main.tsx` — registers `/app/quick-start` as a public route (no `AppProvider`, no Clerk gate).
- `src/pages/ContextAgentPage.tsx` — parallel `useEffect` for the factualGround handoff. Same `firedRef` guard as the existing URL onboarding path so they can't both fire on the same load.
- `src/components/views/NewAnalysis.tsx` — small "No website yet? Build a Brand Brain from a Founder Brief instead →" link below the URL input (non-intrusive, per spec).

### Partner-agnostic Deploy card (folded in from the same spec)
- `src/config/deployPartner.ts` — partners map keyed by `VITE_DEPLOY_PARTNER` env var (defaults to `lovable`; `bolt` scaffolded for future).
- `src/components/BuildWithPartnerButton.tsx` — renamed from `BuildWithLovableButton` (git rename detected, blame preserved). Reads `activePartner` and drives the display copy, the prompt-pack endpoint URL, and the tooltip from config.
- **Subtitle updated** per spec: *"Turn this Brand Brain into a working product. Your brand brain becomes the foundation."*

## Spec deviations (worth flagging)

1. **Endpoint name**: spec says `POST /api/analyze`; we extended the actual endpoint `/api/context-hub/analyze` (matches the codebase). Reuses `softAuth`, the cache check, the 24h-anonymous flow, and the same response shape. No new endpoint surface.
2. **Partner URL format**: kept Lovable's documented `?autosubmit=true#prompt=...` fragment format (which we verified works) instead of the spec's `lovable.dev/new?prompt=...` example. The existing L-1 prompt-pack endpoint already returns docs-compliant URLs with `isUrlSafe` / fallback logic, so the partner config drives **display + endpoint selection** only — URL assembly stays on the server.
3. **Session token name**: localStorage key is `forge_quick_start_session` per spec, but on the wire we pass it as `sessionId` (which is what the existing endpoint already accepts and stores into `onboard_session_id`). No schema changes needed; a future Clerk-signup claim flow can read the same localStorage key.
4. **No `source` column migration**: stamped `profile_data.source = 'quick-start'` into the JSONB instead. Queryable, no migration.

## Build

`npm run build` (tsc + vite) passes clean. Bundle grew ~2 KB gzipped.

## Test plan

- [ ] Open `/app/quick-start` in a fresh incognito (no Clerk session). Confirm: form renders, required-field gate works, advanced accordion expands.
- [ ] Fill the 4 required fields + click submit. Confirm: redirects to `/app/context-hub`, the 5-stage processing animation runs, lands on Brand Profile after ~60s.
- [ ] Confirm the resulting profile has Voice / Personas / Whitespace / Strategy tabs populated. Spot-check that `strategicMoats` includes entries derived from "What we do NOT do".
- [ ] Confirm `discoveredCompetitors` matches the founder's input verbatim (no invented competitors).
- [ ] Click **Build with Lovable** on the Deploy card. Confirm: opens Lovable with the prompt pre-loaded (or fallback panel if oversized).
- [ ] On Brand Profile, the subtitle now reads "Turn ...'s Brand Brain into a working product. Your brand brain becomes the foundation."
- [ ] Set `VITE_DEPLOY_PARTNER=bolt` locally and reload. Confirm the CTA, tooltip, and copy switch to Bolt. (Bolt endpoint will 404 until L-1's twin is built — that's a future PR.)
- [ ] Open `/app/context-hub` (the URL-based New Analysis view). Confirm the new "No website yet?" link sits below the URL input, non-intrusive.
- [ ] Verify the existing URL-based analyze flow still works (regression check on `firedRef` gating in `ContextAgentPage`).

## Follow-ups (out of scope for this PR)

- Clerk signup claim flow: when a user with `forge_quick_start_session` signs up, migrate `onboard_session_id`-matched rows to their `clerk_user_id`. The server-side plumbing exists; the frontend wiring is the gap.
- A `bolt` prompt-pack endpoint paralleling `/api/forge/prompt-pack/lovable` once we partner with Bolt.
- "No website yet?" copy on the marketing landing page (the spec mentions this as a future link).

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_