### PR TITLE
fix(publish): dedupe respects live_status — republish after unpublish actually publishes

### DIFF
--- a/server.js
+++ b/server.js
@@ -11129,9 +11129,17 @@ app.post('/api/publishing/publish', async (req, res) => {
       }
     }
 
-    // Load existing publish_log entries for this queue item — used to skip already-published channels
+    // Load existing publish_log entries for this queue item — used to skip already-published channels.
+    // Critical: also require live_status to still be live. After an unpublish, status stays
+    // 'published' (it really did publish, that's history) but live_status flips to 'deleted'.
+    // The old query (status='published' alone) treated unpublished-then-republished targets as
+    // duplicates and silently skipped them with a fake "Already published" response — the toast
+    // would say success but nothing actually hit the channel.
     const existingLogRes = await pool.query(
-      `SELECT channel FROM publish_log WHERE queue_item_id = $1 AND status = 'published'`,
+      `SELECT channel FROM publish_log
+       WHERE queue_item_id = $1
+         AND status = 'published'
+         AND (live_status IS NULL OR live_status = 'published')`,
       [queueItemId]
     ).catch(() => ({ rows: [] }));
     const alreadyPublished = new Set(existingLogRes.rows.map(r => r.channel));


### PR DESCRIPTION
## Summary

**The real bug.** Brian was right to push back — #94 and #95 fixed the UI surfaces but the **publish dedupe guard** was the missing piece, and without it every republish was silently a no-op.

## The full circle

```
1. Publish LinkedIn         → publish_log { status:'published', live_status:'published' }
2. Unpublish via unplug     → publish_log { status:'published', live_status:'deleted' }   (PR #94)
                              publish_results.linkedin removed                            (PR #94)
                              Chip flips back to selectable                               (PR #95)
3. Re-select LinkedIn chip + click Publish Now
                            → /api/publishing/publish
                            → dedupe builds alreadyPublished set FROM:
                                  WHERE status='published'   ← only checks status, ignores live_status
                              → LinkedIn lands in the skip-set
                            → for-loop hits LinkedIn, early-returns:
                                  { status:'published', skipped:true, message:'Already published' }
                            → Aggregator reports success
                            → Toast claims success
                            → NOTHING ACTUALLY RAN
```

That's why Brian saw *"sent to facebook, ghost, reddit, webflow, x, linkedin — status: published"* but the post never showed up on LinkedIn. The publish handler was lying because the dedupe check was reading the historical "was this ever a publish?" field instead of the current "is this still live?" field.

## Fix

One query change at `server.js:11132`:

```diff
- WHERE queue_item_id = $1 AND status = 'published'
+ WHERE queue_item_id = $1
+   AND status = 'published'
+   AND (live_status IS NULL OR live_status = 'published')
```

Now `live_status='deleted'` (or `'unknown'` / `'republishing'`) rows are NOT treated as duplicates — the publish loop runs for them. `live_status IS NULL` is preserved as "currently live" since that's the default state for a freshly-published row before any sync.

## Combined effect across #94 + #95 + this PR

| Stage | publish_results | publish_log | Chip selector | PUBLISHED TO | Publish Now behavior |
|---|---|---|---|---|---|
| Fresh publish | `{linkedin:{...}}` | `status=published, live_status=published` | Published chip | ✓ Live row | Skip (already live) |
| Unpublished via unplug | `{}` | `status=published, live_status=deleted` | Normal selectable (#95) | Hidden (#94) | **Publish actually runs (this PR)** |
| Republished | `{linkedin:{...new}}` | new row `status=published, live_status=published` | Published chip | ✓ Live row | Skip (already live) |

## Test plan

- [ ] Deploy
- [ ] On the article Brian's been fighting with: re-select LinkedIn chip, click Publish Now
- [ ] Confirm the publish actually fires — should take 500ms+ (Zernio round-trip), not <50ms (instant fake-success path)
- [ ] LinkedIn post lands on the correct page (Forge Intelligence)
- [ ] PUBLISHED TO now shows LinkedIn ✓ Live with a working View post link
- [ ] Regression: don't double-publish. If you Publish Now on the same item TWICE in a row without unpublishing in between, the second attempt should skip LinkedIn (it's currently live).

## Mea culpa

You called this in #94 → #95 thread. The dedupe guard reading the wrong field was the actual root cause. The earlier patches addressed the visible state but not the publish-handler's decision logic. Sorry for the back-and-forth.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_