### PR TITLE
revert(superadmin): restore Mission Control + brand switcher on dev

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -221,11 +221,7 @@ const publishingNavItems = [
 const settingsNavItems = [
   { id: 'brand-settings', label: 'Brand Settings', icon: 'settings', href: '/app/brand-settings' },
   { id: 'integrations',   label: 'Integrations',   icon: 'plug',     href: '/app/integrations' },
-  // Mission Control sidebar entry intentionally removed in this hotfix —
-  // production was accidentally merged into main and the isSuperAdmin guard
-  // at the filter site (~line 550) was leaking the entry to non-admin users.
-  // /app/mc remains accessible by direct URL for super-admins until the gate
-  // logic is verified and the entry is reinstated in a follow-up PR.
+  { id: 'admin',          label: 'Mission Control', icon: 'cpu',     href: '/app/mc' },
 ] as const;
 
 const topNavItems: TopNavItem[] = [
@@ -241,7 +237,7 @@ const topNavItems: TopNavItem[] = [
 ];
 
 export function Sidebar() {
-  const { currentView, setCurrentView, setAnalysisInput, analysisInput, sidebarCollapsed, setSidebarCollapsed, isProcessing, brandProfile, isPaid, brandLoading, activeBrand, refetchBrand } = useApp();
+  const { currentView, setCurrentView, setAnalysisInput, analysisInput, sidebarCollapsed, setSidebarCollapsed, isProcessing, brandProfile, isPaid, brandLoading, activeBrand, refetchBrand, isSuperAdmin } = useApp();
   const [gateFeature, setGateFeature] = useState<string | null>(null);
   const [seededPromoCode, setSeededPromoCode] = useState<string>('');
 
@@ -551,7 +547,7 @@ export function Sidebar() {
               </button>
               {!sidebarCollapsed && settingsGroupOpen && (
                 <div className="nav-group-children">
-                  {settingsNavItems.map(child => {
+                  {settingsNavItems.filter(c => c.id !== 'admin' || isSuperAdmin).map(child => {
                     const childActive = path.startsWith(child.href);
                     return (
                       <a

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -72,12 +72,7 @@ const pathTitles: Record<string, string> = {
 };
 
 export function TopBar({ pageTitle }: { pageTitle?: string }) {
-  const { currentView, brandProfile, activeBrand, sidebarCollapsed, setSidebarCollapsed, allBrands, switchBrand, trial } = useApp();
-  // Hotfix: pinned to false until the isSuperAdmin gate is verified after the
-  // production-into-main merge regression. Mission Control nav entry already
-  // hidden in #84 for the same reason. Restore by re-destructuring isSuperAdmin
-  // from useApp() once /api/auth/me is confirmed gating correctly.
-  const isSuperAdmin = false;
+  const { currentView, brandProfile, activeBrand, sidebarCollapsed, setSidebarCollapsed, allBrands, switchBrand, trial, isSuperAdmin } = useApp();
   const { user } = useUser();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
Reverts the production hotfixes from #84 and #85 on dev so super-admin UI is fully visible (gated through the existing isSuperAdmin path) during continued development. Production / main remain hotfixed — this branch carries the restored state forward.

Restored:
  - Sidebar.tsx: re-adds the { id: 'admin', label: 'Mission Control' } entry to settingsNavItems and re-applies the `.filter(c => c.id !== 'admin' || isSuperAdmin)` guard at the render site, re-destructures isSuperAdmin from useApp().
  - TopBar.tsx: re-destructures isSuperAdmin from useApp() and drops the `const isSuperAdmin = false` override. The three existing JSX checks (`isSuperAdmin && allBrands.length > 0 && …`) now behave per the original implementation.

This is a clean reversion of the hotfix code paths to the same shape they had before #84/#85. The underlying isSuperAdmin gate (driven by /api/auth/me) was not modified by the hotfixes — they only short-circuited the consumer sites. So restoring the destructure is sufficient to put the gate back in charge.

Build: tsc + vite pass clean.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i