### PR TITLE
fix(publishing-queue): unpublished channels render as fresh-selectable chips

### DIFF
--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -1441,6 +1441,12 @@ ${authorFooterHtml}
                               const liveStatus = logEntry?.live_status;
                               const isPublished = liveStatus === 'published' || (!logEntry && result?.status === 'published');
                               const chipClass = (() => {
+                                // If publish_results no longer carries this channel, the channel
+                                // is in pre-publish state — even if a historical publish_log row
+                                // exists from a prior publish/unpublish cycle. Treat as fresh so
+                                // the user can re-select it for publishing without fighting a
+                                // greyed-out chip.
+                                if (!result) return '';
                                 if (!logEntry) {
                                   if (result?.status === 'published') return 'published';
                                   if (result?.status === 'error') return 'error';
@@ -1783,6 +1789,12 @@ return (
                               const liveStatus = logEntry?.live_status;
                               const isPublished = liveStatus === 'published' || (!logEntry && result?.status === 'published');
                               const chipClass = (() => {
+                                // If publish_results no longer carries this channel, the channel
+                                // is in pre-publish state — even if a historical publish_log row
+                                // exists from a prior publish/unpublish cycle. Treat as fresh so
+                                // the user can re-select it for publishing without fighting a
+                                // greyed-out chip.
+                                if (!result) return '';
                                 if (!logEntry) {
                                   if (result?.status === 'published') return 'published';
                                   if (result?.status === 'error') return 'error';


### PR DESCRIPTION
## Summary

Follow-up to #94. After that PR's unpublish-cleanup fix, the LinkedIn chip in the "Publish to:" selector at the **top** of the queue card was rendering grey-with-strikethrough — looking unselectable — even though the channel had been properly unpublished and `publish_results` cleared.

## Root cause

The chip-class logic at `PublishingQueuePage.tsx:1443` (and the duplicate at `:1791`) was reading `publish_log.live_status` directly. When a historical `'deleted'` log row existed (which #94 intentionally preserves as an audit trail), the chip got `'published-deleted'` class regardless of whether `publish_results` still carried the channel.

User-visible: chip looks locked, user thinks they can't republish.

## Fix

Short-circuit the chip-class logic when `publish_results[channel]` is absent. No result entry → no `'published-deleted'` styling → chip renders as a normal selectable target. The `'published-deleted'` visual is reserved for the legitimate "still in publish_results AND the live post was deleted externally" state, where surfacing that history actually helps.

```diff
 const chipClass = (() => {
+  // If publish_results no longer carries this channel, the channel
+  // is in pre-publish state — even if a historical publish_log row
+  // exists from a prior publish/unpublish cycle.
+  if (!result) return '';
   if (!logEntry) {
     ...
   }
   ...
 })();
```

Applied at both the grid view and list view chip-rendering sites.

## Combined effect (post #94 + #95)

| Event | publish_results | publish_log | PUBLISHED TO panel | Publish-to chip |
|---|---|---|---|---|
| Fresh publish | `{linkedin: {...}}` | row, `live_status='published'` | ✓ Live (green) + View post | Published chip with link |
| Unpublish via unplug | `{}` (channel removed) | row, `live_status='deleted'` | hidden | **Normal selectable** ← fixed by this PR |
| Republish after unpublish | `{linkedin: {...new}}` | new row, `live_status='published'` | ✓ Live (green) + View post | Published chip with link |

## Test plan

- [ ] Deploy
- [ ] On the queue item Brian was hitting, click the LinkedIn chip in the "Publish to:" row — confirm it's now a normal selectable button (no strikethrough, no grey state)
- [ ] Select LinkedIn + click Publish — confirm a fresh publish runs
- [ ] Spot-check: a channel that's genuinely in `publish_results` with `live_status='deleted'` (e.g., externally deleted then synced) still renders as `published-deleted` — that surface is still useful

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_