### PR TITLE
fix(brand-profile): friendly empty-state for Signal Summary

### DIFF
--- a/src/components/views/BrandProfile.tsx
+++ b/src/components/views/BrandProfile.tsx
@@ -452,7 +452,35 @@ export function BrandProfile() {
           </div>
         )}
 
-        {activeTab === 'signals' && (
+        {activeTab === 'signals' && (() => {
+          const visibleSignals = brandProfile.thirdPartySignals.filter(s => s.value !== null && s.confidence > 0);
+          if (visibleSignals.length === 0) {
+            const isQuickStart = brandProfile.brandUrl?.startsWith('quickstart://');
+            return (
+              <div className="tab-content signals-content">
+                <div
+                  style={{
+                    padding: '32px 24px',
+                    textAlign: 'center',
+                    background: '#f8fafc',
+                    border: '1px dashed #cbd5e1',
+                    borderRadius: 12,
+                  }}
+                >
+                  <h3 style={{ margin: '0 0 8px', fontSize: 15, fontWeight: 600, color: '#0f172a' }}>
+                    No third-party signals yet
+                  </h3>
+                  <p style={{ margin: 0, fontSize: 13, color: '#64748b', lineHeight: 1.6, maxWidth: 520, marginLeft: 'auto', marginRight: 'auto' }}>
+                    {isQuickStart
+                      ? <>These surface when Forge analyzes a live website — G2 ratings, Reddit mentions, press coverage, and the like. Add your URL anytime from <strong>Brand Settings</strong> to unlock them.</>
+                      : <>Forge didn't find third-party signals for this brand yet. These often grow over time — try a re-analysis later as your footprint expands.</>
+                    }
+                  </p>
+                </div>
+              </div>
+            );
+          }
+          return (
           <div className="tab-content signals-content">
             <div className="signals-table">
               <div className="table-header">
@@ -461,7 +489,7 @@ export function BrandProfile() {
                 <span className="th-value">Value</span>
                 <span className="th-confidence">Confidence</span>
               </div>
-              {brandProfile.thirdPartySignals.filter(s => s.value !== null && s.confidence > 0).map((signal, idx) => (
+              {visibleSignals.map((signal, idx) => (
                 <div key={idx} className="table-row">
                   <span className="td-source">{signal.source}</span>
                   <span className="td-type">{signal.signalType}</span>
@@ -490,11 +518,12 @@ export function BrandProfile() {
               ))}
             </div>
             <p className="signals-note">
-              Third-party signals are gathered from public sources and may vary in accuracy. 
+              Third-party signals are gathered from public sources and may vary in accuracy.
               Last checked: {formatDate(brandProfile.thirdPartySignals[0]?.lastChecked || brandProfile.updatedAt)}
             </p>
           </div>
-        )}
+          );
+        })()}
 
         {activeTab === 'gaps' && (
           <div className="tab-content gaps-content">


### PR DESCRIPTION
## Summary

Follow-up to #71. Brian noticed during a test run that the Signal Summary tab was rendering empty on Quick Start brand profiles — just a table header with no rows. That's because Quick Start profiles intentionally have `thirdPartySignals: []` (third-party signals are externally-validated data like G2 ratings, Reddit mentions, press — they require a real website to source from, and synthesizing them from the founder's own brief would defeat the point).

Replaces the empty table with a friendly explainer card when no signals are visible.

## Behavior

- **Quick Start profile (`brandUrl` starts with `quickstart://`)**: *"No third-party signals yet — these surface when Forge analyzes a live website — G2 ratings, Reddit mentions, press coverage, and the like. Add your URL anytime from **Brand Settings** to unlock them."*
- **URL-based profile that happened to find zero signals**: *"Forge didn't find third-party signals for this brand yet. These often grow over time — try a re-analysis later as your footprint expands."*
- **Normal case (signals present)**: unchanged — still renders the existing table.

## Trigger logic

Uses `visibleSignals.length === 0` (post-filter for `value !== null && confidence > 0`) — same filter the table was already applying. This means the explainer also catches URL-based scans where every signal came back null/zero-confidence, which used to look just as broken.

## Test plan

- [ ] Open the Quick Start brain Brian tested (`brand=ed927580-…`). Confirm Signal Summary tab now shows the explainer instead of an empty table.
- [ ] Open a URL-based brain that has real third-party signals. Confirm the table still renders unchanged.
- [ ] Spot-check a URL-based brain where Sonar found zero signals — confirm the second copy variant shows.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_