### PR TITLE
fix(site-template): detect SPA shells by body content, not total HTML size

### DIFF
--- a/server.js
+++ b/server.js
@@ -2830,17 +2830,34 @@ ${cleaned}`;
 
     // Run scrape for one URL: fetch via direct HTTP (fast), fall back to Jina
     // rendered HTML if the direct fetch gives us an SPA shell or fails.
+    // Detect SPA shells by looking at the BODY content size specifically.
+    // The old heuristic checked total cleaned-HTML length, but modern SPAs
+    // have huge <head> sections (Google Fonts preconnects, OpenGraph meta,
+    // tracking scripts) that easily clear 2k chars even when the body is
+    // literally `<div id="root"></div>`. Result: SPA shells passed the
+    // filter and got fed to Claude, which found zero structural regions.
+    // Now we extract just the <body> contents and gate on THAT size, plus
+    // a regex for the classic empty-mount-point shells.
+    const SPA_SHELL_RE = /<body[^>]*>\s*(?:<noscript>[\s\S]*?<\/noscript>\s*)?<div\s+id=["'](?:root|__next|app|svelte|nuxt)["'][^>]*>\s*<\/div>/i;
+    const looksLikeSpaShell = (html) => {
+      if (SPA_SHELL_RE.test(html)) return true;
+      const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+      if (!bodyMatch) return false;
+      const cleanedBody = cleanHtml(bodyMatch[1]).trim();
+      return cleanedBody.length < 500;
+    };
+
     // Then Claude extracts on the best HTML we have.
     const runScrape = async (url, type, minExtracted) => {
       let html = null;
       let source = null;
       try {
         const direct = await fetchHtmlDirect(url);
-        // Heuristic: a body of <2k chars after cleaning is almost certainly
-        // an SPA shell. Skip straight to Jina in that case.
-        if (cleanHtml(direct).length >= 2000) {
+        if (!looksLikeSpaShell(direct)) {
           html = direct;
           source = 'local';
+        } else {
+          console.log(`[SCRAPE-TEMPLATE] direct fetch returned SPA shell for ${url} — skipping to Jina`);
         }
       } catch (e) {
         console.warn(`[SCRAPE-TEMPLATE] direct fetch failed for ${url}: ${e.message}`);


### PR DESCRIPTION
## Summary

Brian got 0/10 on `sandbox-gtm.com` after #99. Confirmed the page source:

```html
<body>
  <div id="root"></div>
  <script type="module" src="/assets/index-ee0vZf_D.js"></script>
</body>
```

Pure Vite SPA — empty `<div id="root">` is the entire body. But the SPA-shell heuristic in #99 checks **total cleaned-HTML length ≥ 2000 chars** before deciding to fall through to Jina. The `<head>` on this page has 2.5KB of Google Fonts preconnect URLs alone, plus OpenGraph meta + Twitter cards + GA snippet. Total cleaned HTML clears 2k easily. So:

- Direct fetch passes the "is this real HTML?" filter
- Never falls through to Jina
- Claude gets fed the shell
- Finds zero structural regions (correctly — there aren't any)
- Reports 0/10 to the user, which looks like a Claude failure but is actually correct behavior on garbage input

## Fix

Replace the total-length check with a **body-specific** SPA-shell detector:

```ts
const SPA_SHELL_RE = /<body[^>]*>\s*(?:<noscript>[\s\S]*?<\/noscript>\s*)?<div\s+id=["'](?:root|__next|app|svelte|nuxt)["'][^>]*>\s*<\/div>/i;

const looksLikeSpaShell = (html) => {
  if (SPA_SHELL_RE.test(html)) return true;
  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
  if (!bodyMatch) return false;
  const cleanedBody = cleanHtml(bodyMatch[1]).trim();
  return cleanedBody.length < 500;
};
```

1. **Regex match for the classic empty-mount-point shell** — catches React (`root`), Next.js (`__next`), Vue (`app`), SvelteKit (`svelte`), Nuxt (`nuxt`).
2. **Fallback body-content length check** — if the cleaned body (scripts/styles/svg/comments stripped) is under 500 chars, treat as shell. Catches non-standard SPA mount points and edge cases.

When the detector fires, skip the direct fetch and use Jina instead, which JS-renders the page and returns real DOM.

## Verified

Tested against:
- ✅ sandbox-gtm.com exact body shape → detected
- ✅ Real article body with nav + `<article>` + content → NOT detected (no false positive)
- ✅ Next.js shell (`<div id="__next">`) → detected
- ✅ Shell with `<noscript>` fallback → detected

## Logs

Added `[SCRAPE-TEMPLATE] direct fetch returned SPA shell for <url> — skipping to Jina` so future "scrape failed" reports show whether the SPA path was taken.

## Test plan

- [ ] Deploy
- [ ] Brian: re-run the scrape on `sandbox-gtm.com/the-sandbox/event-pipeline-attribution-...`
- [ ] Confirm prod logs show the SPA-shell-detected line + a Jina fetch + a much higher extraction count
- [ ] Spot check a non-SPA site (any WordPress or Hugo blog) — should still use direct fetch (no Jina hop), no behavior change

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_