### PR TITLE
hotfix(topbar): hide super-admin brand switcher (asap)

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -72,7 +72,12 @@ const pathTitles: Record<string, string> = {
 };
 
 export function TopBar({ pageTitle }: { pageTitle?: string }) {
-  const { currentView, brandProfile, activeBrand, sidebarCollapsed, setSidebarCollapsed, allBrands, switchBrand, trial, isSuperAdmin } = useApp();
+  const { currentView, brandProfile, activeBrand, sidebarCollapsed, setSidebarCollapsed, allBrands, switchBrand, trial } = useApp();
+  // Hotfix: pinned to false until the isSuperAdmin gate is verified after the
+  // production-into-main merge regression. Mission Control nav entry already
+  // hidden in #84 for the same reason. Restore by re-destructuring isSuperAdmin
+  // from useApp() once /api/auth/me is confirmed gating correctly.
+  const isSuperAdmin = false;
   const { user } = useUser();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary

**Sibling hotfix to #84.** Same root cause: the production-into-main merge appears to have reverted the `isSuperAdmin` guard, leaking super-admin-only UI to regular users. `TopBar.tsx` lines ~122, 131, and 138 all gate a brand-switcher dropdown + multi-brand version indicator on `isSuperAdmin && allBrands.length > 0` — exposed right now.

## Fix shape

Same pattern as #84 — pin `isSuperAdmin = false` locally in the component instead of unwinding every conditional. Drops the destructure from `useApp()` and declares a local const so every JSX check short-circuits predictably.

```tsx
// before
const { ..., isSuperAdmin } = useApp();

// after
const { ... } = useApp();           // isSuperAdmin removed from destructure
const isSuperAdmin = false;         // hotfix override — restore once gate verified
```

## Risk

- **Non-admins**: no runtime change. The activeBrand pill at line 122 (gated on `!isSuperAdmin || !allBrands.length`) is now always true → they continue to see their brand pill exactly as before.
- **Super-admins**: lose the brand-switcher dropdown and the multi-brand version indicator. `activeBrand` falls back to whatever `useActiveBrand` returns for the signed-in user.

## Restore path

Re-destructure `isSuperAdmin` from `useApp()` and delete the local const override once `/api/auth/me` is confirmed gating correctly. Tracking alongside the Mission Control reinstatement noted in #84.

Build: tsc + vite pass clean.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_