### PR TITLE
hotfix(sidebar): remove Mission Control entry (asap)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -221,7 +221,11 @@ const publishingNavItems = [
 const settingsNavItems = [
   { id: 'brand-settings', label: 'Brand Settings', icon: 'settings', href: '/app/brand-settings' },
   { id: 'integrations',   label: 'Integrations',   icon: 'plug',     href: '/app/integrations' },
-  { id: 'admin',          label: 'Mission Control',          icon: 'cpu',      href: '/app/mc' },
+  // Mission Control sidebar entry intentionally removed in this hotfix —
+  // production was accidentally merged into main and the isSuperAdmin guard
+  // at the filter site (~line 550) was leaking the entry to non-admin users.
+  // /app/mc remains accessible by direct URL for super-admins until the gate
+  // logic is verified and the entry is reinstated in a follow-up PR.
 ] as const;
 
 const topNavItems: TopNavItem[] = [
@@ -237,7 +241,7 @@ const topNavItems: TopNavItem[] = [
 ];
 
 export function Sidebar() {
-  const { currentView, setCurrentView, setAnalysisInput, analysisInput, sidebarCollapsed, setSidebarCollapsed, isProcessing, brandProfile, isPaid, brandLoading, activeBrand, refetchBrand, isSuperAdmin } = useApp();
+  const { currentView, setCurrentView, setAnalysisInput, analysisInput, sidebarCollapsed, setSidebarCollapsed, isProcessing, brandProfile, isPaid, brandLoading, activeBrand, refetchBrand } = useApp();
   const [gateFeature, setGateFeature] = useState<string | null>(null);
   const [seededPromoCode, setSeededPromoCode] = useState<string>('');
 
@@ -547,7 +551,7 @@ export function Sidebar() {
               </button>
               {!sidebarCollapsed && settingsGroupOpen && (
                 <div className="nav-group-children">
-                  {settingsNavItems.filter(c => c.id !== 'admin' || isSuperAdmin).map(child => {
+                  {settingsNavItems.map(child => {
                     const childActive = path.startsWith(child.href);
                     return (
                       <a


### PR DESCRIPTION
## Summary

**Hotfix — production was accidentally merged into main and the `isSuperAdmin` guard at the sidebar filter site appears to have been reverted, leaking the Mission Control entry to non-admin users.** Killing the sidebar entry entirely is the shortest path to remediating the visible regression. `/app/mc` remains reachable by direct URL for super-admins until the gate logic is verified and the entry is reinstated in a follow-up PR.

## Changes

1. **`Sidebar.tsx` `settingsNavItems`** — drop the `{ id: 'admin', label: 'Mission Control' }` entry
2. **Sidebar settings-group children render** — drop the now-dead `.filter(c => c.id !== 'admin' || isSuperAdmin)` (TS caught it immediately — `c.id` can no longer be `'admin'`)
3. **Sidebar component destructure** — drop unused `isSuperAdmin`

## Risk

- Non-admins: **no runtime change** — the entry shouldn't have been visible to them anyway. This just makes that the unconditional truth.
- Super-admins: lose the sidebar shortcut to `/app/mc`. Route is still routable by direct URL.
- Build: `tsc + vite` pass clean.

## Once merged

- [ ] Fast-forward production immediately so the leak stops in prod
- [ ] Follow-up PR: investigate the `isSuperAdmin` regression from the production-into-main merge, restore the guard, reinstate the Mission Control nav entry behind the verified gate

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_