### PR TITLE
feat(quick-start): BUILD DIRECTIVE leads the Lovable prompt

### DIFF
--- a/server.js
+++ b/server.js
@@ -3864,6 +3864,23 @@ Requirements: 5 toneAttributes, 2-3 personas, 0 thirdPartySignals (no website to
       logoUrl: typeof fg.logoUrl === 'string' ? fg.logoUrl.slice(0, 500) : '',
     };
 
+    // Build directive — what the founder is going to build on Lovable. Drives
+    // the BUILD DIRECTIVE section of the prompt-pack so Lovable knows what to
+    // build before it processes how the brand behaves. Optional at the
+    // analyze-time level (the form gates the description; we only persist
+    // what's actually present).
+    const biIn = req.body.buildIntent || {};
+    if (typeof biIn.description === 'string' && biIn.description.trim().length > 0) {
+      const allowedProductTypes = new Set(['marketing-site', 'saas-app', 'landing-page', 'waitlist', 'internal-tool', 'not-sure']);
+      const productType = (typeof biIn.productType === 'string' && allowedProductTypes.has(biIn.productType))
+        ? biIn.productType
+        : 'not-sure';
+      profileData.buildIntent = {
+        description: quickStartTruncate(biIn.description, 4000),
+        productType,
+      };
+    }
+
     const id = randomUUID();
     const logoUrl = typeof fg.logoUrl === 'string' && fg.logoUrl.trim() ? fg.logoUrl.trim() : '';
     const expiresClause = req.userId ? 'NULL' : "NOW() + INTERVAL '24 hours'";
