### PR TITLE
fix(scrape): tighter Tier 2 hydration + 15KB body sample

### DIFF
--- a/server.js
+++ b/server.js
@@ -14282,7 +14282,7 @@ async function _tryUnlocker(url, { format, timeout, country, caller, metadata })
       url, source: 'brightdata_unlocker',
       status_code: resp.status, body_size: responseBody.length, latency_ms: latencyMs,
       success: resp.ok, caller,
-      metadata: { ...(metadata ?? {}), body_sample: resp.ok ? responseBody.slice(0, 2000) : undefined },
+      metadata: { ...(metadata ?? {}), body_sample: resp.ok ? responseBody.slice(0, 15000) : undefined },
       error: resp.ok ? null : `HTTP ${resp.status}: ${responseBody.slice(0, 200)}`,
     });
     if (!resp.ok) {
@@ -14320,16 +14320,20 @@ async function _tryScrapingBrowser(url, { timeout, caller, metadata }) {
       if (['image', 'stylesheet', 'font', 'media'].includes(type)) req.abort();
       else req.continue();
     });
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
-    // Best-effort: wait for the SPA mount point to hydrate. If the heuristic
-    // doesn't fire within 10s, proceed anyway — some sites hydrate weirdly
-    // and we'd rather take what we can get than fail entirely.
+    await page.goto(url, { waitUntil: 'networkidle2', timeout });
+    // Wait for actual article-shaped content, not just any DOM. The previous
+    // heuristic (root has children + 1KB innerHTML) fires the moment the
+    // layout shell mounts — well before the article body actually renders,
+    // which is why Tier 2 was returning 10KB pages with no article in them.
+    // Now: require an h1 with real text AND at least 3 paragraphs. If that
+    // doesn't fire within 15s we take what we have rather than fail.
     try {
       await page.waitForFunction(() => {
-        const root = document.querySelector('#root, #__next, #app, #svelte, #nuxt');
-        return root && root.children.length > 0 && root.innerHTML.length > 1000;
-      }, { timeout: 10_000 });
-    } catch { /* hydration heuristic didn't fire — continue */ }
+        const h1 = document.querySelector('h1');
+        const paragraphs = document.querySelectorAll('p').length;
+        return h1 && h1.textContent.trim().length > 10 && paragraphs >= 3;
+      }, { timeout: 15_000 });
+    } catch { /* content heuristic didn't fire — continue with what we have */ }
     const html = await page.content();
     await browser.close();
     browser = null;
@@ -14338,7 +14342,7 @@ async function _tryScrapingBrowser(url, { timeout, caller, metadata }) {
       url, source: 'brightdata_browser',
       status_code: 200, body_size: html.length, latency_ms: latencyMs,
       success: true, caller,
-      metadata: { ...(metadata ?? {}), body_sample: html.slice(0, 2000) },
+      metadata: { ...(metadata ?? {}), body_sample: html.slice(0, 15000) },
     });
     return { success: true, status: 200, html, source: 'brightdata_browser', latencyMs, error: null };
   } catch (e) {


### PR DESCRIPTION
## Why

After PR #105 we can finally see what Bright Data returns. Latest run on the sandbox-gtm.com article:

| Tier | body_size |
|---|---|
| unlocker | 4,153 B (shell) |
| browser  | 10,311 B |

Tier 2 cascade *is* firing (good). But 10 KB for a long-form article after JS rendering is suspiciously light — likely we're calling `page.content()` before the article body has rendered.

The current hydration heuristic in `_tryScrapingBrowser`:

```js
await page.waitForFunction(() => {
  const root = document.querySelector('#root, #__next, #app, ...');
  return root && root.children.length > 0 && root.innerHTML.length > 1000;
}, { timeout: 10_000 });
```

Fires as soon as the **layout shell** mounts — even a header+nav clears 1 KB of innerHTML in the first 300ms of hydration. That's not "article rendered," that's "router mounted."

## Changes

1. **`waitUntil: 'networkidle2'`** on `goto` (was `domcontentloaded`). For Vite SPAs, DCL fires before async data fetches.
2. **Hydration heuristic now requires real article structure**: an `<h1>` with text + at least 3 `<p>` tags. Up to 15s.
3. **`body_sample` 2 KB → 15 KB** so the captured sample includes body content, not just `<head>`. (The previous 2 KB cap was all meta + font preloads.)

## After deploy — definitive next step

Re-run the article scrape and inspect `body_sample` on the new `brightdata_browser` row:

- **If we see `<h1>` and real paragraphs** → Tier 2 is now grabbing the full DOM. The 0/10 toast then means the extractor's class-name-only approach is the actual bug; next PR rewrites the Claude prompt to grade content + selectors.
- **If we still see only layout chrome** → hydration is still racing async content. Tighten further (e.g., wait for `<article>` or a specific landmark).

Either way, we end this branch of guessing.

## Test plan

- [ ] Render deploys cleanly
- [ ] Re-run sandbox-gtm.com Site Template scrape
- [ ] `GET /api/admin/scrape-log?url=sandbox-gtm.com&adminPassword=…&limit=3`
- [ ] Inspect `metadata.body_sample` on the brightdata_browser row → reveals which sub-bug to fix next

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_