### PR TITLE
fix(publishing-queue): unplug icon + clearer label for unpublish action

### DIFF
--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -33,9 +33,15 @@ const Archive = () => (
   </svg>
 );
 
-const Trash = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4h6v2"/>
+const Unplug = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m19 5 3-3"/>
+    <path d="m2 22 3-3"/>
+    <path d="M6.3 20.3a2.4 2.4 0 0 0 3.4 0L12 18l-6-6-2.3 2.3a2.4 2.4 0 0 0 0 3.4Z"/>
+    <path d="M7.5 13.5 10 11"/>
+    <path d="M10.5 16.5 13 14"/>
+    <path d="m12 6 6 6"/>
+    <path d="M17.5 6.5a2.4 2.4 0 0 0 0-3.4l0 0a2.4 2.4 0 0 0-3.4 0L12 5.2 18 11l2.1-2.1a2.4 2.4 0 0 0 0-3.4Z"/>
   </svg>
 );
 const Link2 = () => (
@@ -1413,8 +1419,8 @@ ${authorFooterHtml}
                           <Archive />
                         </button>
                       )}
-                      <button className="pq-icon-btn danger" title="Remove from queue" aria-label="Remove this item from the queue" onClick={() => openDeleteModal(item)}>
-                        <Trash />
+                      <button className="pq-icon-btn danger" title="Unpublish by channel" aria-label="Unpublish this content from one or more channels" onClick={() => openDeleteModal(item)}>
+                        <Unplug />
                       </button>
                     </div>
                   </div>
@@ -1746,8 +1752,8 @@ return (
                           <Archive />
                         </button>
                       )}
-                      <button className="pq-icon-btn danger" title="Remove from queue" aria-label="Remove this item from the queue" onClick={() => openDeleteModal(item)}>
-                        <Trash />
+                      <button className="pq-icon-btn danger" title="Unpublish by channel" aria-label="Unpublish this content from one or more channels" onClick={() => openDeleteModal(item)}>
+                        <Unplug />
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

The per-channel unpublish modal has been wired end-to-end since commit `deabf73`, but its entry point was a 🗑 trash icon labeled *"Remove from queue"* — which reads as "delete entirely" not "unpublish from one channel." The feature was *findable* but not *discoverable*. Brian: *"this disappears"* — really meaning the affordance doesn't match the mental model so users never click it.

This swaps the icon and label so the entry point matches what the modal behind it actually does.

## Changes

| Before | After |
|---|---|
| 🗑 `Trash` icon | 🔌 `Unplug` icon (disconnect-from-channel semantic) |
| `title="Remove from queue"` | `title="Unpublish by channel"` |
| `aria-label="Remove this item from the queue"` | `aria-label="Unpublish this content from one or more channels"` |

Applied at both the grid view site (`PublishingQueuePage.tsx:1416`) and the list view site (`:1749`). The `Trash` inline SVG component is removed (was only referenced at those two sites).

No change to the modal itself, the `/api/publishing/unpublish` endpoint, or the behavior. Just makes the existing feature findable.

## Build

`tsc + vite` pass clean. ~13 lines changed.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_