### PR TITLE
feat(articles): render GFM tables (incl. single-line-flat) as <table>

### DIFF
--- a/server.js
+++ b/server.js
@@ -2107,11 +2107,51 @@ app.get('/articles/:brandSlug/:articleSlug', async (req, res) => {
 
     // ── Build SSR body content for AI crawlers (ChatGPT, Perplexity, GPTBot, Googlebot) ──
     // React hydrates over this on client load. Wrapped in off-screen container so humans don't see it twice.
+    // Table-aware: GFM markdown tables (including the single-line-flat shape
+    // that Content Generator sometimes emits, e.g. article 63ed73dd-…) get
+    // promoted to real <table> markup so AI crawlers cite them as tabular
+    // data instead of seeing literal pipe characters in a paragraph.
+    const ssrTryParseTable = (raw) => {
+      if (!raw.includes('|')) return null;
+      if (!/\|\s*:?-{3,}:?\s*\|/.test(raw)) return null;
+      const cells = raw.split('|').map(c => c.trim());
+      const isSep = (c) => /^:?-{3,}:?$/.test(c);
+      const sepStart = cells.findIndex(isSep);
+      if (sepStart === -1) return null;
+      let sepEnd = sepStart;
+      while (sepEnd < cells.length && isSep(cells[sepEnd])) sepEnd++;
+      const colCount = sepEnd - sepStart;
+      if (colCount < 1) return null;
+      const headers = [];
+      for (let i = sepStart - 1; i >= 0 && headers.length < colCount; i--) {
+        if (cells[i].length > 0) headers.unshift(cells[i]);
+      }
+      if (headers.length !== colCount) return null;
+      const after = cells.slice(sepEnd);
+      let idx = 0;
+      while (idx < after.length && after[idx].length === 0) idx++;
+      const rows = [];
+      while (idx + colCount <= after.length) {
+        rows.push(after.slice(idx, idx + colCount));
+        idx += colCount;
+        while (idx < after.length && after[idx].length === 0) idx++;
+      }
+      if (rows.length === 0) return null;
+      return { headers, rows };
+    };
+    const ssrRenderParagraph = (para) => {
+      const table = ssrTryParseTable(para);
+      if (table) {
+        const thead = `<thead><tr>${table.headers.map(h => `<th>${h}</th>`).join('')}</tr></thead>`;
+        const tbody = `<tbody>${table.rows.map(r => `<tr>${r.map(c => `<td>${c}</td>`).join('')}</tr>`).join('')}</tbody>`;
+        return `<table>${thead}${tbody}</table>`;
+      }
+      return `<p>${para.trim().replace(/\n/g, '<br>')}</p>`;
+    };
     const sectionsHtml = (aj.sections || []).map(s => {
       const heading = (s.heading || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
       const body = (s.body || s.content || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-      // Preserve paragraph breaks
-      const paragraphs = body.split(/\n\n+/).map(p => `<p>${p.trim().replace(/\n/g, '<br>')}</p>`).join('\n');
+      const paragraphs = body.split(/\n\n+/).map(ssrRenderParagraph).join('\n');
       return `<section><h2>${heading}</h2>${paragraphs}</section>`;
     }).join('\n');
 

--- a/src/pages/PublicArticlePage.tsx
+++ b/src/pages/PublicArticlePage.tsx
@@ -81,11 +81,114 @@ function renderBody(raw: string): React.ReactNode {
 
   return (
     <>
-      {paragraphs.map((para, pi) => (
-        <p key={pi} style={{ marginBottom: '1rem' }}>{renderInline(para, `p${pi}`)}</p>
-      ))}
+      {paragraphs.map((para, pi) => {
+        const table = tryParseTable(para);
+        if (table) {
+          return (
+            <table
+              key={pi}
+              style={{
+                borderCollapse: 'collapse',
+                width: '100%',
+                margin: '1.25rem 0',
+                fontSize: '0.95em',
+                lineHeight: 1.55,
+              }}
+            >
+              <thead>
+                <tr>
+                  {table.headers.map((h, ci) => (
+                    <th
+                      key={ci}
+                      style={{
+                        textAlign: 'left',
+                        padding: '8px 12px',
+                        borderBottom: '2px solid #E2E8F0',
+                        fontWeight: 600,
+                        color: '#0F172A',
+                      }}
+                    >
+                      {renderInline(h, `t${pi}-h${ci}`)}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {table.rows.map((row, ri) => (
+                  <tr key={ri}>
+                    {row.map((cell, ci) => (
+                      <td
+                        key={ci}
+                        style={{
+                          padding: '8px 12px',
+                          borderBottom: '1px solid #F1F5F9',
+                          verticalAlign: 'top',
+                          color: '#1E293B',
+                        }}
+                      >
+                        {renderInline(cell, `t${pi}-r${ri}-c${ci}`)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          );
+        }
+        return (
+          <p key={pi} style={{ marginBottom: '1rem' }}>{renderInline(para, `p${pi}`)}</p>
+        );
+      })}
     </>
   );
+}
+
+// Markdown table parser. Handles both well-formed multi-line GFM and the
+// degenerate single-line-flat case where the Content Generator emits a table
+// without newlines between rows (the article 63ed73dd-… case). Detection key
+// is the GFM separator row "|---|...|" with 3+ dashes per cell.
+//
+// Approach: ignore whitespace (including newlines), split on "|", trim, then
+// use the separator's column count to slice header + data rows out of the
+// non-empty cells. Works the same way regardless of how line breaks landed,
+// so a single-line flat table and a properly newlined table both round-trip
+// to the same structure.
+function tryParseTable(raw: string): { headers: string[]; rows: string[][] } | null {
+  if (!raw.includes('|')) return null;
+  if (!/\|\s*:?-{3,}:?\s*\|/.test(raw)) return null;
+
+  const cells = raw.split('|').map(c => c.trim());
+  const isSep = (c: string) => /^:?-{3,}:?$/.test(c);
+
+  const sepStart = cells.findIndex(isSep);
+  if (sepStart === -1) return null;
+  let sepEnd = sepStart;
+  while (sepEnd < cells.length && isSep(cells[sepEnd])) sepEnd++;
+  const colCount = sepEnd - sepStart;
+  if (colCount < 1) return null;
+
+  // Headers: the last `colCount` non-empty cells before the separator.
+  const headers: string[] = [];
+  for (let i = sepStart - 1; i >= 0 && headers.length < colCount; i--) {
+    if (cells[i].length > 0) headers.unshift(cells[i]);
+  }
+  if (headers.length !== colCount) return null;
+
+  // Rows: walk cells after the separator in chunks of colCount, skipping
+  // row-boundary empties between each chunk. (Empty cells WITHIN a row are
+  // preserved because the chunk takes exactly colCount cells without filtering.)
+  const after = cells.slice(sepEnd);
+  let idx = 0;
+  while (idx < after.length && after[idx].length === 0) idx++;
+  const rows: string[][] = [];
+  while (idx + colCount <= after.length) {
+    rows.push(after.slice(idx, idx + colCount));
+    idx += colCount;
+    while (idx < after.length && after[idx].length === 0) idx++;
+  }
+  if (rows.length === 0) return null;
+
+  return { headers, rows };
 }
 
 


### PR DESCRIPTION
Article 63ed73dd-… surfaced a long-standing rendering gap: when the
Content Generator emits a markdown table, the public article renderer
treats it as inline prose. Worse, the generator sometimes flattens the
table to a single line with no newlines between rows, so even a
markdown-aware renderer wouldn't parse it cleanly.

Fix lifts both halves:

1) src/pages/PublicArticlePage.tsx — new tryParseTable() in renderBody.
   Detection key is the GFM separator row "|---|...|" (or :---: / ---:
   variants for alignment). Parser splits on "|" with whitespace/newline-
   agnostic trim, infers column count from the separator, then walks the
   remaining cells in colCount-sized chunks (skipping row-boundary
   empties between chunks but preserving empty cells WITHIN a row).
   This works the same way regardless of how line breaks landed, so:
     - Single-line-flat input ("| h1 | h2 | |---|---| | r1 | r2 |") and
     - Properly multi-line GFM
   both round-trip to the same { headers, rows } structure.
   Renders as a real <table> with <thead>/<tbody>, basic inline styles
   matching the existing typography, and renderInline() applied to each
   cell so markdown links + footnote refs inside cells still resolve.

2) server.js (~line 2110) — same parser ported into the SSR section
   rendering so AI crawlers (GPTBot, Googlebot, Perplexity) see <table>
   markup instead of a paragraph of literal pipes. This is the GEO
   payoff: tabular data with proper schema is high-value citation
   material for LLM citations.

Tested against the exact string from article 63ed73dd-…: parser
reconstructs the 3 headers + 3 rows × 3 cells cleanly. Build (tsc +
vite) passes. node --check on server.js passes.

Followup (not in this PR): nudge the Content Generator prompt to emit
tables with proper \n between rows so future articles store cleanly.
With this renderer in place, even the flat shape now renders correctly,
but the underlying storage shape should still be fixed for clarity.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i