### PR TITLE
fix(seo): canonical + robots SSR for /articles library

### DIFF
--- a/server.js
+++ b/server.js
@@ -2149,6 +2149,124 @@ app.get('/articles/:brandSlug/:articleSlug', async (req, res) => {
   }
 });
 
+// ── Articles library SSR — canonical + robots ─────────────────────────────
+// Google flagged "Duplicate without user-selected canonical" on
+// /articles/forgeintelligence-ai because the SPA shell served at both
+// /articles and /articles/:brandSlug had no <link rel="canonical">. The
+// per-article route at line 1880 already does the full SSR treatment; this
+// extends the same pattern to the library views so Search Console sees one
+// canonical Articles URL per publisher.
+app.get('/articles/:brandSlug', async (req, res) => {
+  const { brandSlug } = req.params;
+  try {
+    const brandsRes = await pool.query('SELECT id, brand_url, brand_name, profile_data FROM brand_profiles');
+    let matchedBrand = null;
+    for (const b of brandsRes.rows) {
+      const slug = (b.brand_url || '').replace(/https?:\/\//, '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+      if (slug === brandSlug) { matchedBrand = b; break; }
+    }
+    if (!matchedBrand) {
+      for (const b of brandsRes.rows) {
+        const slug = (b.brand_url || '').replace(/https?:\/\//, '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+        const nameSlug = ((b.profile_data?.voice_profile?.brand_name) || '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+        const nameSlug2 = (b.brand_name || '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+        if (slug.startsWith(brandSlug) || brandSlug.startsWith(slug) ||
+            nameSlug.startsWith(brandSlug) || nameSlug2.startsWith(brandSlug)) {
+          matchedBrand = b; break;
+        }
+      }
+    }
+    if (!matchedBrand) return res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+
+    // Force canonical brand slug — same SSOT logic as the article route.
+    const canonicalBrandSlug = (matchedBrand.brand_url || '').replace(/https?:\/\//, '').replace(/[^a-z0-9]/gi, '-').toLowerCase().replace(/^-+|-+$/g, '');
+    if (canonicalBrandSlug && brandSlug !== canonicalBrandSlug) {
+      const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+      return res.redirect(301, `/articles/${canonicalBrandSlug}${qs}`);
+    }
+
+    const artBaseDomain = process.env.BASE_DOMAIN || 'forgeintelligence.ai';
+    const FORGE_OWN_BRAND_ID = 'cde5feeb-b3d7-4990-adee-a54977ab9c52';
+    const isForgeOwnContent = matchedBrand.id === FORGE_OWN_BRAND_ID;
+    const brandName = (matchedBrand.brand_name || matchedBrand.profile_data?.voice_profile?.brand_name || brandSlug).replace(/"/g, '&quot;');
+
+    // Canonical resolution mirrors the per-article route at line 1953:
+    //   - Forge's own library is canonical to itself (forgeintelligence.ai)
+    //   - Customer libraries canonical at the customer's article_base_url or
+    //     brand root, since the Forge-hosted library is a preview, not the
+    //     publisher.
+    let canonicalUrl;
+    if (isForgeOwnContent) {
+      canonicalUrl = `https://${artBaseDomain}/articles/${brandSlug}`;
+    } else if (matchedBrand.article_base_url && matchedBrand.article_base_url.trim()) {
+      canonicalUrl = matchedBrand.article_base_url.replace(/\/+$/, '');
+    } else if (matchedBrand.brand_url) {
+      const rootUrl = matchedBrand.brand_url.startsWith('http')
+        ? matchedBrand.brand_url.replace(/\/+$/, '')
+        : `https://${matchedBrand.brand_url.replace(/\/+$/, '')}`;
+      canonicalUrl = rootUrl;
+    } else {
+      canonicalUrl = `https://${artBaseDomain}/articles/${brandSlug}`;
+    }
+
+    const robotsMeta = isForgeOwnContent
+      ? 'index, follow, max-image-preview:large, max-snippet:-1'
+      : 'noindex, nofollow, noarchive';
+
+    const titleStr = `${brandName} — Articles`;
+    const descStr = `Browse articles from ${brandName}.`.replace(/"/g, '&quot;');
+
+    const headTags = `
+  <title>${titleStr}</title>
+  <meta name="description" content="${descStr}" />
+  <link rel="canonical" href="${canonicalUrl}" />
+  <meta name="robots" content="${robotsMeta}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="${brandName}" />
+  <meta property="og:title" content="${titleStr}" />
+  <meta property="og:description" content="${descStr}" />
+  <meta property="og:url" content="${canonicalUrl}" />`;
+
+    const html = await fs.promises.readFile(path.join(__dirname, 'dist', 'index.html'), 'utf8');
+    const injected = html
+      .replace(/<title>[^<]*<\/title>/, '')
+      .replace('<head>', '<head>' + headTags);
+    res.set('Cache-Control', 'no-cache');
+    return res.send(injected);
+  } catch(e) {
+    console.error('[ARTICLES-LIBRARY-SSR]', e.message);
+    return res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+  }
+});
+
+// Bare /articles renders the same component as /articles/:brandSlug for the
+// union of all brands. That's the duplicate Google flagged. Redirect to
+// Forge's canonical brand library so there is exactly one indexable Articles
+// URL on this domain. Customer brand libraries remain reachable via their own
+// brand-scoped URL (and get noindex'd per the handler above).
+app.get('/articles', async (req, res) => {
+  const FORGE_OWN_BRAND_ID = 'cde5feeb-b3d7-4990-adee-a54977ab9c52';
+  try {
+    const forgeBrand = await pool.query(
+      'SELECT brand_url FROM brand_profiles WHERE id = $1',
+      [FORGE_OWN_BRAND_ID]
+    );
+    const brandUrl = forgeBrand.rows[0]?.brand_url || '';
+    const forgeSlug = brandUrl
+      .replace(/https?:\/\//, '')
+      .replace(/[^a-z0-9]/gi, '-')
+      .toLowerCase()
+      .replace(/^-+|-+$/g, '');
+    if (forgeSlug) {
+      const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+      return res.redirect(301, `/articles/${forgeSlug}${qs}`);
+    }
+  } catch(e) {
+    console.error('[ARTICLES-BARE-SSR]', e.message);
+  }
+  return res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+});
+
 // ── Marketing pages SSR — inject real content so scrapers + crawlers see it ──
 // Without this, SPA shell returns 1538 bytes of empty <div id="root"></div>
 // Forge's own scraper AND Google both need real HTML to extract product info.


### PR DESCRIPTION
## Summary

Resolves the Google Search Console warning Brian flagged: **"Duplicate without user-selected canonical"** on `https://forgeintelligence.ai/articles/forgeintelligence-ai`.

## Root cause

The per-article route at `server.js:1880` already does full SSR — canonical, robots, OG, JSON-LD, the works. But **both** `/articles/:brandSlug` and bare `/articles` were falling through to the catch-all at `server.js:17317` that just serves `dist/index.html` unchanged. Result:

- No `<link rel="canonical">` on either URL
- No `<meta name="robots">` directive
- The same `PublicArticlesLibraryPage` component renders both URLs against overlapping article sets (bare `/articles` fetches *all* brands; `/articles/forgeintelligence-ai` fetches just one — and right now those sets largely overlap because Forge is the only brand whose library is meaningfully populated)

Google saw two URLs serving substantially the same content, picked one as canonical, and flagged the other as the loser.

## What changed

Two new route handlers in `server.js`, registered after the per-article route and well before the catch-all so Express matches the longer paths first.

### `/articles/:brandSlug`

Mirrors the per-article SSR pattern:

- Looks up the brand by slug (same exact-then-prefix match the article route uses)
- **301-redirects to the canonical `brand_url`-derived slug** when a non-canonical alias was requested — forecloses the same "two-slugs-for-one-brand" dup that the article route already fixed
- **Forge-own brand** → canonical = self, `robots: index, follow, max-image-preview:large, max-snippet:-1`
- **Customer brand** → canonical = customer `brand_url` / `article_base_url`, `robots: noindex, nofollow, noarchive` (these are previews, not the publisher's indexable surface)
- Injects `<title>`, `<meta description>`, `<link rel="canonical">`, robots, og:* into `dist/index.html`

### `/articles` (no slug)

- 301-redirects to `/articles/<forge-canonical-slug>` so this domain has **exactly one** indexable Articles URL
- Customer brand libraries stay reachable at their brand-scoped URL (and get noindex'd by the handler above)
- The redirect destination is resolved at request time from `brand_profiles.brand_url` for the Forge brand, so it auto-corrects if Forge's brand_url is ever edited

## Test plan

- [ ] Deploy
- [ ] `curl -I https://forgeintelligence.ai/articles` → expect `301 → /articles/forgeintelligence-ai`
- [ ] `curl -sL https://forgeintelligence.ai/articles/forgeintelligence-ai | grep -E 'canonical|robots'` → expect canonical = self, robots = `index, follow, …`
- [ ] `curl -I https://forgeintelligence.ai/articles/forge-intelligence` → expect `301 → /articles/forgeintelligence-ai`
- [ ] In Google Search Console: **Validate Fix** on the "Duplicate without user-selected canonical" issue; verify Forge-own articles still appear in the index
- [ ] Spot-check that an article URL (`/articles/forgeintelligence-ai/<some-slug>`) still SSRs as before — the new library handler shouldn't shadow it (Express matches the two-segment route first)

## What this does *not* change

- The per-article route at line 1880 is untouched — its canonical / JSON-LD logic stays as-is
- The client-side `PublicArticlesLibraryPage` component is untouched — SSR runs server-side; React hydrates the same way
- Customer brand libraries continue to be reachable (just noindex'd) — preserves the existing preview-share workflow

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_