### PR TITLE
feat(context-hub): Stage 1 Jina-first crawl + Readability fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,18 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.37.0",
         "@clerk/clerk-react": "^5.61.3",
+        "@mozilla/readability": "^0.5.0",
         "@pipedream/sdk": "^2.4.3",
         "express": "^4.18.2",
         "jose": "^5.9.6",
+        "jsdom": "^25.0.1",
         "lucide-react": "^0.383.0",
         "pg": "^8.11.3",
         "puppeteer-core": "^25.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.20.0"
+        "react-router-dom": "^6.20.0",
+        "turndown": "^7.2.0"
       },
       "devDependencies": {
         "@types/pg": "^8.11.0",
@@ -58,6 +61,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
     },
     "node_modules/@clerk/clerk-react": {
       "version": "5.61.6",
@@ -106,6 +122,116 @@
         }
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -138,6 +264,21 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
+      "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -606,6 +747,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -918,11 +1068,77 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -940,6 +1156,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1036,6 +1258,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -1423,6 +1657,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1441,6 +1687,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -1488,6 +1760,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/jose": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
@@ -1511,6 +1789,80 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1785,6 +2137,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/lucide-react": {
       "version": "0.383.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.383.0.tgz",
@@ -1943,6 +2301,12 @@
         }
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1974,6 +2338,18 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -2200,6 +2576,15 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/puppeteer-core": {
       "version": "25.0.4",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.4.tgz",
@@ -2364,6 +2749,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2389,6 +2780,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -2627,6 +3030,12 @@
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
@@ -2716,6 +3125,24 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2723,6 +3150,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -2736,6 +3175,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -2890,6 +3342,18 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -2910,6 +3374,40 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -2964,6 +3462,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,18 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",
     "@clerk/clerk-react": "^5.61.3",
+    "@mozilla/readability": "^0.5.0",
     "@pipedream/sdk": "^2.4.3",
     "express": "^4.18.2",
     "jose": "^5.9.6",
+    "jsdom": "^25.0.1",
     "lucide-react": "^0.383.0",
     "pg": "^8.11.3",
     "puppeteer-core": "^25.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.20.0"
