### PR TITLE
fix(deep-link): no flash on ?brand= partner URL first load

### DIFF
--- a/src/components/views/BrandProfile.tsx
+++ b/src/components/views/BrandProfile.tsx
@@ -106,6 +106,22 @@ export function BrandProfile() {
   }, [brandProfile?.brandUrl, reanalyzing, setBrandProfile]);
 
   if (!brandProfile) {
+    // Deep-link fetch in flight — ContextAgentPage's ?brand=<uuid> useEffect
+    // is loading the profile. Show a quiet loading skeleton instead of the
+    // "No Brand Profile Available" empty state so partner deep-links don't
+    // flash a misleading "run an analysis" CTA during the network hop.
+    const isAwaitingDeepLink = typeof window !== 'undefined'
+      && !!new URLSearchParams(window.location.search).get('brand');
+    if (isAwaitingDeepLink) {
+      return (
+        <div className="brand-profile empty-state" aria-busy="true" aria-live="polite">
+          <div className="empty-icon" style={{ animation: 'forge-pulse 1.2s ease-in-out infinite' }}>{icons.layers}</div>
+          <h2 className="empty-title">Loading Brand Profile…</h2>
+          <p className="empty-description">Pulling your brand brain.</p>
+          <style>{`@keyframes forge-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }`}</style>
+        </div>
+      );
+    }
     return (
       <div className="brand-profile empty-state">
         <div className="empty-icon">{icons.layers}</div>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -72,7 +72,12 @@ export function AppProvider({ children }: { children: ReactNode }) {
     const params = new URLSearchParams(window.location.search);
     const viewParam = params.get('view');
     const valid: ViewType[] = ['new-analysis', 'active-run', 'brand-profile', 'strategy', 'brain-history', 'content-generator', 'campaign-generator'];
-    return (valid.includes(viewParam as ViewType) ? viewParam : 'new-analysis') as ViewType;
+    if (valid.includes(viewParam as ViewType)) return viewParam as ViewType;
+    // ?brand=<uuid> deep-link → seed brand-profile synchronously so first
+    // paint doesn't flash New Analysis before the post-mount useEffect
+    // switches the view. Partner / prospect deep-links should land directly.
+    if (params.get('brand')) return 'brand-profile';
+    return 'new-analysis';
   });
   const [brandProfile, setBrandProfile] = useState<BrandProfile | null>(null);
   const [analysisInput, setAnalysisInput] = useState<AnalysisInput>({


### PR DESCRIPTION
## Summary

Fix for the "light blue full screen until refresh" Nango hit on the partner deep-link from #79 / #80. Two stacked first-paint races collapsed into one bad UX moment.

## Root cause

1. **Flash A — wrong initial view.** `AppContext` initializes `currentView` synchronously from `?view=` only. `?brand=` alone fell through to `'new-analysis'`, so the first paint rendered the New Analysis view (Forge's blue gradient) before `ContextAgentPage`'s post-mount `useEffect` ran `setCurrentView('brand-profile')`. That's the light-blue flash.

2. **Flash B — misleading empty state.** Once the view switched, `brandProfile` was still null until `/api/context-hub/brand/<uuid>` resolved. `BrandProfile` rendered *"No Brand Profile Available — run a new analysis"* during the network hop — confusing for a prospect who never ran an analysis.

Refresh "fixed it" because by the second load `forge_active_brand` was in localStorage and timing shifted enough that the post-fetch frame won.

## Fix

**`src/context/AppContext.tsx`** — seed `currentView = 'brand-profile'` synchronously when `?brand=<uuid>` is present in the URL. No flash to New Analysis on the first paint.

```ts
if (valid.includes(viewParam as ViewType)) return viewParam as ViewType;
if (params.get('brand')) return 'brand-profile';   // NEW
return 'new-analysis';
```

**`src/components/views/BrandProfile.tsx`** — when `brandProfile` is null AND `?brand=` is in the URL, render a quiet loading skeleton ("Loading Brand Profile… Pulling your brand brain.") with `aria-busy` + `aria-live` instead of the "run an analysis" empty state. Other null cases (e.g. genuine "no brand selected") still get the original empty state.

## Test plan

- [ ] Deploy
- [ ] Open `/app/context-hub?brand=<UUID>&promo=NANGO&gate=open` in incognito with throttled Slow 3G in DevTools
- [ ] Confirm first paint is the **loading skeleton** (not New Analysis, not "No Brand Profile Available")
- [ ] When the network hop completes, profile renders smoothly with the gate modal already open and `NANGO` pre-filled
- [ ] Regression check: `/app/context-hub` without `?brand=` still defaults to New Analysis and shows the same empty state as before for genuine "no brand selected"

## Notes

- Localized, run-of-the-mill state guards. No new deps, no schema, no behavior change for non-`?brand=` traffic.
- Build: tsc + vite pass clean.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_