### PR TITLE
release: promote #78 + #79 + #80 to production

### DIFF
--- a/server.js
+++ b/server.js
@@ -2149,6 +2149,124 @@ app.get('/articles/:brandSlug/:articleSlug', async (req, res) => {
   }
 });
 
+// ── Articles library SSR — canonical + robots ─────────────────────────────
+// Google flagged "Duplicate without user-selected canonical" on
+// /articles/forgeintelligence-ai because the SPA shell served at both
+// /articles and /articles/:brandSlug had no <link rel="canonical">. The
+// per-article route at line 1880 already does the full SSR treatment; this
+// extends the same pattern to the library views so Search Console sees one
+// canonical Articles URL per publisher.
+app.get('/articles/:brandSlug', async (req, res) => {
+  const { brandSlug } = req.params;
+  try {
+    const brandsRes = await pool.query('SELECT id, brand_url, brand_name, profile_data FROM brand_profiles');
+    let matchedBrand = null;
+    for (const b of brandsRes.rows) {
+      const slug = (b.brand_url || '').replace(/https?:\/\//, '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+      if (slug === brandSlug) { matchedBrand = b; break; }
+    }
+    if (!matchedBrand) {
+      for (const b of brandsRes.rows) {
+        const slug = (b.brand_url || '').replace(/https?:\/\//, '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+        const nameSlug = ((b.profile_data?.voice_profile?.brand_name) || '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+        const nameSlug2 = (b.brand_name || '').replace(/[^a-z0-9]/gi, '-').toLowerCase();
+        if (slug.startsWith(brandSlug) || brandSlug.startsWith(slug) ||
+            nameSlug.startsWith(brandSlug) || nameSlug2.startsWith(brandSlug)) {
+          matchedBrand = b; break;
+        }
+      }
+    }
+    if (!matchedBrand) return res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+
+    // Force canonical brand slug — same SSOT logic as the article route.
+    const canonicalBrandSlug = (matchedBrand.brand_url || '').replace(/https?:\/\//, '').replace(/[^a-z0-9]/gi, '-').toLowerCase().replace(/^-+|-+$/g, '');
+    if (canonicalBrandSlug && brandSlug !== canonicalBrandSlug) {
+      const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+      return res.redirect(301, `/articles/${canonicalBrandSlug}${qs}`);
+    }
+
+    const artBaseDomain = process.env.BASE_DOMAIN || 'forgeintelligence.ai';
+    const FORGE_OWN_BRAND_ID = 'cde5feeb-b3d7-4990-adee-a54977ab9c52';
+    const isForgeOwnContent = matchedBrand.id === FORGE_OWN_BRAND_ID;
+    const brandName = (matchedBrand.brand_name || matchedBrand.profile_data?.voice_profile?.brand_name || brandSlug).replace(/"/g, '&quot;');
+
+    // Canonical resolution mirrors the per-article route at line 1953:
+    //   - Forge's own library is canonical to itself (forgeintelligence.ai)
+    //   - Customer libraries canonical at the customer's article_base_url or
+    //     brand root, since the Forge-hosted library is a preview, not the
+    //     publisher.
+    let canonicalUrl;
+    if (isForgeOwnContent) {
+      canonicalUrl = `https://${artBaseDomain}/articles/${brandSlug}`;
+    } else if (matchedBrand.article_base_url && matchedBrand.article_base_url.trim()) {
+      canonicalUrl = matchedBrand.article_base_url.replace(/\/+$/, '');
+    } else if (matchedBrand.brand_url) {
+      const rootUrl = matchedBrand.brand_url.startsWith('http')
+        ? matchedBrand.brand_url.replace(/\/+$/, '')
+        : `https://${matchedBrand.brand_url.replace(/\/+$/, '')}`;
+      canonicalUrl = rootUrl;
+    } else {
+      canonicalUrl = `https://${artBaseDomain}/articles/${brandSlug}`;
+    }
+
+    const robotsMeta = isForgeOwnContent
+      ? 'index, follow, max-image-preview:large, max-snippet:-1'
+      : 'noindex, nofollow, noarchive';
+
+    const titleStr = `${brandName} — Articles`;
+    const descStr = `Browse articles from ${brandName}.`.replace(/"/g, '&quot;');
+
+    const headTags = `
+  <title>${titleStr}</title>
+  <meta name="description" content="${descStr}" />
+  <link rel="canonical" href="${canonicalUrl}" />
+  <meta name="robots" content="${robotsMeta}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="${brandName}" />
+  <meta property="og:title" content="${titleStr}" />
+  <meta property="og:description" content="${descStr}" />
+  <meta property="og:url" content="${canonicalUrl}" />`;
+
+    const html = await fs.promises.readFile(path.join(__dirname, 'dist', 'index.html'), 'utf8');
+    const injected = html
+      .replace(/<title>[^<]*<\/title>/, '')
+      .replace('<head>', '<head>' + headTags);
+    res.set('Cache-Control', 'no-cache');
+    return res.send(injected);
+  } catch(e) {
+    console.error('[ARTICLES-LIBRARY-SSR]', e.message);
+    return res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+  }
+});
+
+// Bare /articles renders the same component as /articles/:brandSlug for the
+// union of all brands. That's the duplicate Google flagged. Redirect to
+// Forge's canonical brand library so there is exactly one indexable Articles
+// URL on this domain. Customer brand libraries remain reachable via their own
+// brand-scoped URL (and get noindex'd per the handler above).
+app.get('/articles', async (req, res) => {
+  const FORGE_OWN_BRAND_ID = 'cde5feeb-b3d7-4990-adee-a54977ab9c52';
+  try {
+    const forgeBrand = await pool.query(
+      'SELECT brand_url FROM brand_profiles WHERE id = $1',
+      [FORGE_OWN_BRAND_ID]
+    );
+    const brandUrl = forgeBrand.rows[0]?.brand_url || '';
+    const forgeSlug = brandUrl
+      .replace(/https?:\/\//, '')
+      .replace(/[^a-z0-9]/gi, '-')
+      .toLowerCase()
+      .replace(/^-+|-+$/g, '');
+    if (forgeSlug) {
+      const qs = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+      return res.redirect(301, `/articles/${forgeSlug}${qs}`);
+    }
+  } catch(e) {
+    console.error('[ARTICLES-BARE-SSR]', e.message);
+  }
+  return res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+});
+
 // ── Marketing pages SSR — inject real content so scrapers + crawlers see it ──
 // Without this, SPA shell returns 1538 bytes of empty <div id="root"></div>
 // Forge's own scraper AND Google both need real HTML to extract product info.

--- a/server.js
+++ b/server.js
@@ -14153,6 +14153,7 @@ const PROMO_CODES = new Map([
   ['FORGEFRIEND',   { discount: 100, description: 'Friend of Forge' }],
   ['EARLYBIRD',     { discount: 100, description: 'Early Access' }],
   ['SANDBOX100',    { discount: 100, description: 'Sandbox Group Internal' }],
+  ['NANGO',         { discount: 100, description: 'Nango Partnership' }],
 ]);
 
 // POST /api/promo/validate — validate a promo code (unlimited use)

--- a/src/components/GateModal.tsx
+++ b/src/components/GateModal.tsx
@@ -7,6 +7,7 @@ interface GateModalProps {
   onClose: () => void;
   brandProfileId?: string;
   onUnlocked?: () => void;
+  initialPromoCode?: string;
 }
 
 declare global { interface Window { paypal: any; } }
@@ -14,7 +15,7 @@ declare global { interface Window { paypal: any; } }
 const PAYPAL_CLIENT_ID = 'AV1QAbjyqG1YTRCWKXzWjZr1Ls7uNLRnk5SzoC-ajEb3rZaq5h58SCUoi9lcZgd9OCvJrM2WchL1om6l';
 const CLERK_SIGNUP_URL = 'https://accounts.forgeintelligence.ai/sign-up';
 
-export default function GateModal({ featureName, onClose, brandProfileId, onUnlocked }: GateModalProps) {
+export default function GateModal({ featureName, onClose, brandProfileId, onUnlocked, initialPromoCode }: GateModalProps) {
   const { trial } = useApp();
   // Trial-expired headline: user got the 7-day trial and it ended (eligible AND !active).
   const trialExpired = trial?.eligible && !trial.active;
@@ -27,7 +28,7 @@ export default function GateModal({ featureName, onClose, brandProfileId, onUnlo
   const [ppLoading, setPpLoading] = useState(true);
   const [ppError, setPpError] = useState('');
   const [paid, setPaid] = useState(false);
-  const [promoCode, setPromoCode] = useState('');
+  const [promoCode, setPromoCode] = useState(initialPromoCode || '');
   const [promoStatus, setPromoStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [promoMsg, setPromoMsg] = useState('');
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -239,6 +239,26 @@ const topNavItems: TopNavItem[] = [
 export function Sidebar() {
   const { currentView, setCurrentView, setAnalysisInput, analysisInput, sidebarCollapsed, setSidebarCollapsed, isProcessing, brandProfile, isPaid, brandLoading, activeBrand, refetchBrand, isSuperAdmin } = useApp();
   const [gateFeature, setGateFeature] = useState<string | null>(null);
+  const [seededPromoCode, setSeededPromoCode] = useState<string>('');
+
+  // Partner / prospect deep-link support:
+  //   ?gate=open    → auto-open GateModal on mount (soft paywall on landing)
+  //   ?promo=CODE   → pre-fill promo input so the prospect just clicks Apply
+  // Both params are consumed once and stripped from the URL so a refresh
+  // doesn't re-pop the modal. ?brand= and other query params are preserved.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const wantsGate = params.get('gate') === 'open';
+    const promo = params.get('promo') || '';
+    if (!wantsGate && !promo) return;
+    if (promo) setSeededPromoCode(promo);
+    if (wantsGate) setGateFeature('Forge Intelligence');
+    params.delete('gate');
+    params.delete('promo');
+    const qs = params.toString();
+    const url = window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
+    window.history.replaceState({}, '', url);
+  }, []);
   const LOCKED_ROUTES = [
     '/app/geo-strategist', '/app/authenticity-enricher', '/app/content-generator',
     '/app/campaign-generator', '/app/social-generator', '/app/compliance-gate', '/app/publishing-queue', '/app/calendar',
@@ -351,6 +371,7 @@ export function Sidebar() {
           onClose={() => setGateFeature(null)}
           brandProfileId={activeBrand?.id || (brandProfile as any)?.id || (() => { try { return localStorage.getItem('forge_active_brand_id'); } catch(e) { return null; } })() || new URLSearchParams(window.location.search).get('brand') || undefined}
           onUnlocked={() => { setGateFeature(null); refetchBrand(); }}
+          initialPromoCode={seededPromoCode}
         />
       )}
       {/* Mobile backdrop */}


### PR DESCRIPTION
## Summary

Promote main → production. Three merged PRs in one bundle:

| PR | What | Scope |
|---|---|---|
| #78 | `fix(seo): canonical + robots SSR for /articles library` | Resolves Google Search Console "Duplicate without user-selected canonical" on `/articles/forgeintelligence-ai`. Adds SSR canonical + robots for `/articles/:brandSlug` and 301-redirects bare `/articles` → `/articles/<forge-canonical-slug>`. |
| #79 | `feat(gate): support ?promo= and ?gate=open deep-link params` | New URL params for prospect / partner handoffs. `?promo=CODE` pre-fills the GateModal input; `?gate=open` auto-pops the modal on landing. Both consumed once and stripped from the URL on mount. |
| #80 | `feat(promo): add NANGO partnership code` | Adds `NANGO` to the hardcoded `PROMO_CODES` map. 100% discount, unlimited use, matches the existing `SANDBOX100` / `FORGEFRIEND` / `EARLYBIRD` pattern. Pairs with #79's `?promo=NANGO`. |

## Once this deploys

**Nango deep-link is fully wired:**
```
https://forgeintelligence.ai/app/context-hub
  ?brand=<UUID>
  &promo=NANGO
  &gate=open
```
Lands them on the Brand Profile, gate auto-opens with NANGO pre-filled, one click → unlocked → Clerk signup → auto-tether on first authenticated fetch.

**Search Console action:** click **Validate Fix** on the "Duplicate without user-selected canonical" issue once deployed.

## Review notes

- No `package.json` / dependency changes in this window
- No DB schema migrations
- Three production-affecting files touched: `server.js` (canonical SSR + NANGO map entry), `src/components/Sidebar.tsx` (URL param consumer), `src/components/GateModal.tsx` (new `initialPromoCode` prop)
- All three PRs CI'd and reviewed individually before reaching main

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_