+    "react-router-dom": "^6.20.0",
+    "turndown": "^7.2.0"
   },
   "devDependencies": {
     "@types/pg": "^8.11.0",

--- a/server.js
+++ b/server.js
@@ -7,6 +7,9 @@ import Anthropic from '@anthropic-ai/sdk';
 import { randomUUID, randomBytes, createHmac, createHash } from 'crypto';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import puppeteer from 'puppeteer-core';
+import { Readability } from '@mozilla/readability';
+import { JSDOM } from 'jsdom';
+import TurndownService from 'turndown';
 
 const { Pool } = pkg;
 const __filename = fileURLToPath(import.meta.url);
@@ -4429,9 +4432,14 @@ Content themes in this market: ${(sonarJson.contentThemes || []).join(', ')}`;
 
 
     // ── Tool 1.5: Website Scraper — actual content extraction ─────────────────
+    // Two-tier fetch per page via getBrandPageContent:
+    //   Tier A: Jina Reader (semantic markdown — fast, free, the common case)
+    //   Tier B: forgeScrape (BD Tier 1 → Tier 2 cascade) + local Readability+Turndown
+    // Pages: homepage + up to 8 high-signal subpages discovered via sitemap.xml
+    // (link-extraction fallback). All fetched in parallel; every attempt logged
+    // to scrape_log with caller='context-hub'.
     console.log(`[Context Hub] Tool 1.5: Scraping website content for ${brandUrl}...`);
     let scrapedContent = '';
-    let homeHtml = '';
     let workingBaseUrl = '';
     // Masked-subdomain support: if the user set a scrapeUrlOverride in Brand Settings
     // (e.g., brand_url is a vanity domain pointing to a Render subservice), use the
@@ -4449,303 +4457,47 @@ Content themes in this market: ${(sonarJson.contentThemes || []).join(', ')}`;
       }
     } catch { /* no profile yet, use brandUrl directly */ }
     try {
-      // Chrome UA — some sites (Squarespace, Vercel edge, etc.) 403 on unknown UAs. Forge UA tried first for honesty, Chrome as fallback.
-      const FORGE_UA = 'ForgeIntelligence/1.0 (Brand Analysis)';
-      const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
-
-      const stripHtml = (html) => html
-        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-        .replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, '')
-        .replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, '')
-        .replace(/<header[^>]*>[\s\S]*?<\/header>/gi, '')
-        .replace(/<[^>]+>/g, ' ')
-        .replace(/&[a-z]+;/gi, ' ')
-        .replace(/\s+/g, ' ')
-        .trim();
-
-      // Extract crawler-targeted brand content from <head>: meta tags + JSON-LD structured data.
-      // SPA sites (Vite/Next/SvelteKit/etc.) put their brand description, services list, and
-      // schema.org markup in <head> precisely because they know JS-rendered <body> content
-      // isn't visible to crawlers. stripHtml() throws all of this away — wholesale-strips
-      // <script> (kills JSON-LD) and operates on body text only. metaExtract() runs first
-      // and pulls the high-value structured content into a readable text block.
-      const metaExtract = (html) => {
-        const parts = [];
-
-        const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-        if (titleMatch) {
-          const t = titleMatch[1].replace(/\s+/g, ' ').trim();
-          if (t && t.length > 5) parts.push(`Title: ${t}`);
-        }
-
-        // Meta tags: description (multiple forms), keywords, og:site_name, author
-        const metaPatterns = [
-          { re: /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i, label: 'Description' },
-          { re: /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i, label: 'OG Description' },
-          { re: /<meta[^>]+content=["']([^"']+)["'][^>]+name=["']description["']/i, label: 'Description' },  // attr order swap
-          { re: /<meta[^>]+name=["']keywords["'][^>]+content=["']([^"']+)["']/i, label: 'Keywords' },
-          { re: /<meta[^>]+property=["']og:site_name["'][^>]+content=["']([^"']+)["']/i, label: 'Site name' },
-          { re: /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i, label: 'OG Title' },
-          { re: /<meta[^>]+name=["']author["'][^>]+content=["']([^"']+)["']/i, label: 'Author' },
-        ];
-        const seen = new Set();
-        for (const { re, label } of metaPatterns) {
-          const m = html.match(re);
-          if (m && m[1]) {
-            const v = m[1].replace(/\s+/g, ' ').trim();
-            const key = `${label}:${v}`;
-            if (v.length > 10 && !seen.has(key)) {
-              parts.push(`${label}: ${v}`);
-              seen.add(key);
-            }
-          }
-        }
-
-        // JSON-LD structured data blocks. Parse them and render as readable structured text
-        // so Tool 2 Claude can use the schema fields directly (services, descriptions, etc.).
-        const jsonLdMatches = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi) || [];
-        for (const block of jsonLdMatches) {
-          const inner = block.replace(/<script[^>]*>/i, '').replace(/<\/script>/i, '').trim();
-          try {
-            const data = JSON.parse(inner);
-            const items = Array.isArray(data) ? data : [data];
-            for (const item of items) {
-              const type = item['@type'] || 'Schema';
-              const lines = [`Schema (${type}):`];
-              if (item.name) lines.push(`  Name: ${item.name}`);
-              if (item.description) lines.push(`  Description: ${item.description}`);
-              if (item.serviceType) lines.push(`  Services: ${Array.isArray(item.serviceType) ? item.serviceType.join(', ') : item.serviceType}`);
-              if (item.areaServed) lines.push(`  Area served: ${item.areaServed}`);
-              const offers = item.hasOfferCatalog?.itemListElement || [];
-              if (offers.length > 0) {
-                lines.push(`  Offerings:`);
-                for (const o of offers) {
-                  const svc = o.itemOffered;
-                  if (svc?.name) lines.push(`    - ${svc.name}${svc.description ? ': ' + svc.description : ''}`);
-                }
-              }
-              if (item.parentOrganization?.name) lines.push(`  Parent organization: ${item.parentOrganization.name}`);
-              if (item.alternateName) lines.push(`  Also known as: ${item.alternateName}`);
-              if (lines.length > 1) parts.push(lines.join('\n'));
-            }
-          } catch {
-            // Malformed JSON-LD — skip silently
-          }
-        }
-
-        return parts.join('\n\n');
-      };
-
-      // Tell the developer exactly why a fetch failed (not just "it didn't work")
-      const describeFetchFailure = (err) => {
-        if (!err) return 'unknown';
-        const code = err.cause?.code || err.code || '';
-        if (code === 'ENOTFOUND' || /ENOTFOUND|getaddrinfo/i.test(err.message || '')) return `DNS-NOT-FOUND (${err.message || code})`;
-        if (code === 'ECONNREFUSED') return 'CONNECTION-REFUSED';
-        if (code === 'ECONNRESET') return 'CONNECTION-RESET';
-        if (err.name === 'TimeoutError' || /timeout/i.test(err.message || '')) return 'TIMEOUT';
-        if (/certificate|TLS|SSL/i.test(err.message || '')) return `TLS-ERROR (${err.message})`;
-        return `${err.name || 'Error'}: ${err.message || code || 'no detail'}`;
-      };
-
-      // Fetch with detailed error surfacing. Returns { res, html, error } — never throws.
-      const fetchWithDiag = async (url, { ua = FORGE_UA, timeout = 10000 } = {}) => {
-        try {
-          const res = await fetch(url, {
-            headers: { 'User-Agent': ua, 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Language': 'en-US,en;q=0.9' },
-            redirect: 'follow',
-            signal: AbortSignal.timeout(timeout)
-          });
-          if (!res.ok) return { res, html: '', error: `HTTP-${res.status}` };
-          const html = await res.text();
-          return { res, html, error: null };
-        } catch(e) {
-          return { res: null, html: '', error: describeFetchFailure(e) };
-        }
-      };
-
-      // Build candidate base URLs. Brands saved as "example.com" may have apex-only or www-only DNS —
-      // try both, and try Chrome UA as a fallback if the Forge UA gets 403.
       const inputUrl = scrapeInputUrl.startsWith('http') ? scrapeInputUrl : `https://${scrapeInputUrl}`;
       const u = new URL(inputUrl);
-      const bareHost = u.hostname.replace(/^www\./, '');
-      const candidates = [];
-      if (u.hostname.startsWith('www.')) {
-        candidates.push(`${u.protocol}//${u.hostname}`, `${u.protocol}//${bareHost}`);
+      workingBaseUrl = `${u.protocol}//${u.host}`;
+
+      // Discover subpages and fetch the homepage in parallel.
+      const [subpages, homeContent] = await Promise.all([
+        discoverSubpages(workingBaseUrl, 8),
+        getBrandPageContent(workingBaseUrl, { caller: 'context-hub' }),
+      ]);
+
+      // Fan out to all discovered subpages in parallel.
+      const subContents = subpages.length
+        ? await Promise.all(subpages.map(pageUrl =>
+            getBrandPageContent(pageUrl, { caller: 'context-hub' }).catch(err => ({ success: false, markdown: null, source: 'error', error: err?.message }))
+          ))
+        : [];
+
+      // Concatenate per-page markdown (20 KB per page) into the section
+      // siteContentSection consumes. Tagged by URL + source so downstream
+      // Claude can attribute claims to specific pages.
+      if (homeContent?.success && homeContent.markdown) {
+        scrapedContent += `HOMEPAGE (${workingBaseUrl}, via ${homeContent.source}):\n${homeContent.markdown.slice(0, 20000)}\n\n`;
       } else {
-        candidates.push(`${u.protocol}//${u.hostname}`, `${u.protocol}//www.${u.hostname}`);
+        console.log(`[Context Hub] Homepage fetch failed — ${homeContent?.error || 'no detail'}`);
       }
-
-      // Try each candidate with Forge UA, then Chrome UA
-      for (const candidate of candidates) {
-        let attempt = await fetchWithDiag(candidate, { ua: FORGE_UA });
-        if (!attempt.html && /HTTP-4\d\d/.test(attempt.error || '')) {
-          // Some sites 403/406 unknown UAs. Retry same URL with a standard Chrome UA.
-          console.log(`[Context Hub] ${candidate} returned ${attempt.error} with Forge UA — retrying with Chrome UA`);
-          attempt = await fetchWithDiag(candidate, { ua: CHROME_UA });
-        }
-        if (attempt.html) {
-          homeHtml = attempt.html;
-          workingBaseUrl = candidate;
-          // Log raw HTML bytes, but also flag SPA shells where the visible content will be empty
-          // after stripHtml() because everything renders client-side. Without this hint, the
-          // contradiction in the logs ("X bytes scraped" + "minimal content") is confusing.
-          const isSpaShell = /<div[^>]+id=["'](root|app|__next|svelte)["']/i.test(attempt.html);
-          console.log(`[Context Hub] Homepage scraped from ${candidate} (${attempt.html.length} bytes${isSpaShell ? ' — SPA shell detected, expect minimal extracted text' : ''})`);
-          break;
-        } else {
-          console.log(`[Context Hub] Homepage fetch failed for ${candidate} — ${attempt.error}`);
+      for (let i = 0; i < subContents.length; i++) {
+        const p = subContents[i];
+        if (p?.success && p.markdown) {
+          scrapedContent += `PAGE (${subpages[i]}, via ${p.source}):\n${p.markdown.slice(0, 20000)}\n\n`;
         }
       }
 
-      if (homeHtml) {
-        // Extract meta + JSON-LD FIRST — captures brand content from SPA sites where the
-        // body strip yields nothing. For server-rendered sites, this adds high-quality
-        // structured context on top of the body text.
-        const homeMeta = metaExtract(homeHtml);
-        if (homeMeta && homeMeta.length > 30) {
-          scrapedContent += `HOMEPAGE METADATA:\n${homeMeta}\n\n`;
-        }
-        // Then run the body strip as before. May add nothing on SPAs, but useful on
-        // server-rendered sites where <body> has the actual content.
-        const homeText = stripHtml(homeHtml).slice(0, 3000);
-        if (homeText.length > 80) scrapedContent += `HOMEPAGE CONTENT:\n${homeText}\n\n`;
-      }
-
-      // Extract internal links from homepage for deeper crawl
-      const linkMatches = homeHtml.match(/href=["'](\/[^"'#?]+)["']/g) || [];
-      const internalPaths = [...new Set(
-        linkMatches
-          .map(m => m.match(/href=["'](\/[^"'#?]+)["']/)?.[1])
-          .filter(Boolean)
-          .filter(p => /\/(about|story|product|service|blog|mission|team|who-we|what-we|our-)/i.test(p))
-      )].slice(0, 4);
-
-      // Also try common about paths if none found
-      const aboutPaths = internalPaths.length > 0 ? internalPaths : ['/about', '/about-us', '/pages/about'];
-
-      if (workingBaseUrl) {
-        for (const path of aboutPaths) {
-          const pageUrl = new URL(path, workingBaseUrl).href;
-          let pageAttempt = await fetchWithDiag(pageUrl, { ua: FORGE_UA, timeout: 8000 });
-          if (!pageAttempt.html && /HTTP-4\d\d/.test(pageAttempt.error || '')) {
-            pageAttempt = await fetchWithDiag(pageUrl, { ua: CHROME_UA, timeout: 8000 });
-          }
-          if (pageAttempt.html) {
-            // Subpages: meta tags less interesting (usually duplicate the homepage), so just
-            // pull JSON-LD + body text. JSON-LD on a /pricing or /about page often has
-            // page-specific schema that's worth capturing.
-            const pageMeta = metaExtract(pageAttempt.html);
-            const pageText = stripHtml(pageAttempt.html).slice(0, 2000);
-            // Filter pageMeta to only schema blocks (drop title/desc duplicates)
-            const pageSchemas = pageMeta.split('\n\n').filter(b => b.startsWith('Schema (')).join('\n\n');
-            if (pageSchemas) scrapedContent += `PAGE (${path}) METADATA:\n${pageSchemas}\n\n`;
-            if (pageText.length > 100) {
-              scrapedContent += `PAGE (${path}):\n${pageText}\n\n`;
-            }
-          } else {
-            console.log(`[Context Hub] Subpage ${path} failed — ${pageAttempt.error}`);
-          }
-        }
-      }
-
-      if (scrapedContent.length > 200) {
-        console.log(`[Context Hub] Scraped ${scrapedContent.length} chars from ${aboutPaths.length + 1} pages (base: ${workingBaseUrl})`);
-      } else {
-        // Local scrape failed to extract usable content — typically a JS-rendered SPA where the
-        // raw HTML is 10kb+ but stripHtml() yields a few dozen chars (title tag only). Two-tier
-        // fallback follows: first Jina Reader (renders the page server-side in real time —
-        // works even on brand-new sites that aren't indexed anywhere yet), then Sonar (relies on
-        // Perplexity's index — fast when the site is already crawled, useless for brand-new sites).
-        //
-        // Order matters: Jina runs first because it can handle brand-new SPAs. Sonar is the
-        // backup for the case where Jina's free tier rate-limits us OR returns an error.
-        console.log(`[Context Hub] Local scrape minimal (${scrapedContent.length} chars from ${homeHtml.length} bytes HTML) — trying Jina Reader fallback`);
-        try {
-          const jinaHeaders = { 'Accept': 'text/plain' };
-          if (process.env.JINA_API_KEY) {
-            jinaHeaders['Authorization'] = `Bearer ${process.env.JINA_API_KEY}`;
-          }
-          // Bound the request — Jina cold-renders can take 5-12s but anything beyond
-          // ~15s indicates the target site itself is slow / hanging and we should
-          // move on to Sonar rather than block the entire analyze call.
-          const jinaAbort = new AbortController();
-          const jinaTimeout = setTimeout(() => jinaAbort.abort(), 15000);
-          const jinaRes = await fetch(`https://r.jina.ai/${brandUrl}`, {
-            headers: jinaHeaders,
-            signal: jinaAbort.signal,
-          }).finally(() => clearTimeout(jinaTimeout));
-          if (jinaRes.ok) {
-            const jinaText = (await jinaRes.text()).trim();
-            if (jinaText.length > 200) {
-              // Cap at 8000 chars to match the local-scrape budget and keep the
-              // downstream Claude prompt under its size envelope.
-              scrapedContent = `JINA-EXTRACTED CONTENT (JS-rendered by Jina Reader — this is what a user sees):\n${jinaText.slice(0, 8000)}`;
-              console.log(`[Context Hub] Jina Reader fallback succeeded: ${jinaText.length} chars (capped to 8000)`);
-            } else {
-              console.log(`[Context Hub] Jina Reader returned minimal content (${jinaText.length} chars) — trying Sonar next`);
-            }
-          } else {
-            console.log(`[Context Hub] Jina Reader HTTP ${jinaRes.status} — trying Sonar next`);
-          }
-        } catch (jinaErr) {
-          console.log(`[Context Hub] Jina Reader error (non-fatal):`, jinaErr.message);
-        }
-      }
-
-      // Tier 3: Sonar fallback. Runs only if Jina didn't lift us past the threshold.
-      // Useful when Jina is rate-limited or the target is geo-blocked from Jina's
-      // egress IPs but already crawled into Perplexity's index.
-      if (scrapedContent.length <= 200) {
-        console.log(`[Context Hub] Jina + local still under threshold — falling back to Sonar content extraction`);
-        try {
-          const sonarContentRes = await fetch('https://api.perplexity.ai/chat/completions', {
-            method: 'POST',
-            headers: {
-              'Authorization': `Bearer ${process.env.PERPLEXITY_API_KEY}`,
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-              model: 'sonar',
-              messages: [{
-                role: 'user',
-                content: `Visit ${brandUrl} and extract the actual visible content from the homepage and any About/Product/Mission page. Return ONLY the raw text content from those pages — no commentary, no formatting, no markdown headers, no lists. Just the prose as a user would read it. If a page is JavaScript-rendered, render it and extract the resulting visible text. If you cannot access the site, return exactly the string "SITE_INACCESSIBLE" and nothing else.
-
-Maximum 4000 words. Focus on:
-- What the company does (homepage hero + product description)
-- Their mission, story, or about-us content
-- Any product features, services, or offerings described
-- Customer pain points or use cases mentioned
-
-Return only the extracted page text.`
-              }],
-              max_tokens: 4000
-            })
-          });
-          if (sonarContentRes.ok) {
-            const sonarContentData = await sonarContentRes.json();
-            const sonarExtractedText = (sonarContentData.choices?.[0]?.message?.content || '').trim();
-            if (sonarExtractedText && sonarExtractedText !== 'SITE_INACCESSIBLE' && sonarExtractedText.length > 200) {
-              scrapedContent = `SONAR-EXTRACTED CONTENT (site is JS-rendered — this is what a user sees):\n${sonarExtractedText}`;
-              console.log(`[Context Hub] Sonar content fallback succeeded: ${sonarExtractedText.length} chars`);
-            } else {
-              console.log(`[Context Hub] Sonar content fallback returned no usable content (${sonarExtractedText.slice(0, 100)})`);
-            }
-          } else {
-            console.log(`[Context Hub] Sonar content fallback HTTP ${sonarContentRes.status}`);
-          }
-        } catch (sonarErr) {
-          console.log(`[Context Hub] Sonar content fallback error:`, sonarErr.message);
-        }
-      }
+      const okPages = (homeContent?.success ? 1 : 0) + subContents.filter(p => p?.success).length;
+      console.log(`[Context Hub] Scraped ${scrapedContent.length} chars from ${okPages} page(s) (base: ${workingBaseUrl}, discovered: ${subpages.length})`);
     } catch(e) {
       console.log(`[Context Hub] Scraper error (non-fatal):`, e.message);
     }
 
     const scraperSuccess = scrapedContent.length > 200;
     const siteContentSection = scraperSuccess
-      ? `\n\nACTUAL WEBSITE CONTENT (scraped — use this as primary source, do NOT guess from domain name):\n${scrapedContent.slice(0, 8000)}`
+      ? `\n\nACTUAL WEBSITE CONTENT (scraped — use this as primary source, do NOT guess from domain name):\n${scrapedContent.slice(0, 100000)}`
       : '';
     if (!scraperSuccess) console.warn(`[Context Hub] ⚠️ SCRAPER FAILED for ${brandUrl} — Claude will guess from domain name + Sonar context only`);
 
@@ -14385,6 +14137,144 @@ async function forgeScrape(url, opts = {}) {
   // higher-tier tool).
   if (browserResult.success) return browserResult;
   return unlockerResult.success ? unlockerResult : browserResult;
+}
+
+// ── getBrandPageContent — Stage 1 page-content primitive ───────────────────
+// Returns clean markdown for a single brand page. Two-tier:
+//
+//   Tier A: Jina Reader (r.jina.ai) — semantic content extraction with built-in
+//           JS rendering. Returns markdown directly. Fast on the common case.
+//   Tier B: forgeScrape (Tier 1 → Tier 2 cascade) + local Mozilla Readability
+//           + Turndown. For sites Jina can't reach (rate-limit, geo-block,
+//           outright failure) — we render via Bright Data and extract locally.
+//
+// Returns { success, markdown, source, latencyMs, error }
+//   source: 'jina_reader' | 'brightdata_unlocker' | 'brightdata_browser'
+//
+// Every attempt is logged to scrape_log with caller='context-hub' for audit.
+const _turndown = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced', emDelimiter: '_' });
+function htmlToMarkdown(html, url) {
+  try {
+    const dom = new JSDOM(html, { url });
+    const article = new Readability(dom.window.document).parse();
+    if (!article?.content) return '';
+    return _turndown.turndown(article.content).trim();
+  } catch {
+    return '';
+  }
+}
+
+async function getBrandPageContent(url, { caller = 'context-hub', metadata = {}, jinaTimeout = 15000 } = {}) {
+  // ── Tier A: Jina Reader ──────────────────────────────────────────────────
+  const jinaStart = Date.now();
+  try {
+    const headers = { 'Accept': 'text/plain' };
+    if (process.env.JINA_API_KEY) headers['Authorization'] = `Bearer ${process.env.JINA_API_KEY}`;
+    const ac = new AbortController();
+    const tid = setTimeout(() => ac.abort(), jinaTimeout);
+    let resp;
+    try {
+      resp = await fetch(`https://r.jina.ai/${url}`, { headers, signal: ac.signal });
+    } finally { clearTimeout(tid); }
+    const latencyMs = Date.now() - jinaStart;
+    if (resp.ok) {
+      const markdown = (await resp.text()).trim();
+      const usable = markdown.length > 500;
+      await _logScrape({
+        url, source: 'jina_reader', status_code: resp.status, body_size: markdown.length,
+        latency_ms: latencyMs, success: usable, caller,
+        metadata: { ...metadata, body_sample: markdown.slice(0, 2000) },
+        error: usable ? null : `markdown under threshold (${markdown.length} chars)`,
+      });
+      if (usable) return { success: true, markdown, source: 'jina_reader', latencyMs, error: null };
+    } else {
+      await _logScrape({
+        url, source: 'jina_reader', status_code: resp.status, body_size: 0,
+        latency_ms: latencyMs, success: false, caller, metadata,
+        error: `HTTP ${resp.status}`,
+      });
+    }
+  } catch (e) {
+    await _logScrape({
+      url, source: 'jina_reader', success: false, latency_ms: Date.now() - jinaStart,
+      caller, metadata, error: e.message,
+    });
+  }
+
+  // ── Tier B: forgeScrape → Readability + Turndown ─────────────────────────
+  // forgeScrape logs its own attempts (Tier 1 + Tier 2 rows) — no double-log here.
+  const fetched = await forgeScrape(url, { caller, metadata });
+  if (!fetched.success || !fetched.html) {
+    return { success: false, markdown: null, source: fetched.source, latencyMs: fetched.latencyMs, error: fetched.error || 'forgeScrape returned no html' };
+  }
+  const markdown = htmlToMarkdown(fetched.html, url);
+  if (markdown.length < 200) {
+    return { success: false, markdown: null, source: fetched.source, latencyMs: fetched.latencyMs, error: `Readability extracted ${markdown.length} chars (under threshold)` };
+  }
+  return { success: true, markdown, source: fetched.source, latencyMs: fetched.latencyMs, error: null };
+}
+
+// ── discoverSubpages — sitemap.xml first, link-extraction fallback ─────────
+// Returns up to `max` same-origin URLs likely to contain brand-defining
+// content (about, customers, pricing, integrations, FAQ, etc.). Skips noise
+// (login, legal, blog post slugs, search/tag/category aggregates).
+function rankBrandPages(urls) {
+  const HIGH = /\/(about|story|mission|team|company|why-us|our-)/i;
+  const MED  = /\/(product|service|customer|case-stud|pricing|integration|faq|how-it-works|solution|platform)/i;
+  const SKIP = /\/(login|signup|sign-in|sign-up|legal|privacy|terms|cookie|sitemap|robots|admin|account|password|settings|cart|checkout|search\?|tag\/|tags\/|category\/|categories\/|author\/|feed|rss|wp-json|wp-admin|api\/)/i;
+  const seen = new Set();
+  const scored = [];
+  for (const raw of urls) {
+    const u = raw.replace(/#.*$/, '').replace(/\?.*$/, '');
+    if (!u || seen.has(u) || SKIP.test(u)) continue;
+    seen.add(u);
+    scored.push({ url: u, score: HIGH.test(u) ? 3 : MED.test(u) ? 2 : 1 });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map(s => s.url);
+}
+
+async function discoverSubpages(baseUrl, max = 8) {
+  const baseHost = new URL(baseUrl).host;
+  const sameOrigin = (u) => { try { return new URL(u).host === baseHost; } catch { return false; } };
+
+  // Step 1: sitemap.xml (handles sitemapindex by following the first child)
+  try {
+    const sm = await fetch(new URL('/sitemap.xml', baseUrl).href, { signal: AbortSignal.timeout(8000) });
+    if (sm.ok) {
+      let xml = await sm.text();
+      let urls = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
+      if (/<sitemapindex/i.test(xml) && urls.length) {
+        try {
+          const child = await fetch(urls[0], { signal: AbortSignal.timeout(8000) });
+          if (child.ok) {
+            const cx = await child.text();
+            urls = [...cx.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
+          }
+        } catch { /* child fetch failed — fall through with index URLs */ }
+      }
+      const ranked = rankBrandPages(urls.filter(sameOrigin).filter(u => u !== baseUrl && u !== `${baseUrl}/`));
+      if (ranked.length) return ranked.slice(0, max);
+    }
+  } catch { /* sitemap missing/slow — fall through to link extraction */ }
+
+  // Step 2: link extraction from homepage HTML (uses forgeScrape so we get a
+  // rendered DOM if the homepage is a SPA — link maps are usually in the
+  // hydrated nav, not the shell).
+  try {
+    const home = await forgeScrape(baseUrl, { caller: 'context-hub-discover' });
+    if (home.success && home.html) {
+      const origin = new URL(baseUrl).origin;
+      const hrefs = [...home.html.matchAll(/href=["']([^"']+)["']/g)].map(m => m[1])
+        .map(h => h.startsWith('/') ? origin + h : h)
+        .filter(h => /^https?:\/\//i.test(h))
+        .filter(sameOrigin)
+        .filter(h => h !== baseUrl && h !== `${baseUrl}/`);
+      return rankBrandPages(hrefs).slice(0, max);
+    }
+  } catch { /* both discovery paths failed — caller continues with home only */ }
+
+  return [];
 }
 
 // Soft auth — attaches userId if present, continues either way (for public + authed routes)


### PR DESCRIPTION
## Why

Stage 1 (`/api/context-hub/analyze`) — the most-trafficked endpoint in the product — was running on pre-`forgeScrape` direct-fetch machinery. No anti-bot, no JS render, no Tier 2 fallback. On any modern SPA (most of the customer base) it silently returned the shell, capped body text at 3 KB, and built brand profiles off meta tags + JSON-LD alone.

Jina was already there as a Tier-B fallback, but only fired when the local strip yielded under 200 chars — on shells that return 3 KB of header markup, Jina never ran.

This rebuilds Stage 1 with the architecture we landed on after the sandbox-gtm.com diagnostic: **Jina-first, forgeScrape-fallback, parallel page fetches, full markdown content into Claude.**

## Architecture

**New module-scope primitive: `getBrandPageContent(url)` → clean markdown**

```
Tier A: Jina Reader (r.jina.ai)
  → semantic markdown, JS-rendered by Jina, 15 s timeout
  → accept on > 500 chars

Tier B: forgeScrape (BD Tier 1 → Tier 2 cascade)
  → render via Bright Data Web Unlocker → Scraping Browser
  → @mozilla/readability + turndown locally → markdown
  → no second API call; we already paid to render
```

**Subpage discovery: `discoverSubpages(baseUrl, max=8)`**

- `sitemap.xml` first (handles `<sitemapindex>` by following the first child)
- Falls back to link extraction from a `forgeScrape`'d home (important for SPAs whose nav only exists in the hydrated DOM)
- `rankBrandPages` scores paths: high (`/about`, `/story`, `/mission`, `/team`, `/company`), med (`/product`, `/customer`, `/pricing`, `/case-stud`, `/integration`, `/faq`, etc.), skip (`/login`, `/legal`, `/api`, etc.)

**Analyze handler now ~50 lines for the scrape section (was ~290):**

```js
const [subpages, homeContent] = await Promise.all([
  discoverSubpages(workingBaseUrl, 8),
  getBrandPageContent(workingBaseUrl, { caller: 'context-hub' }),
]);
const subContents = await Promise.all(subpages.map(u =>
  getBrandPageContent(u, { caller: 'context-hub' })
));
// concat per-page markdown @ 20 KB each
```

Parallel fetches → wall-clock ~15–20 s vs. ~60 s sequential. Tool 2 prompt gets up to 100 KB of clean markdown (was 8 KB of mixed strip+meta+Sonar text).

## What's removed

- `stripHtml`, `metaExtract`, `fetchWithDiag`, `describeFetchFailure` — scoped helpers inside the analyze handler, no longer needed
- `FORGE_UA` / `CHROME_UA` rotation logic
- SPA-shell detection regex (forgeScrape already handles this internally)
- **Sonar content-extraction fallback** — `forgeScrape` Tier 2 strictly subsumes it. **Sonar Tool 1 (competitor/ICP research) kept** — different purpose, still useful.

A separate `stripHtml` in the competitor-scrape handler (server.js:~6442) is untouched and out of scope.

## New deps

- `@mozilla/readability` ^0.5.0
- `jsdom` ^25.0.1
- `turndown` ^7.2.0

Combined ~150 KB, fully local, no API calls. Used only on the Tier B path (when Jina can't reach a site).

## Observability

Every Jina + forgeScrape attempt logs to `scrape_log` with `caller='context-hub'`. Includes the first 2 KB body sample (Jina markdown or HTML, depending on tier). Same shape we used to diagnose sandbox-gtm.com.

## No backwards compat

Wipe-and-rescan philosophy. Existing brand profiles remain readable; new scans go through the new path.

## Test plan

- [ ] Render deploys cleanly (new npm deps install on first boot)
- [ ] Rescan **sandbox-gtm.com** — expect a 6/6-quality brand profile, Jina markdown in scrape_log
- [ ] Rescan a known **Tailwind/Vite SPA** that previously failed Stage 1 — expect Jina to win Tier A
- [ ] Rescan a **bot-protected / Cloudflare site** — expect Jina to fail, forgeScrape Tier 2 to win Tier B
- [ ] Rescan a **server-rendered WordPress / Webflow** site — expect Jina to win quickly, no Tier B hop
- [ ] `GET /api/admin/scrape-log?caller=context-hub&adminPassword=…` — audit which tier won for which brand
- [ ] Confirm wall-clock latency cut roughly in half (parallel page fetch)
- [ ] Spot-check the persisted brand profile: voiceProfile, ICP, market category should all be richer than before

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_