### PR TITLE
fix(analytics/facebook): use Zernio internal _id for analytics, not platform URN

### DIFF
--- a/server.js
+++ b/server.js
@@ -11563,6 +11563,11 @@ Output only the post text.` }]
                 status: 'published',
                 url: zr.postUrl,
                 postId: zr.postId,
+                // Zernio's internal _id — needed by analytics sync for Zernio lookups.
+                // Zernio's /analytics endpoint expects this, NOT the Facebook platform URN
+                // (pageId_postId). Without it, the sync hits 404 on every Zernio-published
+                // Facebook post — which is what was happening before this was added.
+                zernioPostId: zr.zernioPostId,
                 via: 'zernio',
                 utmParams
               };
@@ -12464,15 +12469,25 @@ app.post('/api/analytics/sync/:brandProfileId', async (req, res) => {
         try {
           const rd = row.response_data || {};
           const postId = rd.postId || rd.post_id || rd.id;
+          // Zernio's internal _id (separate from the Facebook platform URN).
+          // Populated for posts published after the zernioPostId capture landed
+          // in the publish handler. Older Zernio posts have null here and route
+          // to the legacy Graph API fallback below.
+          const zernioPostId = rd.zernioPostId || rd.zernio_post_id || null;
           if (!postId) { errors.push({ contentId: row.content_id, error: 'no_post_id' }); continue; }
 
           let impressions = 0, clicks = 0, reactions = 0, comments = 0, reposts = 0;
           let rawData = {};
           let dataSource = 'none';
 
-          if (fbIsZernio) {
-            const analyticsRes = await callZernio('GET', `/analytics?postId=${encodeURIComponent(postId)}`);
-            console.log(`[Analytics/Facebook] Zernio analytics for ${postId}: HTTP ${analyticsRes.status}`);
+          // Use Zernio analytics ONLY when this specific post has a Zernio _id —
+          // Zernio's /analytics endpoint expects its internal _id, NOT the
+          // Facebook platform URN (pageId_postId). Posts published before the
+          // zernioPostId fix have no _id stored, so they route through the
+          // legacy Graph API fallback even if the brand is Zernio-routed.
+          if (fbIsZernio && zernioPostId) {
+            const analyticsRes = await callZernio('GET', `/analytics?postId=${encodeURIComponent(zernioPostId)}`);
+            console.log(`[Analytics/Facebook] Zernio analytics for ${zernioPostId} (URN ${postId}): HTTP ${analyticsRes.status}`);
 
             if (analyticsRes.status === 202) {
               await pool.query(


### PR DESCRIPTION
## Symptom

Sandbox-GTM Performance Dashboard reports `No Facebook data found — connect this integration first` despite Facebook being connected and two posts successfully published via Zernio.

Render logs show the real story:

```
[Analytics/Facebook] Found 2 published posts, provider=zernio
[Analytics/Facebook] Zernio analytics for 955063921018028_122127759435189588: HTTP 404
[Analytics/Facebook] Zernio analytics for 955063921018028_122127048423189588: HTTP 404
```

(Also note: the toast copy itself is misleading — it fires whenever the sync returns `synced: 0` with an empty dashboard, regardless of integration state. Worth fixing in a follow-up PR.)

## Root cause

The Facebook sync was passing the **Facebook platform URN** (`pageId_postId` from the Graph API) to Zernio's `/analytics` endpoint, which only accepts **Zernio's internal `_id`**. The LinkedIn sync handles this correctly via a separate `zernioPostId` field; the Facebook sync never got the equivalent refactor.

Two parts:

**Publish side — `server.js:~11562`**

```js
// Was:
results[channel] = { status: 'published', url: zr.postUrl, postId: zr.postId, via: 'zernio', utmParams };

// Now (matches LinkedIn at ~11314):
results[channel] = { ..., postId: zr.postId, zernioPostId: zr.zernioPostId, ... };
```

`zernioPublish()` already returns both. Facebook was just dropping `zernioPostId` on the floor.

**Sync side — `server.js:~12466`**

```js
// Was:
const postId = rd.postId || rd.post_id || rd.id;
if (fbIsZernio) { callZernio('GET', `/analytics?postId=${postId}`); }  // platform URN → 404

// Now (matches LinkedIn at ~12122-12134):
const postId = rd.postId || rd.post_id || rd.id;
const zernioPostId = rd.zernioPostId || rd.zernio_post_id || null;
if (fbIsZernio && zernioPostId) { callZernio('GET', `/analytics?postId=${zernioPostId}`); }
else if (fbToken && fbCreds.pageId) { /* legacy Graph API fallback */ }
```

## Caveat for existing data

The two historical Sandbox-GTM Facebook posts have `postId` but no `zernioPostId` in `response_data` — they were published before this fix lands. After deploy they'll route to the legacy Graph API fallback; if the brand's Facebook credentials don't include `pageAccessToken` + `pageId` they'll silently skip. Options:

1. Manual backfill — map platform URN → Zernio `_id` via Zernio's post list API and update `publish_log.response_data`
2. Re-publish the two posts to get fresh records
3. Accept the loss for those two

All **future** Facebook publishes via Zernio will work correctly.

## Test plan

- [ ] Render deploys cleanly
- [ ] Publish a fresh Facebook post for Sandbox-GTM via Zernio
- [ ] Check `publish_log.response_data` contains `zernioPostId` for the new row
- [ ] Run analytics sync; verify scrape_log shows the new post syncing with real metrics
- [ ] Performance Dashboard's Facebook tab populates

## Follow-up PR worth filing

The toast at `PerformanceDashboardPage.tsx:433` is misleading — "connect this integration first" fires whenever `synced: 0` + empty dashboard, not based on actual credentials state. Better to differentiate `no_credentials` / `no_published_posts` / `all_pending` / `up_to_date` server-side and key the toast off that.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_