### PR TITLE
chore(scrape-log): capture body sample in metadata

### DIFF
--- a/server.js
+++ b/server.js
@@ -14281,7 +14281,8 @@ async function _tryUnlocker(url, { format, timeout, country, caller, metadata })
     await _logScrape({
       url, source: 'brightdata_unlocker',
       status_code: resp.status, body_size: responseBody.length, latency_ms: latencyMs,
-      success: resp.ok, caller, metadata,
+      success: resp.ok, caller,
+      metadata: { ...(metadata ?? {}), body_sample: resp.ok ? responseBody.slice(0, 2000) : undefined },
       error: resp.ok ? null : `HTTP ${resp.status}: ${responseBody.slice(0, 200)}`,
     });
     if (!resp.ok) {
@@ -14336,7 +14337,8 @@ async function _tryScrapingBrowser(url, { timeout, caller, metadata }) {
     await _logScrape({
       url, source: 'brightdata_browser',
       status_code: 200, body_size: html.length, latency_ms: latencyMs,
-      success: true, caller, metadata,
+      success: true, caller,
+      metadata: { ...(metadata ?? {}), body_sample: html.slice(0, 2000) },
     });
     return { success: true, status: 200, html, source: 'brightdata_browser', latencyMs, error: null };
   } catch (e) {


### PR DESCRIPTION
## Why

We're stuck on whether the "0/10 structural regions" toast for sandbox-gtm.com means:

- (a) Bright Data Unlocker returned an SPA shell and Tier 2 failed to fire, or
- (b) Unlocker returned real content but our class-name-only extractor threw it all away

`scrape_log` records `body_size` but not what's *in* the body, so we can't tell. Jina pulled a perfect payload from the same article URL, which makes (b) look likely — but I'd rather see bytes than guess again.

## Change

Stash the first 2KB of the response body into `scrape_log.metadata.body_sample` on the success path of both `_tryUnlocker` and `_tryScrapingBrowser`. The admin endpoint already returns `metadata`, so the sample surfaces automatically via `GET /api/admin/scrape-log?url=...&adminPassword=...`.

No behavior change in the scrape itself — purely additive logging.

## After this lands

1. Re-run the Site Template scrape on the sandbox-gtm.com article
2. `GET /api/admin/scrape-log?url=sandbox-gtm.com&adminPassword=…`
3. Read `metadata.body_sample` on the unlocker row → answers (a) vs (b) in one look
4. Real fix follows: if (b), rewrite the extractor to grade content + structural selectors instead of grading by class names

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_