### PR TITLE
feat(promo): add NANGO partnership code

### DIFF
--- a/server.js
+++ b/server.js
@@ -14153,6 +14153,7 @@ const PROMO_CODES = new Map([
   ['FORGEFRIEND',   { discount: 100, description: 'Friend of Forge' }],
   ['EARLYBIRD',     { discount: 100, description: 'Early Access' }],
   ['SANDBOX100',    { discount: 100, description: 'Sandbox Group Internal' }],
+  ['NANGO',         { discount: 100, description: 'Nango Partnership' }],
 ]);
 
 // POST /api/promo/validate — validate a promo code (unlimited use)


### PR DESCRIPTION
## Summary

Adds the `NANGO` promo code to `server.js` so the deep-link URL from #79 actually unlocks the gate when Nango.dev prospects click Apply:

```
https://forgeintelligence.ai/app/context-hub?brand=<UUID>&promo=NANGO&gate=open
```

100% discount, unlimited use, matches the existing `SANDBOX100` / `FORGEFRIEND` / `EARLYBIRD` pattern. The `description` field (`'Nango Partnership'`) shows up in the success toast inside the modal.

## Follow-up (noted in conversation, not blocking)

Promo codes still live in a hardcoded `Map` at `server.js:14152`. Future PR should migrate to a `promo_codes` table with per-code usage caps, expiry, and per-tenant ownership so we can issue one-time codes per prospect (instead of one shared code per partner). Out of scope for this PR.

## Test plan

- [ ] Deploy
- [ ] After #79 also deploys, open `/app/context-hub?brand=<any-anonymous-brand-uuid>&promo=NANGO&gate=open` in incognito
- [ ] Confirm the modal pops with `NANGO` pre-filled, clicking Apply returns `valid: true` with the `Nango Partnership` description, and `is_paid` flips on the brand row

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_