### PR TITLE
chore(security): patch Clerk (critical) and postcss vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -326,12 +326,12 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.61.4",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.4.tgz",
-      "integrity": "sha512-xGvQvzfc5pQEuqCW8CNUgnlR+9nt6gSSMGMYx3l972utIJrFKByQJFCRZpwYBvAHiveuK11Wgy3J39p904jb+w==",
+      "version": "5.61.6",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.6.tgz",
+      "integrity": "sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.3",
+        "@clerk/shared": "^3.47.5",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.3",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.3.tgz",
-      "integrity": "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw==",
+      "version": "3.47.5",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
+      "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2489,9 +2489,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Closes 3 of the 6 Dependabot alerts surfaced after the production sync. All within existing semver ranges — `package.json` untouched, only `package-lock.json` moves.

## Patches applied (`npm audit fix`, no `--force`)

| Package | Was | Now | Severity | Advisory |
|---|---|---|---|---|
| `@clerk/clerk-react` | 5.61.4 | 5.61.6 | high | [GHSA-w24r-5266-9c3c](https://github.com/advisories/GHSA-w24r-5266-9c3c) — authorization bypass when combining org / billing / reverification checks |
| `@clerk/shared` (transitive) | 3.47.3 | 3.47.5 | **critical (CVSS 9.1)** | [GHSA-vqx2-fgx2-5wq9](https://github.com/advisories/GHSA-vqx2-fgx2-5wq9) — middleware-based route protection bypass in Clerk JS SDKs. **Headline fix.** |
| `postcss` (transitive) | 8.5.9 | 8.5.14 | moderate | [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) — XSS via unescaped `</style>` in CSS stringify output |

## Build

`tsc + vite build` pass clean. Bundle size effectively unchanged (+0.7 KB gzipped from the Clerk update).

## Deferred (separate PR — requires major version bump + careful testing)

| Package | Severity | Why deferred |
|---|---|---|
| `vite` 5.x → 8.x | moderate | Major bump, path-traversal in optimized deps `.map` handling — **dev-server only, no end-user impact in prod build** |
| `esbuild` (transitive of vite) | moderate | SSRF on dev server — **dev-server only**, bundles with vite update |

Both deferred items are dev-server-scoped and don't ship to production users, so they can wait for a focused vite-major-bump PR that handles plugin compatibility (`@vitejs/plugin-react` etc.) and full build + dev-mode regression testing.

## Test plan

- [ ] Deploy
- [ ] Smoke test sign-in / sign-up via Clerk on prod (the 5.61.6 patch is the riskiest of the three)
- [ ] Spot-check the Quick Start route + an authenticated `/app/context-hub` session
- [ ] Open a follow-up issue / PR for the Vite 5→8 migration

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_