### PR TITLE
fix(publishing-queue): unpublished channels disappear from PUBLISHED TO

### DIFF
--- a/server.js
+++ b/server.js
@@ -10004,6 +10004,27 @@ app.post('/api/publishing/unpublish', requireAuth, async (req, res) => {
       [finalStatus, queueItemId, channel]
     );
 
+    // Also remove the channel from publishing_queue.publish_results JSONB.
+    // The PUBLISHED TO panel in the UI iterates over publish_results, so
+    // until this entry is cleared the unpublished channel keeps showing up
+    // (with whatever live_status the most recent log row has — including
+    // 'published' if a republish followed the unpublish). The reset-channel
+    // endpoint at server.js:9806 does this same write; mirroring here.
+    if (deleteFromChannel) {
+      const qrRow = await pool.query(
+        'SELECT publish_results FROM publishing_queue WHERE id = $1',
+        [queueItemId]
+      ).catch(() => ({ rows: [] }));
+      if (qrRow.rows.length) {
+        const updatedResults = qrRow.rows[0].publish_results || {};
+        delete updatedResults[channel];
+        await pool.query(
+          'UPDATE publishing_queue SET publish_results = $1 WHERE id = $2',
+          [JSON.stringify(updatedResults), queueItemId]
+        ).catch(() => {});
+      }
+    }
+
     // Recompute queue status from remaining live publish_log entries
     // Don't blindly set 'staged' — if other channels are still live, it's 'partial'
     const remainingLog = await pool.query(

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -1547,7 +1547,16 @@ ${authorFooterHtml}
                           <RefreshCw /> {syncing === item.id ? 'Syncing...' : 'Sync Status'}
                         </button>
                       </div>
-                      {Object.entries(results).filter(([ch]) => !ch.startsWith('__')).map(([ch, res]) => {
+                      {Object.entries(results)
+                        .filter(([ch]) => !ch.startsWith('__'))
+                        // Hide channels whose latest publish_log row is marked deleted —
+                        // the channel was unpublished via the unplug modal and shouldn't
+                        // still appear in PUBLISHED TO claiming to be live.
+                        .filter(([ch]) => {
+                          const log = (publishLog[item.id] || []).find(l => l.channel === ch);
+                          return log?.live_status !== 'deleted';
+                        })
+                        .map(([ch, res]) => {
                         const log = (publishLog[item.id] || []).find(l => l.channel === ch);
                         // Prefer publish log live_status (most accurate) over publish result status
                         // If log says deleted, show deleted regardless of publish_results JSONB
@@ -1880,7 +1889,16 @@ return (
                           <RefreshCw /> {syncing === item.id ? 'Syncing...' : 'Sync Status'}
                         </button>
                       </div>
-                      {Object.entries(results).filter(([ch]) => !ch.startsWith('__')).map(([ch, res]) => {
+                      {Object.entries(results)
+                        .filter(([ch]) => !ch.startsWith('__'))
+                        // Hide channels whose latest publish_log row is marked deleted —
+                        // the channel was unpublished via the unplug modal and shouldn't
+                        // still appear in PUBLISHED TO claiming to be live.
+                        .filter(([ch]) => {
+                          const log = (publishLog[item.id] || []).find(l => l.channel === ch);
+                          return log?.live_status !== 'deleted';
+                        })
+                        .map(([ch, res]) => {
                         const log = (publishLog[item.id] || []).find(l => l.channel === ch);
                         // Prefer publish log live_status (most accurate) over publish result status
                         // If log says deleted, show deleted regardless of publish_results JSONB


### PR DESCRIPTION
## Summary

Brian unpublished a LinkedIn post via the unplug modal. The PUBLISHED TO panel kept showing `LinkedIn ✓ Live View post` anyway. Two-layer bug, surgical fix on both sides.

## Root cause

| Layer | Bug |
|---|---|
| Server | `/api/publishing/unpublish` marks `publish_log.live_status='deleted'` but **never clears the channel from `publishing_queue.publish_results`** (the JSONB the UI iterates). The sibling `reset-channel` endpoint at `server.js:9806` already does this — `unpublish` was the odd one out. |
| Client | The PUBLISHED TO iterator never filtered on the log's `live_status`. Even when a republish wrote a fresh log row over a `'deleted'` one, the unpublished channel could resurface as `✓ Live`. |

## Fix

**Server (`server.js`)** — in the unpublish handler, when `deleteFromChannel=true` (the normal "unpublish via modal" path), also `delete results[channel]` and write the JSONB back to `publishing_queue.publish_results`. Mirrors the reset-channel pattern. The `publish_log` row is left intact (with `live_status='deleted'`) so the audit trail is preserved.

**Client (`PublishingQueuePage.tsx`)** — defense-in-depth filter on the iterator: if the latest `publish_log` row for a channel says `live_status='deleted'`, the row is filtered out before render. Catches cases where server cleanup misses something or where a sync detected external deletion after `publish_results` was last written.

## Behavior after this lands

- Click unplug → pick channels → unpublish → channels **immediately disappear** from PUBLISHED TO
- Republish later → channel reappears with the new publish state
- No zombie "Live" rows

## Test plan

- [ ] Deploy
- [ ] On a queue item with multiple live channels, click unplug → uncheck one channel and unpublish — confirm only the selected channel disappears
- [ ] Republish the same channel — confirm it reappears with a working View Post link
- [ ] Regression: unpublish ALL channels — confirm queue card transitions to `staged` (since `recomputedStatus` already handled this; no new behavior, just verifying)

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_