### PR TITLE
fix(scrape): hoist puppeteer-core to top-level ESM import

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ import pkg from 'pg';
 import Anthropic from '@anthropic-ai/sdk';
 import { randomUUID, randomBytes, createHmac, createHash } from 'crypto';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
+import puppeteer from 'puppeteer-core';
 
 const { Pool } = pkg;
 const __filename = fileURLToPath(import.meta.url);
@@ -14224,7 +14225,7 @@ function requireApiKeyScope(scope) {
 
 // Tier 2 (Scraping Browser) — CDP connection via puppeteer-core. We don't
 // bundle Chromium; we connect to Bright Data's remote browser over WebSocket.
-const puppeteer = require('puppeteer-core');
+// (puppeteer is imported at the top of the file alongside other ESM imports.)
 
 const SPA_SHELL_RE = /<body[^>]*>\s*(?:<noscript>[\s\S]*?<\/noscript>\s*)?<div\s+id=["'](?:root|__next|app|svelte|nuxt)["'][^>]*>\s*<\/div>/i;
 function looksLikeSpaShell(html) {


### PR DESCRIPTION
## Summary

PR #103 introduced a `const puppeteer = require('puppeteer-core')` mid-file inside `server.js`, which is an ESM module (`"type": "module"` in package.json) using `import` throughout. Node 22 refuses to load it:

```
ReferenceError: Cannot determine intended module format because both require() and top-level await are present.
  at server.js:14227:19
  code: 'ERR_AMBIGUOUS_MODULE_SYNTAX'
```

This is the boot crash hitting Render right now on the development service.

## Fix

Move the puppeteer-core import to the top of `server.js` alongside the other ESM `import` statements. The body of `_tryScrapingBrowser` is unchanged — the only edit is the import location/syntax.

## Test plan

- [x] `node --check server.js` passes locally
- [ ] Render development deploy boots cleanly (no `ERR_AMBIGUOUS_MODULE_SYNTAX`)
- [ ] Re-run sandbox-gtm.com Site Template scrape from PR #103's plan once boot is green

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_