### PR TITLE
feat(context-hub): Jina Reader as tier-2 SPA fallback

### DIFF
--- a/server.js
+++ b/server.js
@@ -4442,9 +4442,51 @@ Content themes in this market: ${(sonarJson.contentThemes || []).join(', ')}`;
         console.log(`[Context Hub] Scraped ${scrapedContent.length} chars from ${aboutPaths.length + 1} pages (base: ${workingBaseUrl})`);
       } else {
         // Local scrape failed to extract usable content — typically a JS-rendered SPA where the
-        // raw HTML is 10kb+ but stripHtml() yields a few dozen chars (title tag only). Fall back
-        // to Sonar, which runs full server-side rendering and sees what users actually see.
-        console.log(`[Context Hub] Local scrape minimal (${scrapedContent.length} chars from ${homeHtml.length} bytes HTML) — falling back to Sonar content extraction`);
+        // raw HTML is 10kb+ but stripHtml() yields a few dozen chars (title tag only). Two-tier
+        // fallback follows: first Jina Reader (renders the page server-side in real time —
+        // works even on brand-new sites that aren't indexed anywhere yet), then Sonar (relies on
+        // Perplexity's index — fast when the site is already crawled, useless for brand-new sites).
+        //
+        // Order matters: Jina runs first because it can handle brand-new SPAs. Sonar is the
+        // backup for the case where Jina's free tier rate-limits us OR returns an error.
+        console.log(`[Context Hub] Local scrape minimal (${scrapedContent.length} chars from ${homeHtml.length} bytes HTML) — trying Jina Reader fallback`);
+        try {
+          const jinaHeaders = { 'Accept': 'text/plain' };
+          if (process.env.JINA_API_KEY) {
+            jinaHeaders['Authorization'] = `Bearer ${process.env.JINA_API_KEY}`;
+          }
+          // Bound the request — Jina cold-renders can take 5-12s but anything beyond
+          // ~15s indicates the target site itself is slow / hanging and we should
+          // move on to Sonar rather than block the entire analyze call.
+          const jinaAbort = new AbortController();
+          const jinaTimeout = setTimeout(() => jinaAbort.abort(), 15000);
+          const jinaRes = await fetch(`https://r.jina.ai/${brandUrl}`, {
+            headers: jinaHeaders,
+            signal: jinaAbort.signal,
+          }).finally(() => clearTimeout(jinaTimeout));
+          if (jinaRes.ok) {
+            const jinaText = (await jinaRes.text()).trim();
+            if (jinaText.length > 200) {
+              // Cap at 8000 chars to match the local-scrape budget and keep the
+              // downstream Claude prompt under its size envelope.
+              scrapedContent = `JINA-EXTRACTED CONTENT (JS-rendered by Jina Reader — this is what a user sees):\n${jinaText.slice(0, 8000)}`;
+              console.log(`[Context Hub] Jina Reader fallback succeeded: ${jinaText.length} chars (capped to 8000)`);
+            } else {
+              console.log(`[Context Hub] Jina Reader returned minimal content (${jinaText.length} chars) — trying Sonar next`);
+            }
+          } else {
+            console.log(`[Context Hub] Jina Reader HTTP ${jinaRes.status} — trying Sonar next`);
+          }
+        } catch (jinaErr) {
+          console.log(`[Context Hub] Jina Reader error (non-fatal):`, jinaErr.message);
+        }
+      }
+
+      // Tier 3: Sonar fallback. Runs only if Jina didn't lift us past the threshold.
+      // Useful when Jina is rate-limited or the target is geo-blocked from Jina's
+      // egress IPs but already crawled into Perplexity's index.
+      if (scrapedContent.length <= 200) {
+        console.log(`[Context Hub] Jina + local still under threshold — falling back to Sonar content extraction`);
         try {
           const sonarContentRes = await fetch('https://api.perplexity.ai/chat/completions', {
             method: 'POST',


### PR DESCRIPTION
## Summary

Closes the SPA-scan gap that hit Brian's other Claude Code project.

The existing chain was **local HTTP → Sonar → blind**, but Sonar can only return content for pages it's already indexed. Brand-new SPAs (SYSOI's landing page on first scan day, any vibe-coded site fresh out of Lovable, etc.) aren't in Perplexity's index yet, so Sonar returns `SITE_INACCESSIBLE` and the scrape falls through to Claude blind-guessing from the domain name. The output looks like a profile but is hallucinated, which presents to the user as *"scan didn't work."*

## New chain

```
local HTTP scrape    (lightweight, ~50ms)
     │ if < 200 chars (typical SPA shell)
     ▼
Jina Reader r.jina.ai   ← NEW. Renders the page server-side in real time,
     │                    returns markdown. Works on brand-new sites that
     │ if < 200 chars     aren't indexed anywhere yet.
     ▼
Perplexity Sonar          (Existing — now the backup for when Jina is
     │                    rate-limited or geo-blocked but Sonar has the
     │                    site cached.)
     ▼
Claude blind-guess        (Last resort — logged warning.)
```

**Why Jina before Sonar**: Jina actually fetches and renders the live page so it's authoritative for new sites. Sonar is great when Perplexity has the site cached but useless when it doesn't.

## Implementation

- New tier-2 fallback in the existing scraper try block at `server.js:4441`
- `JINA_API_KEY` env var optional — code works without it at the free tier's rate limits and auto-uses the bearer if set
- 15s `AbortController` timeout so a slow target can't block the overall analyze call
- Output capped at 8000 chars to match the local-scrape budget and keep the downstream Claude prompt under its envelope
- Tagged `JINA-EXTRACTED CONTENT` in the prompt so Claude knows the source attribution (mirrors the existing `SONAR-EXTRACTED` tag)
- Logs at every branch so a future "scan failed" report is one grep away from the answer

No schema changes, no new dependencies (just `fetch` + `AbortController`), no behavior change for sites where the local scrape already succeeds.

## Ops

Set `JINA_API_KEY` env var in prod once you've provisioned the Jina account. Works without it at the free tier.

## Test plan

- [ ] Deploy
- [ ] Re-scan SYSOI (or any brand-new SPA) via Context Hub
- [ ] Grep prod logs for `[Context Hub] Jina Reader fallback succeeded:` — confirm content length is reasonable (1k+ chars)
- [ ] Confirm Brand Profile is grounded in the actual page content, not a guess from the domain
- [ ] Regression: re-scan an existing brand with normal HTML — confirm Jina branch never fires (local scrape returns > 200 chars and we don't hit the fallback)

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_