### PR TITLE
fix(context-hub): Jina link-summary + dedupe homepage variants

### DIFF
--- a/server.js
+++ b/server.js
@@ -14195,7 +14195,15 @@ async function getBrandPageContent(url, { caller = 'context-hub', metadata = {},
   // ── Tier A: Jina Reader ──────────────────────────────────────────────────
   const jinaStart = Date.now();
   try {
-    const headers = { 'Accept': 'text/plain' };
+    // X-With-Links-Summary asks Jina to append a "Links/Buttons:" section
+    // after the readability-extracted markdown. Crucial for SPA marketing
+    // pages: readability drops the <nav>/<header> region, so without this
+    // header the markdown contains content-area links only — missing the
+    // primary nav (pricing, blog, book-demo, etc.) that we need for
+    // subpage discovery. The appended section uses standard [text](url)
+    // syntax, so our existing extractMarkdownLinks regex picks it up
+    // automatically.
+    const headers = { 'Accept': 'text/plain', 'X-With-Links-Summary': 'true' };
     if (process.env.JINA_API_KEY) headers['Authorization'] = `Bearer ${process.env.JINA_API_KEY}`;
     const ac = new AbortController();
     const tid = setTimeout(() => ac.abort(), jinaTimeout);
@@ -14268,7 +14276,9 @@ function rankBrandPages(urls) {
   const seen = new Set();
   const scored = [];
   for (const raw of urls) {
-    const u = raw.replace(/#.*$/, '').replace(/\?.*$/, '');
+    // Strip fragment, query, AND trailing slash so /about and /about/ dedupe
+    // and don't appear as two distinct subpages.
+    const u = raw.replace(/#.*$/, '').replace(/\?.*$/, '').replace(/\/+$/, '');
     if (!u || seen.has(u) || SKIP_PATH.test(u) || SKIP_EXT.test(u)) continue;
     seen.add(u);
     scored.push({ url: u, score: HIGH.test(u) ? 3 : MED.test(u) ? 2 : 1 });
@@ -14295,8 +14305,14 @@ async function discoverSubpages(baseUrl, max = 8, { seedMarkdown = null, seedHtm
   const baseHost = new URL(baseUrl).host;
   const origin = new URL(baseUrl).origin;
   const sameOrigin = (u) => { try { return new URL(u).host === baseHost; } catch { return false; } };
+  // Strip fragment and trailing slash for comparison/dedup. Without this,
+  // [See How It Works](https://example.com/#capabilities) escapes the
+  // baseUrl filter (URL with fragment !== baseUrl) and rides through as
+  // a "subpage" — even though it's literally the homepage with an anchor.
+  const canonical = (u) => u.replace(/#.*$/, '').replace(/\/+$/, '');
+  const baseCanonical = canonical(baseUrl);
   const normalize = (u) => u.startsWith('/') ? origin + u : u;
-  const isPage = (u) => /^https?:\/\//i.test(u) && sameOrigin(u) && u !== baseUrl && u !== `${baseUrl}/`;
+  const isPage = (u) => /^https?:\/\//i.test(u) && sameOrigin(u) && canonical(u) !== baseCanonical;
 
   // Step 1: sitemap.xml (handles sitemapindex by following the first child)
   try {


### PR DESCRIPTION
## Why

Post-#109 rescan of sandbox-gtm.com showed two new bugs in `scrape_log`:

| URL | Result |
|---|---|
| `https://sandbox-gtm.com` | jina_reader 3,250 ✅ |
| `https://sandbox-gtm.com/` | jina_reader 3,250 ✅ (the *same* page) |

Only one "subpage" discovered, and it was the homepage with a trailing slash. So we fetched the home twice and missed every actual subpage (pricing, blog, book-demo, sign-in). Two issues:

### 1. Jina readability drops nav links

Jina Reader runs Mozilla Readability, which extracts the main content area and strips `<nav>` / `<header>`. On SPA marketing pages the primary subpage links live in the hydrated nav — so seedMarkdown comes back with content-area links only. Discovery had nothing useful to parse.

**Fix:** Add `X-With-Links-Summary: true` to the Jina request. Jina then appends a `Links/Buttons:` section listing every link on the page (nav + footer + body) in standard `[text](url)` syntax. Existing `extractMarkdownLinks` regex picks it up unchanged.

One header. Same API call. Same latency. Complete link map.

### 2. Homepage variants pass `isPage`

The Jina markdown contained `[See How It Works](https://sandbox-gtm.com/#capabilities)`. My filter:

```js
u !== baseUrl && u !== `${baseUrl}/`
```

A URL with a `#fragment` is literally neither, so it passed. `rankBrandPages` then stripped the fragment → `https://sandbox-gtm.com/` → re-fetched as a "subpage."

**Fix:** Replace equality checks with a `canonical()` helper that strips fragment + trailing slash before comparison. Also apply the same trailing-slash strip in `rankBrandPages`'s dedupe key so `/about` and `/about/` dedupe as one.

## Expected next-scan diff

- Subpages list on sandbox-gtm.com should now include `/pricing`, `/the-sandbox`, `/book-demo` (whatever's in the live nav) instead of just the homepage variant
- No more `https://sandbox-gtm.com` AND `https://sandbox-gtm.com/` rows in the same scan

## Test plan

- [ ] Render deploys cleanly
- [ ] Rescan sandbox-gtm.com — confirm 3-5 real subpage rows (pricing, the-sandbox, etc.) in scrape_log
- [ ] No duplicate-home row
- [ ] Tool 2 brand profile gets richer than before (now seeing pricing/blog content)
- [ ] Regression: scan a sitemap-having site (any WP / Webflow) — sitemap path still wins, no behavior change

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_