### PR TITLE
feat(gate): support ?promo= and ?gate=open deep-link params

### DIFF
--- a/src/components/GateModal.tsx
+++ b/src/components/GateModal.tsx
@@ -7,6 +7,7 @@ interface GateModalProps {
   onClose: () => void;
   brandProfileId?: string;
   onUnlocked?: () => void;
+  initialPromoCode?: string;
 }
 
 declare global { interface Window { paypal: any; } }
@@ -14,7 +15,7 @@ declare global { interface Window { paypal: any; } }
 const PAYPAL_CLIENT_ID = 'AV1QAbjyqG1YTRCWKXzWjZr1Ls7uNLRnk5SzoC-ajEb3rZaq5h58SCUoi9lcZgd9OCvJrM2WchL1om6l';
 const CLERK_SIGNUP_URL = 'https://accounts.forgeintelligence.ai/sign-up';
 
-export default function GateModal({ featureName, onClose, brandProfileId, onUnlocked }: GateModalProps) {
+export default function GateModal({ featureName, onClose, brandProfileId, onUnlocked, initialPromoCode }: GateModalProps) {
   const { trial } = useApp();
   // Trial-expired headline: user got the 7-day trial and it ended (eligible AND !active).
   const trialExpired = trial?.eligible && !trial.active;
@@ -27,7 +28,7 @@ export default function GateModal({ featureName, onClose, brandProfileId, onUnlo
   const [ppLoading, setPpLoading] = useState(true);
   const [ppError, setPpError] = useState('');
   const [paid, setPaid] = useState(false);
-  const [promoCode, setPromoCode] = useState('');
+  const [promoCode, setPromoCode] = useState(initialPromoCode || '');
   const [promoStatus, setPromoStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [promoMsg, setPromoMsg] = useState('');
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -239,6 +239,26 @@ const topNavItems: TopNavItem[] = [
 export function Sidebar() {
   const { currentView, setCurrentView, setAnalysisInput, analysisInput, sidebarCollapsed, setSidebarCollapsed, isProcessing, brandProfile, isPaid, brandLoading, activeBrand, refetchBrand, isSuperAdmin } = useApp();
   const [gateFeature, setGateFeature] = useState<string | null>(null);
+  const [seededPromoCode, setSeededPromoCode] = useState<string>('');
+
+  // Partner / prospect deep-link support:
+  //   ?gate=open    → auto-open GateModal on mount (soft paywall on landing)
+  //   ?promo=CODE   → pre-fill promo input so the prospect just clicks Apply
+  // Both params are consumed once and stripped from the URL so a refresh
+  // doesn't re-pop the modal. ?brand= and other query params are preserved.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const wantsGate = params.get('gate') === 'open';
+    const promo = params.get('promo') || '';
+    if (!wantsGate && !promo) return;
+    if (promo) setSeededPromoCode(promo);
+    if (wantsGate) setGateFeature('Forge Intelligence');
+    params.delete('gate');
+    params.delete('promo');
+    const qs = params.toString();
+    const url = window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
+    window.history.replaceState({}, '', url);
+  }, []);
   const LOCKED_ROUTES = [
     '/app/geo-strategist', '/app/authenticity-enricher', '/app/content-generator',
     '/app/campaign-generator', '/app/social-generator', '/app/compliance-gate', '/app/publishing-queue', '/app/calendar',
@@ -351,6 +371,7 @@ export function Sidebar() {
           onClose={() => setGateFeature(null)}
           brandProfileId={activeBrand?.id || (brandProfile as any)?.id || (() => { try { return localStorage.getItem('forge_active_brand_id'); } catch(e) { return null; } })() || new URLSearchParams(window.location.search).get('brand') || undefined}
           onUnlocked={() => { setGateFeature(null); refetchBrand(); }}
+          initialPromoCode={seededPromoCode}
         />
       )}
       {/* Mobile backdrop */}


### PR DESCRIPTION
## Summary

Enables a single-URL prospect handoff for partner flows (Nango.dev being the immediate driver). Run a scan, hand them a link, they land on their Brand Profile with the gate already open and their promo code pre-filled.

## The URL

```
https://forgeintelligence.ai/app/context-hub
  ?brand=<UUID>     ← existing — loads the Brand Profile
  &promo=NANGO      ← NEW — pre-fills the promo input
  &gate=open        ← NEW — auto-opens GateModal on landing
```

The prospect clicks **Apply** (or **Start your free 7-day trial**), signs up via Clerk, and the existing tether flow (`forge_pending_brand_id` → `server.js:14137`) claims the brand on their first authenticated dashboard fetch. No new backend surface needed.

## What changed

**`src/components/GateModal.tsx`**
- New optional `initialPromoCode?: string` prop
- Seeds the existing `promoCode` useState (default `''` keeps every existing caller behavior identical)

**`src/components/Sidebar.tsx`**
- New `useEffect` reads `?gate` and `?promo` once on mount
- If `gate=open`, sets `gateFeature='Forge Intelligence'` (anonymous prospects see the existing *"Start your free 7-day trial"* headline regardless of featureName, so the label barely matters here)
- Strips both consumed params from the URL via `replaceState` so a refresh doesn't re-pop the modal — preserves `?brand=` and any other query params
- Passes seeded code through to the rendered `GateModal`

## Test plan

- [ ] Deploy
- [ ] Open `/app/context-hub?brand=<UUID>&promo=NANGO&gate=open` in incognito
- [ ] Confirm Brand Profile renders, modal pops on landing, promo input shows `NANGO`, URL has been cleaned to `/app/context-hub?brand=<UUID>`
- [ ] Click Apply → confirm `/api/promo/validate` accepts the code and unlocks
- [ ] Refresh the page after dismissing — confirm modal does NOT re-pop
- [ ] Spot-check that regular `/app/context-hub?brand=<UUID>` (no `gate`/`promo`) is unchanged

## Notes

- No backend changes. `/api/promo/validate` already takes `{ code, brandProfileId }`.
- `ContentLibraryPage` also mounts `GateModal` independently; it doesn't get the URL-param treatment in this PR because prospects don't land there directly. Easy to add later if needed.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_