### PR TITLE
fix(publishing): republish auth + unstick stale 'republishing' state

### DIFF
--- a/server.js
+++ b/server.js
@@ -1169,42 +1169,59 @@ app.post('/api/publishing/republish', requireAuth, async (req, res) => {
   const { queueItemId, channel } = req.body;
   if (!queueItemId || !channel) return res.status(400).json({ error: 'queueItemId and channel required' });
   try {
-    // Re-use the main publish endpoint logic by delegating
-    const fakeReq = { body: { queueItemId, channels: [channel] } };
-    const fakeRes = {
-      _data: null,
-      _status: 200,
-      status(s) { this._status = s; return this; },
-      json(d) { this._data = d; }
-    };
-    // Find the publish handler and invoke it
-    // Simpler: just call the DB directly and re-run the publish logic inline
     const queueRes = await pool.query('SELECT * FROM publishing_queue WHERE id = $1', [queueItemId]);
     if (!queueRes.rows.length) return res.status(404).json({ error: 'Queue item not found' });
-    const item = queueRes.rows[0];
 
-    // Mark any previous log entry for this channel as 'republishing'
+    // Mark any previous log entry for this channel as 'republishing'. We
+    // ALSO have to roll this back if the inner publish call fails — otherwise
+    // the row stays in 'republishing' forever and the UI thinks the operation
+    // is still in flight (Brian hit this after a disconnect/reconnect when
+    // the server-to-server publish call was 401'ing).
     await pool.query(
       "UPDATE publish_log SET live_status = 'republishing' WHERE queue_item_id = $1 AND channel = $2",
       [queueItemId, channel]
     );
 
-    // Forward to main publish route
+    // Forward to main publish route. The publish handler accepts EITHER a
+    // Clerk bearer token OR an adminPassword for cron-style server-to-server
+    // calls. We're already past requireAuth on the outer republish call so
+    // the user is verified — using adminPassword here is the right shape for
+    // the server-to-server hop. Without it the fetch lands on the 401 path
+    // and the publish never runs.
     const publishRes = await fetch(`${process.env.BASE_URL || 'http://localhost:' + (process.env.PORT || 3000)}/api/publishing/publish`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ queueItemId, channels: [channel] })
+      body: JSON.stringify({
+        queueItemId,
+        channels: [channel],
+        adminPassword: process.env.ADMIN_PASSWORD,
+      })
     });
     const publishData = await publishRes.json();
 
-    if (publishData.success) {
-      res.json({ success: true, result: publishData.results?.[channel] });
-    } else {
-      res.status(500).json({ error: publishData.error || 'Republish failed' });
+    if (publishRes.ok && publishData.success) {
+      return res.json({ success: true, result: publishData.results?.[channel] });
     }
+
+    // Inner publish failed — unstick the 'republishing' state so the queue
+    // card doesn't show "republishing…" forever. Reset to NULL (the canonical
+    // "no live status known" value, same as a fresh log row).
+    await pool.query(
+      "UPDATE publish_log SET live_status = NULL WHERE queue_item_id = $1 AND channel = $2 AND live_status = 'republishing'",
+      [queueItemId, channel]
+    ).catch(() => {});
+
+    const errMsg = publishData?.error || `Republish failed (HTTP ${publishRes.status})`;
+    console.error(`[REPUBLISH] queueItemId=${queueItemId} channel=${channel} status=${publishRes.status} error=${errMsg}`);
+    return res.status(500).json({ error: errMsg });
   } catch (err) {
+    // Catch-path: also unstick the row if the fetch itself threw.
+    await pool.query(
+      "UPDATE publish_log SET live_status = NULL WHERE queue_item_id = $1 AND channel = $2 AND live_status = 'republishing'",
+      [queueItemId, channel]
+    ).catch(() => {});
     console.error('[REPUBLISH]', err.message);
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 


### PR DESCRIPTION
## Summary

Brian republished a LinkedIn post after a disconnect/reconnect (had originally published to the wrong page). The republish click "went nuts." Logs:

```
POST /api/publishing/publish    4ms   299b  UA=node      ← internal call
POST /api/publishing/republish  103ms 299b  UA=Mozilla   ← user click
```

**299 bytes / 4ms with UA=`node`** is a smoking-gun 401 from a server-to-server call that wasn't passing auth.

## Two bugs, one symptom

### 1. `/api/publishing/republish` calls `/api/publishing/publish` with no auth

The publish handler at `server.js:10970` requires either a Clerk bearer token OR an `adminPassword` body param. The republish endpoint's internal `fetch()` passes neither — so the inner call 401s and the real publish never runs. The republish endpoint then returns `{error: "Unauthorized"}` to the client.

**Fix**: pass `adminPassword: process.env.ADMIN_PASSWORD` in the internal fetch body. The outer republish endpoint is already `requireAuth`'d, so the user is verified before we hop server-to-server. Matches the existing cron pattern (`isCron = req.body.adminPassword === ADMIN_PASSWORD`).

### 2. `live_status='republishing'` was a one-way door

Before the failed inner fetch, the endpoint stamps `publish_log.live_status='republishing'`. When the fetch fails (or anything errors), the `'republishing'` row never gets cleared — the queue UI shows "republishing…" forever and the user is stuck.

**Fix**: on both failure paths (`!ok` branch AND `catch`), reset `live_status` back to NULL guarded by `WHERE live_status = 'republishing'` so we don't trample any newer state another process might have written in the meantime.

## Drive-by

- Removed dead `fakeReq`/`fakeRes` scaffolding (left over from a never-used approach)
- Tightened error log to include the inner HTTP status code so future failures are one grep away from root cause

## Test plan

- [ ] Deploy
- [ ] Brian: republish the LinkedIn post that was stuck — confirm it goes through and the queue card updates to "Published on LinkedIn" with the new Forge Intelligence page URL
- [ ] Verify in prod logs: `POST /api/publishing/publish` from the internal call should now return 200 with `responseTimeMS` ~500-2000ms (real publish) and a much larger response body (real result JSON, not 299-byte error)
- [ ] If for any reason the inner publish still errors, the queue card should fall back to its prior state (not stuck at "republishing")

## Notes

- No schema changes
- No client changes
- Build: `node --check` passes; happy path behavior unchanged

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_