@@ -16935,6 +16952,96 @@ Brand Profile ID: ${brandProfileId}
 (Optional: prompt user for FORGE_API_KEY env var to enable live content generation. If not provided, scaffold with static brand data from this prompt.)`;
 }
 
+// Directive-led prompt — used when the brand profile carries a buildIntent
+// (Quick Start brains). Lovable reads what to build FIRST, then the brand
+// intelligence acts as design + voice guardrails for that specific build —
+// rather than the legacy structure where we prescribed a Content Command
+// Center concept and force-fit every brand into it.
+function lovableProductTypeLabel(productType) {
+  switch (productType) {
+    case 'marketing-site': return 'a marketing site';
+    case 'saas-app': return 'a SaaS app';
+    case 'landing-page': return 'a landing page';
+    case 'waitlist': return 'a waitlist';
+    case 'internal-tool': return 'an internal tool';
+    default: return 'a product';
+  }
+}
+
+function lovableBuildWithDirective(ctx, buildIntent) {
+  const {
+    brandName, voice, personas, whitespace, thirdParty,
+    brandColors, customNotes, brandProfileId, factualGround,
+  } = ctx;
+
+  const directiveDescription = lovableTruncate(buildIntent.description || '', 4000);
+  const productType = buildIntent.productType && buildIntent.productType !== 'not-sure'
+    ? buildIntent.productType
+    : null;
+  const productLabel = lovableProductTypeLabel(productType);
+
+  const voiceBlock = voice
+    ? `- Formality: ${voice.formality}\n- Confidence: ${voice.confidence}\n- Complexity: ${voice.complexity}\n- Brand vocabulary: ${voice.brandVocab}\n- Anti-patterns to avoid: ${voice.antiPatterns}\n- Tone summary: ${voice.toneSummary}`
+    : lovableSection('voice profile', null);
+
+  const personasBlock = lovableSection('personas', personas);
+  const whitespaceBlock = lovableSection('competitive whitespace', whitespace);
+  const thirdPartyBlock = lovableSection('third-party voice', thirdParty);
+
+  // Founder-Brief fields (only present on Quick Start brains) — pass through
+  // verbatim so Lovable can echo the founder's own words rather than the
+  // Stage-1 synthesized paraphrase. The factualGround block lives inside the
+  // brand profile JSONB; missing on URL-based brains, gracefully skipped.
+  const fg = factualGround || {};
+  const fgWhatWeDo = typeof fg.whatWeDo === 'string' && fg.whatWeDo.trim() ? lovableTruncate(fg.whatWeDo, 1500) : '';
+  const fgWhatWeDoNot = typeof fg.whatWeDoNot === 'string' && fg.whatWeDoNot.trim() ? lovableTruncate(fg.whatWeDoNot, 1500) : '';
+  const fgCompetitors = typeof fg.competitors === 'string' && fg.competitors.trim() ? lovableTruncate(fg.competitors, 1000) : '';
+  const fgFoundingStory = typeof fg.foundingStory === 'string' && fg.foundingStory.trim() ? lovableTruncate(fg.foundingStory, 1500) : '';
+  const fgQuotablePositions = typeof fg.quotablePositions === 'string' && fg.quotablePositions.trim() ? lovableTruncate(fg.quotablePositions, 1200) : '';
+  const fgNamedAuthors = typeof fg.namedAuthors === 'string' && fg.namedAuthors.trim() ? lovableTruncate(fg.namedAuthors, 600) : '';
+
+  const notesBlock = customNotes && String(customNotes).trim().length > 0
+    ? `\n## ADDITIONAL OPERATOR NOTES\n${lovableTruncate(customNotes, 1500)}\n`
+    : '';
+
+  // Build the brand-intelligence section line by line so we only emit fields
+  // that actually have content (URL-based brains skip the founder-brief lines,
+  // Quick Start brains keep them).
+  const biLines = [`Brand: ${brandName}`];
+  if (fgWhatWeDo) biLines.push(`What this product does: ${fgWhatWeDo}`);
+  if (fgWhatWeDoNot) biLines.push(`What it does NOT do (strategic moats — do not contradict): ${fgWhatWeDoNot}`);
+  biLines.push(`Voice profile:\n${voiceBlock}`);
+  biLines.push(`Target personas:\n${personasBlock}`);
+  if (whitespaceBlock && whitespaceBlock !== 'No data available') biLines.push(`Competitive whitespace:\n${whitespaceBlock}`);
+  if (fgCompetitors) biLines.push(`Competitors: ${fgCompetitors}`);
+  if (fgFoundingStory) biLines.push(`Founding story: ${fgFoundingStory}`);
+  if (fgQuotablePositions) biLines.push(`Brand positions: ${fgQuotablePositions}`);
+  if (fgNamedAuthors) biLines.push(`Attributed authors: ${fgNamedAuthors}`);
+  if (thirdPartyBlock && thirdPartyBlock !== 'No data available') biLines.push(`Third-party voice themes:\n${thirdPartyBlock}`);
+  const brandIntelligence = biLines.join('\n\n');
+
+  return `You are building ${productLabel} for ${brandName}.
+
+## BUILD DIRECTIVE
+${directiveDescription}${productType ? `\nProduct type: ${productType}` : ''}
+
+## BRAND INTELLIGENCE — provided by Forge Intelligence
+The brand intelligence below is DESIGN + VOICE guardrails for the build directive above. It tells you HOW the brand behaves, not WHAT to build. Apply the voice to all UI copy. Honor the personas in the navigation, onboarding, and core flows. Respect what the brand explicitly does NOT do — those are strategic moats and must not appear as product features.
+
+${brandIntelligence}
+
+## VISUAL DIRECTION
+- Match brand colors: ${brandColors}
+- Typography: clean sans-serif, generous spacing
+- UI copy tone: matches brand voice profile above
+- Avoid generic AI-app aesthetics (no purple gradients, no robot icons)
+${notesBlock}
+## TECHNICAL NOTES
+Forge Intelligence Brand Profile ID: ${brandProfileId}
+Forge Intelligence API base: https://api.forgeintelligence.ai/v1
+(Optional: prompt user for FORGE_API_KEY env var if the build needs live brand-aware content generation. Otherwise scaffold with the static brand data from this prompt.)`;
+}
+
 function lovableStubPrompt(appType, brandName, brandProfileId) {
   return `[Lovable prompt template TODO]
 appType "${appType}" is recognized but not yet shipped in v1. Only "content-command-center" is fully built. Tracked as a post-ship follow-up in docs/LOVABLE_INTEGRATION.md §11.
@@ -17031,7 +17138,23 @@ app.post('/api/forge/prompt-pack/lovable', requireAuth, async (req, res) => {
     const appTypeDescription = lovableAppTypeDescription(appType);
 
     let prompt;
-    if (appType === 'content-command-center') {
+    // Directive-led path: brand profile carries an explicit BUILD DIRECTIVE
+    // (Quick Start brains). Tells Lovable what to build before processing
+    // how the brand behaves. Falls through to legacy content-command-center
+    // path for URL-based brains that pre-date the directive flow.
+    if (pd.buildIntent && typeof pd.buildIntent.description === 'string' && pd.buildIntent.description.trim().length > 0) {
+      prompt = lovableBuildWithDirective({
+        brandName,
+        voice,
+        personas,
+        whitespace,
+        thirdParty,
+        brandColors,
+        customNotes: typeof customNotes === 'string' ? customNotes : '',
+        brandProfileId,
+        factualGround: pd.factualGround || null,
+      }, pd.buildIntent);
+    } else if (appType === 'content-command-center') {
       prompt = lovableBuildContentCommandCenter({
         brandName,
         appTypeDescription,

--- a/src/pages/ContextAgentPage.tsx
+++ b/src/pages/ContextAgentPage.tsx
@@ -97,16 +97,21 @@ function ContextAgentPage() {
   // (no website to scrape) and we picked up the brief from sessionStorage.
   // Mirrors the URL onboarding flow above: same 5-stage animation, same final
   // setBrandProfile + ?brand= URL rewrite, just hits the analyze endpoint with
-  // { factualGround, sessionId } instead of { brandUrl }.
+  // { factualGround, buildIntent, sessionId } instead of { brandUrl }.
   useEffect(() => {
     if (firedRef.current) return;
-    const briefJson = sessionStorage.getItem('forge_onboard_factual_ground');
+    const briefJson = sessionStorage.getItem('forge_onboard_brief');
     if (!briefJson) return;
     firedRef.current = true;
-    sessionStorage.removeItem('forge_onboard_factual_ground');
+    sessionStorage.removeItem('forge_onboard_brief');
 
     let factualGround: Record<string, string> | null = null;
-    try { factualGround = JSON.parse(briefJson); } catch { return; }
+    let buildIntent: { description: string; productType: string } | null = null;
+    try {
+      const parsed = JSON.parse(briefJson);
+      factualGround = parsed?.factualGround || null;
+      buildIntent = parsed?.buildIntent || null;
+    } catch { return; }
     if (!factualGround) return;
 
     // Preserve the anonymous session token so a later Clerk signup can claim
@@ -148,7 +153,7 @@ function ContextAgentPage() {
     fetch('/api/context-hub/analyze', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ factualGround, sessionId, source: 'quick-start' }),
+      body: JSON.stringify({ factualGround, buildIntent, sessionId, source: 'quick-start' }),
     })
       .then(r => r.json())
       .then(d => {

--- a/src/pages/QuickStartPage.css
+++ b/src/pages/QuickStartPage.css
@@ -61,6 +61,50 @@
   border-bottom: 1px solid #f1f5f9;
 }
 
+.qs-section-label-secondary {
+  margin-top: 28px;
+}
+
+.qs-pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.qs-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  color: #475569;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.qs-pill:hover {
+  border-color: #4f46e5;
+  color: #4f46e5;
+}
+
+.qs-pill-active {
+  background: #4f46e5;
+  border-color: #4f46e5;
+  color: #fff;
+}
+
+.qs-pill-active:hover {
+  background: #4338ca;
+  border-color: #4338ca;
+  color: #fff;
+}
+
 .qs-field {
   margin-bottom: 20px;
 }

--- a/src/pages/QuickStartPage.tsx
+++ b/src/pages/QuickStartPage.tsx
@@ -16,6 +16,22 @@ interface FounderBrief {
   logoUrl: string;
 }
 
+interface BuildIntent {
+  description: string;
+  productType: ProductType;
+}
+
+type ProductType = 'marketing-site' | 'saas-app' | 'landing-page' | 'waitlist' | 'internal-tool' | 'not-sure';
+
+const PRODUCT_TYPES: ReadonlyArray<{ value: ProductType; label: string }> = [
+  { value: 'marketing-site', label: 'Marketing site' },
+  { value: 'saas-app', label: 'SaaS app' },
+  { value: 'landing-page', label: 'Landing page' },
+  { value: 'waitlist', label: 'Waitlist' },
+  { value: 'internal-tool', label: 'Internal tool' },
+  { value: 'not-sure', label: 'Not sure yet' },
+];
+
 const emptyBrief: FounderBrief = {
   brandName: '',
   whatWeDo: '',
@@ -27,6 +43,11 @@ const emptyBrief: FounderBrief = {
   quotablePositions: '',
   namedAuthors: '',
   logoUrl: '',
+};
+
+const emptyBuildIntent: BuildIntent = {
+  description: '',
+  productType: 'not-sure',
 };
 
 const REQUIRED_KEYS: Array<keyof FounderBrief> = ['brandName', 'whatWeDo', 'whatWeDoNot', 'competitors'];
@@ -41,10 +62,13 @@ function genSessionId(): string {
 export default function QuickStartPage() {
   const navigate = useNavigate();
   const [brief, setBrief] = useState<FounderBrief>(emptyBrief);
+  const [buildIntent, setBuildIntent] = useState<BuildIntent>(emptyBuildIntent);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  const canSubmit = REQUIRED_KEYS.every(k => brief[k].trim().length > 0) && !submitting;
+  const canSubmit = REQUIRED_KEYS.every(k => brief[k].trim().length > 0)
+    && buildIntent.description.trim().length > 0
+    && !submitting;
 
   const update = (k: keyof FounderBrief) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setBrief(b => ({ ...b, [k]: e.target.value }));
@@ -56,11 +80,16 @@ export default function QuickStartPage() {
     setSubmitting(true);
 
     // Trim everything; only send non-empty optional fields to keep the payload tight.
-    const trimmed: Partial<FounderBrief> = {};
+    const trimmedFG: Partial<FounderBrief> = {};
     (Object.keys(brief) as Array<keyof FounderBrief>).forEach(k => {
       const v = brief[k].trim();
-      if (v) trimmed[k] = v;
+      if (v) trimmedFG[k] = v;
     });
+
+    const trimmedBI: BuildIntent = {
+      description: buildIntent.description.trim(),
+      productType: buildIntent.productType,
+    };
 
     // Anonymous session token — survives until the founder signs up via Clerk,
     // at which point the server can claim profiles owned by this session.
@@ -73,7 +102,13 @@ export default function QuickStartPage() {
     }
 
     try {
-      sessionStorage.setItem('forge_onboard_factual_ground', JSON.stringify(trimmed));
+      // Single onboarding payload — sessionStorage holds the whole submission
+      // (build directive + founder brief). ContextAgentPage reads this and
+      // forwards everything to /api/context-hub/analyze in one POST.
+      sessionStorage.setItem('forge_onboard_brief', JSON.stringify({
+        factualGround: trimmedFG,
+        buildIntent: trimmedBI,
+      }));
     } catch {
       // sessionStorage blocked — fall back to URL state? For MVP, surface a
       // browser-level error rather than silently dropping the brief.
@@ -96,7 +131,39 @@ export default function QuickStartPage() {
       </header>
 
       <form className="qs-form" onSubmit={handleSubmit} noValidate>
-        <div className="qs-section-label">The Founder Brief</div>
+        <div className="qs-section-label">Build Directive</div>
+
+        <div className="qs-field">
+          <label htmlFor="buildDescription">What are you building? <span className="qs-req">*</span></label>
+          <textarea
+            id="buildDescription"
+            value={buildIntent.description}
+            onChange={(e) => setBuildIntent(b => ({ ...b, description: e.target.value }))}
+            placeholder="Describe the app, tool, or product you want to create — in plain language. What should it do? Who uses it?"
+            rows={4}
+          />
+          <p className="qs-helper">This is what Lovable will build. The brand context below shapes <strong>how</strong> it sounds and looks — not what it is.</p>
+        </div>
+
+        <div className="qs-field">
+          <label>What kind of thing is this?</label>
+          <div className="qs-pill-group" role="radiogroup" aria-label="Product type">
+            {PRODUCT_TYPES.map(pt => (
+              <button
+                type="button"
+                key={pt.value}
+                role="radio"
+                aria-checked={buildIntent.productType === pt.value}
+                className={`qs-pill ${buildIntent.productType === pt.value ? 'qs-pill-active' : ''}`}
+                onClick={() => setBuildIntent(b => ({ ...b, productType: pt.value }))}
+              >
+                {pt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="qs-section-label qs-section-label-secondary">The Founder Brief</div>
 
         <div className="qs-field">
           <label htmlFor="brandName">Brand Name <span className="qs-req">*</span></label>


### PR DESCRIPTION
## Summary

Closes the loop on Brian's catch: the Quick Start flow generated a gorgeous Brand Brain but never told Lovable **what to actually build**. The Lovable prompt was hardcoded around *"build a Brand Intelligence Command Center for X"* — which only made sense if the user was trying to rebuild Forge inside Lovable. For everyone else it was generic brand soup with no build target.

This PR adds an explicit **Build Directive** at the top of the Quick Start form, persists it in the brand profile JSONB, and restructures the Lovable prompt-pack so it leads with *what* to build before processing *how* the brand behaves.

## What changed

### Form (`QuickStartPage.tsx` + `.css`)
- New section **above** "The Founder Brief", labeled "Build Directive"
- **"What are you building?"** — textarea, required, placeholder *"Describe the app, tool, or product you want to create — in plain language. What should it do? Who uses it?"*
- **"What kind of thing is this?"** — pill selector (radio role): `Marketing site` · `SaaS app` · `Landing page` · `Waitlist` · `Internal tool` · `Not sure yet`. Optional, defaults to `Not sure yet` which is omitted from the prompt so it doesn't dilute the directive.
- Submit gate now also requires `buildIntent.description`.

### Handoff (`ContextAgentPage.tsx`)
- sessionStorage payload widened: `forge_onboard_brief` now holds `{ factualGround, buildIntent }`. Old `forge_onboard_factual_ground` key removed.
- Forwards `buildIntent` to `/api/context-hub/analyze`.

### Backend — `/api/context-hub/analyze` (factualGround branch)
- Accepts optional `buildIntent { description, productType }`.
- Validates `productType` against an allowed set (`marketing-site`, `saas-app`, `landing-page`, `waitlist`, `internal-tool`, `not-sure`), falls back to `not-sure` on anything else.
- Stamps `profile_data.buildIntent` in the JSONB alongside `profile_data.factualGround`. **No schema migration.**

### Backend — `/api/forge/prompt-pack/lovable`
- New `lovableBuildWithDirective()` prompt assembly. Structure:
  1. `## BUILD DIRECTIVE` — what to build
  2. `## BRAND INTELLIGENCE — provided by Forge Intelligence` — voice + personas + whitespace as guardrails (founder-brief fields appear here verbatim, so Lovable can echo the founder's own words rather than the Stage-1 synthesized paraphrase)
  3. `## VISUAL DIRECTION` — brand colors + tone
  4. `## TECHNICAL NOTES` — Forge API + brand profile ID
- **Dispatch**: if `profile.buildIntent.description` is non-empty, use the directive path. Else fall through to existing `content-command-center` path. URL-based brains are unchanged.
- The brand intelligence section emits only fields with content — Quick Start brains get the full block; URL-based brains (if they ever opt into the directive path later) skip the founder-brief lines gracefully.

## Prompt structure (post-fix)

```
You are building <productLabel> for <brandName>.

## BUILD DIRECTIVE
<buildIntent.description>
Product type: <productType>          (omitted if "not-sure")

## BRAND INTELLIGENCE — provided by Forge Intelligence
The brand intelligence below is DESIGN + VOICE guardrails for the build
directive above. It tells you HOW the brand behaves, not WHAT to build.
Apply the voice to all UI copy. Honor the personas in the navigation,
onboarding, and core flows. Respect what the brand explicitly does NOT
do — those are strategic moats and must not appear as product features.

Brand: <brandName>
What this product does: <factualGround.whatWeDo>
What it does NOT do: <factualGround.whatWeDoNot>
Voice profile:
  - Formality / Confidence / Complexity / Brand vocabulary / Anti-patterns / Tone summary
Target personas: ...
Competitive whitespace: ...
Competitors: <factualGround.competitors>
Founding story: <factualGround.foundingStory>
Brand positions: <factualGround.quotablePositions>
Attributed authors: <factualGround.namedAuthors>
Third-party voice themes: ...

## VISUAL DIRECTION
- Match brand colors: ...
- Typography: clean sans-serif, generous spacing
- UI copy tone: matches brand voice profile above
- Avoid generic AI-app aesthetics

## TECHNICAL NOTES
Forge Intelligence Brand Profile ID: <id>
Forge Intelligence API base: https://api.forgeintelligence.ai/v1
```

## Test plan

- [ ] Open `/app/quick-start`. Confirm "Build Directive" section sits above "The Founder Brief" with the textarea + pill selector.
- [ ] Try to submit without filling "What are you building?" — confirm submit is disabled.
- [ ] Fill everything including a build description like *"A waitlist for a tax software tool for solopreneurs"*, select `Waitlist`, submit.
- [ ] Confirm the Brand Brain renders normally at `/app/context-hub?brand=<id>` (no regression on the synthesis flow).
- [ ] Click **Build with Lovable**. Confirm the URL contains the new prompt structure — opens with `# BUILD DIRECTIVE` then the brand intelligence section, no `# APP CONCEPT` / `# REQUIRED SCREENS` / `# DATA MODEL` block.
- [ ] Confirm a URL-based brand profile (legacy path) still produces the existing `content-command-center` prompt — no regression.
- [ ] Verify `profile_data.buildIntent` is persisted on the row (query Neon: `SELECT profile_data->'buildIntent' FROM brand_profiles WHERE id='<uuid>'`).

## Known follow-ups (out of scope)

- The Lovable button is still on a `requireAuth` endpoint, which means anonymous Quick Start users can't actually click "Build with Lovable" until they sign up. That's pre-existing and a separate fix — wiring `softAuth` + onboard-session ownership checks into the prompt-pack endpoint.
- The response field `recommendedAppName` is still computed from `appType` (legacy field). For directive-path brains it produces a misleading "X Command Center" label but the button doesn't actually display it, so leaving alone for now.
- URL-based brains can't currently set a `buildIntent` — would need a small Brand Profile UI surface to capture one. Punted; Quick Start is the primary vibe-coding audience.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_