### PR TITLE
feat(publishing): My Website channel — webhook publisher for self-hosted sites

### DIFF
--- a/docs/MY_WEBSITE_INTEGRATION.md
+++ b/docs/MY_WEBSITE_INTEGRATION.md
@@ -1,0 +1,286 @@
+# My Website Integration
+
+Publish Forge-generated articles directly to your own self-hosted site via an authenticated webhook. Forge POSTs each article payload to an endpoint you control; your site decides how to store and render it.
+
+## Setup (Forge side)
+
+1. **Brand Settings → Integrations → My Website**
+2. Paste your receiver URL (e.g. `https://yoursite.com/api/forge/publish`)
+3. Choose payload format: `html`, `markdown`, or `both`
+4. Click **Generate token** — copy it immediately, you won't see it again
+5. Click **Send test payload** to verify your receiver is wired up
+
+## Payload schema
+
+Every successful publish sends:
+
+```json
+{
+  "slug": "event-pipeline-attribution-...",
+  "title": "Event Pipeline Attribution: ...",
+  "excerpt": "First 200 chars of the article body, plaintext.",
+  "heroImageUrl": "https://cdn.example.com/image.png",
+  "canonical": "https://forgeintelligence.ai/articles/<brand>/<slug>",
+  "publishedAt": "2026-05-22T00:11:23.450Z",
+  "meta": {
+    "description": "...",
+    "ogImage": "https://cdn.example.com/image.png",
+    "utm": { "utm_source": "website", "utm_medium": "blog", ... }
+  },
+  "html": "<article>...</article>",
+  "markdown": "# ...\n\n## ..."
+}
+```
+
+The `html` and `markdown` fields are present based on your format setting. `test: true` is added on test payloads only.
+
+## Authentication
+
+Every request includes:
+
+```
+Authorization: Bearer forge_pub_<your-token>
+Content-Type: application/json
+User-Agent: Forge-Intelligence/1.0
+```
+
+Validate the token by comparing the `Authorization` header to a value stored in your server environment (NEVER hard-code it in source).
+
+## Expected response
+
+Return **HTTP 200** on success. Optionally return JSON with a `url` field — Forge will use it as the `published_url` in the Publishing Queue so the "View on site" link works:
+
+```json
+{ "ok": true, "url": "https://yoursite.com/articles/your-slug" }
+```
+
+Return any non-2xx status on failure. The response body (first 300 chars) appears in Forge's publish log error message.
+
+---
+
+## Sample receiver: Node + Express + Postgres
+
+This is what we built for **Sandbox-GTM** (Render + Neon stack). Adapt to your DB schema.
+
+```js
+// app.js (or routes/forge.js)
+import express from 'express';
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const router = express.Router();
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+// Required env: FORGE_BEARER_TOKEN — the exact value Forge displayed once
+// when you clicked "Generate token" in the Forge Integrations UI.
+const FORGE_TOKEN = process.env.FORGE_BEARER_TOKEN;
+
+router.post('/api/forge/publish', express.json({ limit: '2mb' }), async (req, res) => {
+  // 1. Auth check — constant-time compare to defeat timing attacks
+  const auth = req.headers.authorization || '';
+  const provided = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!FORGE_TOKEN || provided.length !== FORGE_TOKEN.length) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  // Buffer.from + timingSafeEqual avoids early-exit string comparison
+  const { timingSafeEqual } = await import('crypto');
+  const a = Buffer.from(provided);
+  const b = Buffer.from(FORGE_TOKEN);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  // 2. Parse the payload
+  const { slug, title, excerpt, heroImageUrl, canonical, publishedAt, meta, html, markdown, test } = req.body || {};
+  if (!slug || !title) return res.status(400).json({ error: 'slug and title required' });
+
+  // 3. (Optional) Drop test payloads — don't pollute the live articles table
+  if (test) return res.json({ ok: true, test: true, message: 'test received' });
+
+  // 4. Upsert into your articles table
+  // Schema assumed:
+  //   CREATE TABLE articles (
+  //     slug          TEXT PRIMARY KEY,
+  //     title         TEXT NOT NULL,
+  //     excerpt       TEXT,
+  //     hero_image    TEXT,
+  //     canonical_url TEXT,
+  //     meta          JSONB,
+  //     html          TEXT,
+  //     markdown      TEXT,
+  //     published_at  TIMESTAMPTZ,
+  //     created_at    TIMESTAMPTZ DEFAULT NOW(),
+  //     updated_at    TIMESTAMPTZ DEFAULT NOW()
+  //   );
+  await pool.query(
+    `INSERT INTO articles (slug, title, excerpt, hero_image, canonical_url, meta, html, markdown, published_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+     ON CONFLICT (slug) DO UPDATE SET
+       title = EXCLUDED.title,
+       excerpt = EXCLUDED.excerpt,
+       hero_image = EXCLUDED.hero_image,
+       canonical_url = EXCLUDED.canonical_url,
+       meta = EXCLUDED.meta,
+       html = EXCLUDED.html,
+       markdown = EXCLUDED.markdown,
+       published_at = EXCLUDED.published_at,
+       updated_at = NOW()`,
+    [slug, title, excerpt || null, heroImageUrl || null, canonical || null,
+     JSON.stringify(meta || {}), html || null, markdown || null, publishedAt || null]
+  );
+
+  // 5. Return the public URL — Forge displays this in the Publishing Queue
+  const publicUrl = `https://yoursite.com/articles/${slug}`;
+  res.json({ ok: true, url: publicUrl });
+});
+
+export default router;
+```
+
+### Env var
+
+```bash
+# Render dashboard → Environment → Add Environment Variable
+FORGE_BEARER_TOKEN=YOUR_BEARER_TOKEN_HERE   # the forge_pub_... value from Forge's UI
+```
+
+### DB schema (Neon / Postgres)
+
+```sql
+CREATE TABLE IF NOT EXISTS articles (
+  slug          TEXT PRIMARY KEY,
+  title         TEXT NOT NULL,
+  excerpt       TEXT,
+  hero_image    TEXT,
+  canonical_url TEXT,
+  meta          JSONB,
+  html          TEXT,
+  markdown      TEXT,
+  published_at  TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS articles_published_at_idx ON articles(published_at DESC);
+```
+
+---
+
+## Sample receiver: Next.js App Router
+
+```ts
+// app/api/forge/publish/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { sql } from '@vercel/postgres'; // or your DB client
+
+const FORGE_TOKEN = process.env.FORGE_BEARER_TOKEN!;
+
+export async function POST(req: NextRequest) {
+  // Auth check
+  const auth = req.headers.get('authorization') || '';
+  const provided = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!FORGE_TOKEN || provided.length !== FORGE_TOKEN.length) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  if (!timingSafeEqual(Buffer.from(provided), Buffer.from(FORGE_TOKEN))) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { slug, title, excerpt, heroImageUrl, canonical, publishedAt, meta, html, markdown, test } = body;
+  if (!slug || !title) return NextResponse.json({ error: 'slug and title required' }, { status: 400 });
+  if (test) return NextResponse.json({ ok: true, test: true });
+
+  await sql`
+    INSERT INTO articles (slug, title, excerpt, hero_image, canonical_url, meta, html, markdown, published_at, updated_at)
+    VALUES (${slug}, ${title}, ${excerpt || null}, ${heroImageUrl || null}, ${canonical || null},
+            ${JSON.stringify(meta || {})}, ${html || null}, ${markdown || null}, ${publishedAt || null}, NOW())
+    ON CONFLICT (slug) DO UPDATE SET
+      title = EXCLUDED.title, excerpt = EXCLUDED.excerpt, hero_image = EXCLUDED.hero_image,
+      canonical_url = EXCLUDED.canonical_url, meta = EXCLUDED.meta,
+      html = EXCLUDED.html, markdown = EXCLUDED.markdown,
+      published_at = EXCLUDED.published_at, updated_at = NOW()
+  `;
+
+  return NextResponse.json({ ok: true, url: `https://yoursite.com/articles/${slug}` });
+}
+```
+
+---
+
+## Sample receiver: filesystem (static-site rebuilds)
+
+For sites that read articles from disk and rebuild on file change (Astro, Eleventy, Next.js static export, etc.):
+
+```js
+// app.js
+import express from 'express';
+import fs from 'fs/promises';
+import path from 'path';
+import { timingSafeEqual } from 'crypto';
+
+const FORGE_TOKEN = process.env.FORGE_BEARER_TOKEN;
+const CONTENT_DIR = path.join(process.cwd(), 'content', 'articles');
+
+const router = express.Router();
+
+router.post('/api/forge/publish', express.json({ limit: '2mb' }), async (req, res) => {
+  const auth = req.headers.authorization || '';
+  const provided = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!FORGE_TOKEN ||
+      provided.length !== FORGE_TOKEN.length ||
+      !timingSafeEqual(Buffer.from(provided), Buffer.from(FORGE_TOKEN))) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  const { slug, title, markdown, meta, publishedAt, heroImageUrl, test } = req.body;
+  if (!slug || !markdown) return res.status(400).json({ error: 'slug and markdown required' });
+  if (test) return res.json({ ok: true, test: true });
+
+  // Write as a frontmatter-prefixed markdown file. Adjust frontmatter
+  // shape to whatever your static-site generator expects.
+  const frontmatter = [
+    '---',
+    `title: ${JSON.stringify(title)}`,
+    `slug: ${slug}`,
+    `publishedAt: ${publishedAt}`,
+    `heroImage: ${heroImageUrl || ''}`,
+    `description: ${JSON.stringify(meta?.description || '')}`,
+    '---',
+    '',
+  ].join('\n');
+
+  await fs.mkdir(CONTENT_DIR, { recursive: true });
+  await fs.writeFile(path.join(CONTENT_DIR, `${slug}.md`), frontmatter + markdown, 'utf8');
+
+  // OPTIONAL: trigger a rebuild here (Netlify build hook, Vercel
+  // deployment webhook, GitHub commit, etc.) so the new file goes live.
+
+  res.json({ ok: true, url: `https://yoursite.com/articles/${slug}` });
+});
+
+export default router;
+```
+
+⚠️ **Doesn't work on serverless runtimes** (Vercel, Netlify Functions) — those filesystems are read-only at runtime. Use the database receiver instead, or trigger a git commit + redeploy from your receiver.
+
+---
+
+## Rotating the token
+
+If you suspect compromise, hit **Rotate token** in the Forge UI. The old token is invalidated immediately and a new one is displayed once. Your site will reject Forge publishes until you update `FORGE_BEARER_TOKEN` in your environment to match.
+
+## Disconnecting
+
+Hit **Disconnect** in the Forge UI. Forge stops sending publishes to your endpoint but retains the configuration in case you reconnect — no need to regenerate the token unless you also rotate it.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Test publish returns 401 | Bearer token in your env doesn't match what Forge stored. Rotate + update both sides. |
+| Test publish returns 404 | Endpoint URL is wrong or your route handler isn't registered. |
+| Test publish returns 5xx | Your DB insert / file write failed. Check your server logs. |
+| Forge publishes succeed but the article doesn't appear on your site | Receiver isn't actually persisting (check DB) or your site's article route doesn't read from the right source. |
+| Publish log shows "Receiver returned HTTP N" | Your endpoint returned a non-2xx status. The response body (first 300 chars) is in the error message. |

--- a/server.js
+++ b/server.js
@@ -10035,6 +10035,153 @@ app.get('/api/publishing/channels/:brandProfileId', requireAuth, async (req, res
 });
 
 // POST /api/publishing/channels — upsert channel connection
+// ── My Website channel (channel = 'website') ─────────────────────────────
+// Lets users publish Forge-generated articles directly to their own
+// self-hosted site via an authenticated webhook. Forge stores three pieces
+// of state per brand under publishing_channels.credentials:
+//
+//   endpointUrl   — full POST target on the user's site
+//   format        — 'html' | 'markdown' | 'both'
+//   bearerToken   — server-generated, prefix `forge_pub_`
+//
+// Token is shown to the user ONCE on generate/rotate, then masked in all
+// subsequent reads. Same pattern as GitHub PATs, Stripe restricted keys.
+//
+// Save / generate / test / delete are split into separate endpoints so the
+// token survives an endpoint-URL edit (it would otherwise be wiped by the
+// wholesale-overwrite in /api/publishing/channels).
+
+// POST /api/integrations/website/:brandProfileId/config
+// Body: { endpointUrl, format }
+// JSONB-merges into credentials so any existing bearerToken is preserved.
+app.post('/api/integrations/website/:brandProfileId/config', requireAuth, async (req, res) => {
+  const { brandProfileId } = req.params;
+  const { endpointUrl, format } = req.body;
+  if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
+  if (!endpointUrl || !/^https?:\/\//i.test(endpointUrl)) {
+    return res.status(400).json({ error: 'endpointUrl must be a full http(s) URL' });
+  }
+  if (format && !['html', 'markdown', 'both'].includes(format)) {
+    return res.status(400).json({ error: "format must be 'html', 'markdown', or 'both'" });
+  }
+  try {
+    const merge = { endpointUrl: endpointUrl.replace(/\/+$/, ''), format: format || 'both' };
+    await pool.query(
+      `INSERT INTO publishing_channels (brand_profile_id, channel, credentials, is_active, updated_at)
+       VALUES ($1, 'website', $2::jsonb, true, NOW())
+       ON CONFLICT (brand_profile_id, channel)
+       DO UPDATE SET credentials = publishing_channels.credentials || $2::jsonb,
+                     is_active = true, updated_at = NOW()`,
+      [brandProfileId, JSON.stringify(merge)]
+    );
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
+// POST /api/integrations/website/:brandProfileId/generate-token
+// Generates a fresh forge_pub_<32-hex> token, JSONB-merges into credentials,
+// returns the plaintext token EXACTLY ONCE. Caller is responsible for
+// surfacing a "save this now, you won't see it again" UI.
+app.post('/api/integrations/website/:brandProfileId/generate-token', requireAuth, async (req, res) => {
+  const { brandProfileId } = req.params;
+  if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
+  try {
+    const bearerToken = `forge_pub_${randomBytes(32).toString('hex')}`;
+    await pool.query(
+      `INSERT INTO publishing_channels (brand_profile_id, channel, credentials, is_active, updated_at)
+       VALUES ($1, 'website', $2::jsonb, true, NOW())
+       ON CONFLICT (brand_profile_id, channel)
+       DO UPDATE SET credentials = publishing_channels.credentials || $2::jsonb,
+                     is_active = true, updated_at = NOW()`,
+      [brandProfileId, JSON.stringify({ bearerToken })]
+    );
+    res.json({ success: true, bearerToken });
+  } catch (e) {
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
+// POST /api/integrations/website/:brandProfileId/test
+// Sends a sample payload at the configured endpoint with the stored token.
+// Does NOT write to publish_log — this is for user-side validation only.
+// Returns { ok, status, latencyMs, responseBody, error? }.
+app.post('/api/integrations/website/:brandProfileId/test', requireAuth, async (req, res) => {
+  const { brandProfileId } = req.params;
+  if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
+  try {
+    const r = await pool.query(
+      `SELECT credentials FROM publishing_channels WHERE brand_profile_id = $1 AND channel = 'website' LIMIT 1`,
+      [brandProfileId]
+    );
+    const creds = r.rows[0]?.credentials || {};
+    if (!creds.endpointUrl) return res.status(400).json({ ok: false, error: 'endpointUrl not configured' });
+    if (!creds.bearerToken) return res.status(400).json({ ok: false, error: 'bearerToken not generated yet' });
+
+    const samplePayload = {
+      test: true,
+      slug: 'forge-test-publish',
+      title: 'Forge Test Publish — Hello from your website integration',
+      excerpt: 'This is a test payload sent from Forge to verify your receiver is wired up correctly. Ignore or delete after confirming.',
+      heroImageUrl: 'https://forgeintelligence.ai/og-default.png',
+      canonical: `${creds.endpointUrl}/articles/forge-test-publish`,
+      publishedAt: new Date().toISOString(),
+      meta: { description: 'Forge test publish', ogImage: 'https://forgeintelligence.ai/og-default.png' },
+      ...(creds.format !== 'markdown' && {
+        html: '<article><h1>Forge Test Publish</h1><h2>Quick sanity check</h2><p>This is the first section of the test article. If you can read this rendered on your site, your receiver is parsing the <code>html</code> field correctly.</p></article>'
+      }),
+      ...(creds.format !== 'html' && {
+        markdown: '# Forge Test Publish\n\n## Quick sanity check\n\nThis is the first section of the test article. If you can read this rendered on your site, your receiver is parsing the `markdown` field correctly.'
+      }),
+    };
+
+    const start = Date.now();
+    let resp, bodyText = '';
+    try {
+      resp = await fetch(creds.endpointUrl, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${creds.bearerToken}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'Forge-Intelligence/1.0',
+        },
+        body: JSON.stringify(samplePayload),
+        signal: AbortSignal.timeout(15000),
+      });
+      bodyText = (await resp.text()).slice(0, 2000);
+    } catch (e) {
+      return res.json({ ok: false, error: `request failed: ${e.message}`, latencyMs: Date.now() - start });
+    }
+    res.json({
+      ok: resp.ok,
+      status: resp.status,
+      latencyMs: Date.now() - start,
+      responseBody: bodyText,
+    });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+// DELETE /api/integrations/website/:brandProfileId
+// Soft-disconnect — marks is_active = false but preserves credentials so a
+// user who reconnects within the same session doesn't have to regenerate.
+app.delete('/api/integrations/website/:brandProfileId', requireAuth, async (req, res) => {
+  const { brandProfileId } = req.params;
+  if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
+  try {
+    await pool.query(
+      `UPDATE publishing_channels SET is_active = false, updated_at = NOW()
+       WHERE brand_profile_id = $1 AND channel = 'website'`,
+      [brandProfileId]
+    );
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
 app.post('/api/publishing/channels', requireAuth, async (req, res) => {
   const { brandProfileId, channel, credentials, utmTemplate } = req.body;
   if (!brandProfileId || !channel) return res.status(400).json({ error: 'brandProfileId and channel required' });
@@ -11959,6 +12106,73 @@ ${canonicalNote}`,
 
           const ghostPost = ghostData.posts?.[0];
           results[channel] = { status: 'published', url: ghostPost?.url, postId: ghostPost?.id, utmParams };
+
+        } else if (channel === 'website') {
+          // ── My Website webhook publish ──
+          // POSTs the article to the customer-configured endpoint with a
+          // bearer token. The customer's receiver is responsible for storing
+          // / rendering the content. We include both html and markdown in
+          // the payload by default (format='both'); customers can narrow
+          // to one if they want a smaller payload.
+          if (!creds.endpointUrl) throw new Error('My Website: endpointUrl not configured');
+          if (!creds.bearerToken) throw new Error('My Website: bearerToken not generated');
+
+          const articleJson = article.article_json || {};
+          const sections = articleJson.sections || [];
+          const htmlContent = sections.map(s =>
+            `${s.heading ? `<h2>${s.heading}</h2>` : ''}<p>${s.body || s.content || ''}</p>`
+          ).join('\n');
+          const markdownContent = sections.map(s =>
+            `${s.heading ? `## ${s.heading}\n\n` : ''}${s.body || s.content || ''}`
+          ).join('\n\n');
+          const excerpt = (sections[0]?.body || sections[0]?.content || '').replace(/<[^>]+>/g, '').slice(0, 200);
+
+          const payload = {
+            slug: articleSlug,
+            title: article.title,
+            excerpt,
+            heroImageUrl: article.hero_image_url || articleJson.hero_image_url || null,
+            canonical: `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`,
+            publishedAt: new Date().toISOString(),
+            meta: {
+              description: articleJson.meta_description || excerpt,
+              ogImage: article.hero_image_url || articleJson.hero_image_url || null,
+              utm: utmParams,
+            },
+            ...(creds.format !== 'markdown' && { html: htmlContent }),
+            ...(creds.format !== 'html' && { markdown: markdownContent }),
+          };
+
+          const start = Date.now();
+          const r = await fetch(creds.endpointUrl, {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${creds.bearerToken}`,
+              'Content-Type': 'application/json',
+              'User-Agent': 'Forge-Intelligence/1.0',
+            },
+            body: JSON.stringify(payload),
+            signal: AbortSignal.timeout(30000),
+          });
+          const respText = (await r.text()).slice(0, 2000);
+          if (!r.ok) throw new Error(`Receiver returned HTTP ${r.status}: ${respText.slice(0, 300)}`);
+
+          // If the receiver returns JSON with a `url` field, use it as the
+          // published_url so the Publishing Queue's "View on site" link works.
+          let publishedUrl = null;
+          try {
+            const parsed = JSON.parse(respText);
+            if (typeof parsed?.url === 'string') publishedUrl = parsed.url;
+          } catch { /* receiver returned non-JSON, that's fine */ }
+          if (!publishedUrl) publishedUrl = payload.canonical;
+
+          results[channel] = {
+            status: 'published',
+            url: publishedUrl,
+            postId: payload.slug,
+            latencyMs: Date.now() - start,
+            utmParams,
+          };
 
         } else {
           results[channel] = { status: 'error', error: `Unknown channel: ${channel}` };

--- a/src/components/MyWebsiteForm.tsx
+++ b/src/components/MyWebsiteForm.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+
+interface SavedWebsite {
+  credentials?: {
+    endpointUrl?: string;
+    format?: 'html' | 'markdown' | 'both';
+    bearerToken?: string;
+  };
+  is_active?: boolean;
+  updated_at?: string;
+}
+
+interface MyWebsiteFormProps {
+  brandProfileId: string;
+  saved: SavedWebsite | null;
+  onChange: () => void;
+}
+
+type Format = 'html' | 'markdown' | 'both';
+
+// Auth is injected automatically by the global fetch interceptor in main.tsx
+// — no need to pass a token. All /api/ calls get the Clerk JWT attached.
+export default function MyWebsiteForm({ brandProfileId, saved, onChange }: MyWebsiteFormProps) {
+  const [endpointUrl, setEndpointUrl] = useState<string>(saved?.credentials?.endpointUrl || '');
+  const [format, setFormat] = useState<Format>((saved?.credentials?.format as Format) || 'both');
+  const [saving, setSaving] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [revealedToken, setRevealedToken] = useState<string | null>(null);
+  const [tokenSaved, setTokenSaved] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; status?: number; latencyMs?: number; error?: string; responseBody?: string } | null>(null);
+  const [error, setError] = useState('');
+
+  const hasToken = !!saved?.credentials?.bearerToken;
+  const maskedToken = hasToken ? `forge_pub_••••${saved!.credentials!.bearerToken!.slice(-4)}` : '';
+
+  const saveConfig = async () => {
+    if (!endpointUrl.match(/^https?:\/\//i)) {
+      setError('Endpoint URL must start with http:// or https://');
+      return;
+    }
+    setSaving(true); setError('');
+    try {
+      const r = await fetch(`/api/integrations/website/${brandProfileId}/config`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpointUrl, format }),
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d.error || 'save failed');
+      onChange();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const generateToken = async () => {
+    if (hasToken && !window.confirm('Rotating will immediately invalidate the current token. Your site will reject Forge publishes until you update the new token in your server environment. Continue?')) return;
+    setGenerating(true); setError('');
+    try {
+      const r = await fetch(`/api/integrations/website/${brandProfileId}/generate-token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d.error || 'generate failed');
+      setRevealedToken(d.bearerToken);
+      setTokenSaved(false);
+      onChange();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const runTest = async () => {
+    setTesting(true); setTestResult(null);
+    try {
+      const r = await fetch(`/api/integrations/website/${brandProfileId}/test`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const d = await r.json();
+      setTestResult(d);
+    } catch (e) {
+      setTestResult({ ok: false, error: (e as Error).message });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text).then(() => setTokenSaved(true));
+  };
+
+  return (
+    <div className="int-form-section int-website-form">
+      {/* Endpoint URL */}
+      <div className="int-form-label">Receiver endpoint URL</div>
+      <input
+        className="int-field-input"
+        type="url"
+        placeholder="https://yoursite.com/api/forge/publish"
+        value={endpointUrl}
+        onChange={e => setEndpointUrl(e.target.value)}
+      />
+      <div className="int-utm-hint">Forge will POST article payloads here. Your site implements the receiver.</div>
+
+      {/* Format */}
+      <div className="int-form-label" style={{ marginTop: 16 }}>Payload format</div>
+      <div className="int-fields" style={{ flexDirection: 'row', gap: 16 }}>
+        {(['html', 'markdown', 'both'] as Format[]).map(f => (
+          <label key={f} style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+            <input type="radio" name="website-format" value={f} checked={format === f} onChange={() => setFormat(f)} />
+            <span style={{ textTransform: 'capitalize' }}>{f}</span>
+          </label>
+        ))}
+      </div>
+      <div className="int-utm-hint">
+        {format === 'html' && 'Payload will include only the rendered HTML body.'}
+        {format === 'markdown' && 'Payload will include only the source markdown.'}
+        {format === 'both' && 'Payload will include both html and markdown — receiver picks.'}
+      </div>
+
+      {/* Save config */}
+      <div style={{ marginTop: 16, display: 'flex', gap: 8 }}>
+        <button className="int-connect-btn" onClick={saveConfig} disabled={saving || !endpointUrl}>
+          {saving ? 'Saving…' : 'Save config'}
+        </button>
+      </div>
+
+      {/* Token section */}
+      <div className="int-form-label" style={{ marginTop: 24 }}>Bearer token</div>
+      {revealedToken ? (
+        <div style={{ background: '#1a1a1a', border: '1px solid #f59e0b', borderRadius: 8, padding: 16, marginTop: 8 }}>
+          <div style={{ color: '#f59e0b', fontWeight: 600, marginBottom: 8 }}>Save this now — you won't see it again</div>
+          <code style={{ display: 'block', wordBreak: 'break-all', background: '#0a0a0a', padding: 12, borderRadius: 4, fontSize: 13, color: '#e5e5e5' }}>{revealedToken}</code>
+          <div style={{ marginTop: 12, display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button className="int-connect-btn" onClick={() => copyToClipboard(revealedToken)}>
+              {tokenSaved ? 'Copied ✓' : 'Copy to clipboard'}
+            </button>
+            <button className="int-edit-btn" onClick={() => setRevealedToken(null)} disabled={!tokenSaved} title={tokenSaved ? 'Dismiss' : 'Copy the token first'}>
+              I saved it — dismiss
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          {hasToken ? <code style={{ fontSize: 13, color: '#888' }}>{maskedToken}</code> : <span style={{ color: '#888', fontSize: 13 }}>No token yet</span>}
+          <button className="int-connect-btn" onClick={generateToken} disabled={generating}>
+            {generating ? 'Generating…' : (hasToken ? 'Rotate token' : 'Generate token')}
+          </button>
+        </div>
+      )}
+
+      {/* Test publish */}
+      <div className="int-form-label" style={{ marginTop: 24 }}>Test publish</div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <button className="int-connect-btn" onClick={runTest} disabled={testing || !hasToken || !saved?.credentials?.endpointUrl}>
+          {testing ? 'Sending…' : 'Send test payload'}
+        </button>
+        <span className="int-utm-hint">Fires a sample article at your endpoint. Doesn't write to publish log.</span>
+      </div>
+      {testResult && (
+        <div style={{ marginTop: 12, padding: 12, background: testResult.ok ? '#0a2e0a' : '#2e0a0a', border: `1px solid ${testResult.ok ? '#16a34a' : '#dc2626'}`, borderRadius: 6, fontSize: 13 }}>
+          <div style={{ fontWeight: 600, color: testResult.ok ? '#16a34a' : '#dc2626', marginBottom: 4 }}>
+            {testResult.ok ? '✓ Receiver responded successfully' : '✗ Test failed'}
+          </div>
+          {testResult.status != null && <div>HTTP {testResult.status} · {testResult.latencyMs}ms</div>}
+          {testResult.error && <div style={{ color: '#fca5a5', marginTop: 4 }}>{testResult.error}</div>}
+          {testResult.responseBody && (
+            <details style={{ marginTop: 8 }}>
+              <summary style={{ cursor: 'pointer', color: '#aaa' }}>Response body</summary>
+              <pre style={{ background: '#0a0a0a', padding: 8, borderRadius: 4, marginTop: 6, overflow: 'auto', maxHeight: 200, fontSize: 12 }}>{testResult.responseBody}</pre>
+            </details>
+          )}
+        </div>
+      )}
+
+      {error && <div className="geo-error" style={{ marginTop: 12 }}>{error}</div>}
+    </div>
+  );
+}

--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { AppShell } from '../layouts/AppShell';
 import GateModal from '../components/GateModal';
 import { useApp } from '../context/AppContext';
+import MyWebsiteForm from '../components/MyWebsiteForm';
 import './IntegrationsPage.css';
 
 // ── Icons ────────────────────────────────────────────────────────────────────
@@ -80,7 +81,7 @@ function SetupGuide({ guide }: { guide: SetupGuide }) {
 }
 
 // ── Channel definitions ───────────────────────────────────────────────────────
-type ChannelId = 'wordpress' | 'webflow' | 'linkedin' | 'x' | 'facebook' | 'reddit' | 'medium' | 'ghost';
+type ChannelId = 'wordpress' | 'webflow' | 'linkedin' | 'x' | 'facebook' | 'reddit' | 'medium' | 'ghost' | 'website';
 
 interface ChannelDef {
   id: ChannelId;
@@ -263,6 +264,25 @@ const CHANNELS: ChannelDef[] = [
       ],
     },
   },
+  {
+    id: 'website',
+    label: 'My Website',
+    description: 'Publish Forge articles to your own self-hosted site via an authenticated webhook. Forge POSTs the article payload to an endpoint you control.',
+    color: '#6366F1',
+    logo: 'My',
+    liveStatus: 'live',
+    credentialFields: [],
+    setupGuide: {
+      title: 'Self-hosted webhook',
+      steps: [
+        { text: 'Add an authenticated POST endpoint to your site (e.g. /api/forge/publish). It accepts a JSON payload and validates the Authorization: Bearer header against a token you control.' },
+        { text: 'In this form, paste the full URL of that endpoint into the "Receiver endpoint URL" field, choose your preferred payload format (HTML, Markdown, or both), and click "Save config".' },
+        { text: 'Click "Generate token" to produce a Forge-issued bearer secret. It will be shown ONCE — copy it immediately. Put it in your server\'s environment as FORGE_BEARER_TOKEN (or equivalent) and use it to validate incoming requests.' },
+        { text: 'Click "Send test payload" to fire a sample article at your endpoint. If your receiver returns 200 OK, you\'re live.' },
+        { text: 'See docs/MY_WEBSITE_INTEGRATION.md for the full payload schema and copy-paste receiver samples (Node/Express + Next.js + Postgres).' },
+      ],
+    },
+  },
 ];
 
 const DEFAULT_UTM: Record<ChannelId, Record<string, string>> = {
@@ -274,6 +294,7 @@ const DEFAULT_UTM: Record<ChannelId, Record<string, string>> = {
   reddit:    { utm_source: 'reddit',   utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
   medium:    { utm_source: 'medium',   utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
   ghost:     { utm_source: 'ghost',    utm_medium: 'blog',   utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
+  website:   { utm_source: 'website',  utm_medium: 'blog',   utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
 };
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -438,11 +459,11 @@ export default function IntegrationsPage() {
   
   const selectedBrand = activeBrand?.id || '';
   const [savedChannels, setSavedChannels] = useState<Record<ChannelId, SavedChannel | null>>({
-    wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, reddit: null, medium: null, ghost: null
+    wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, reddit: null, medium: null, ghost: null, website: null
   });
   const [expanded, setExpanded] = useState<ChannelId | null>(null);
   const [credentials, setCredentials] = useState<Record<ChannelId, Record<string, string>>>({
-    wordpress: {}, webflow: {}, linkedin: {}, x: {}, facebook: {}, reddit: {}, medium: {}, ghost: {}
+    wordpress: {}, webflow: {}, linkedin: {}, x: {}, facebook: {}, reddit: {}, medium: {}, ghost: {}, website: {}
   });
   const [utmTemplates, setUtmTemplates] = useState<Record<ChannelId, Record<string, string>>>(DEFAULT_UTM);
   const [saving, setSaving] = useState<ChannelId | null>(null);
@@ -469,7 +490,7 @@ export default function IntegrationsPage() {
       .then(d => {
         if (d.success) {
           const map: Record<ChannelId, SavedChannel | null> = {
-            wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, reddit: null, medium: null, ghost: null
+            wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, reddit: null, medium: null, ghost: null, website: null
           };
           for (const ch of d.channels) map[ch.channel as ChannelId] = ch;
           setSavedChannels(map);
@@ -804,8 +825,17 @@ export default function IntegrationsPage() {
                       />
                     )}
 
+                    {/* My Website — fully custom form (URL + format + generate token + test) */}
+                    {ch.id === 'website' && selectedBrand && (
+                      <MyWebsiteForm
+                        brandProfileId={selectedBrand}
+                        saved={saved as unknown as { credentials?: { endpointUrl?: string; format?: 'html' | 'markdown' | 'both'; bearerToken?: string }; is_active?: boolean; updated_at?: string } | null}
+                        onChange={() => loadChannels(selectedBrand)}
+                      />
+                    )}
+
                     {/* Manual credential fields for non-Pipedream, non-OAuth channels */}
-                    {!ch.oauthFlow && (
+                    {!ch.oauthFlow && ch.id !== 'website' && (
                       <div className="int-form-section">
                         <div className="int-form-label">
                           Credentials


### PR DESCRIPTION
## Why

User-requested feature: let customers publish Forge articles directly to their own self-hosted sites via an authenticated webhook. **Sandbox-GTM** is the guinea pig — they're on Render + Neon (same stack as Forge), so the DB-write receiver in the docs is the one they'll deploy.

## Architecture

Forge POSTs the article payload to a customer-configured endpoint with a Forge-issued bearer token:

```
POST https://customer-site.com/api/forge/publish
Authorization: Bearer forge_pub_<32 hex>
Content-Type: application/json

{
  "slug": "...",
  "title": "...",
  "excerpt": "...",
  "heroImageUrl": "...",
  "canonical": "...",
  "publishedAt": "...",
  "meta": { description, ogImage, utm },
  "html": "<article>...</article>",
  "markdown": "# ...\n\n## ..."
}
```

Customer's receiver decides what to do with it (DB upsert, filesystem write, trigger a rebuild — whatever fits their stack).

## Backend (server.js)

Four new admin/config endpoints + 1 publish-handler branch:

| Endpoint | Purpose |
|---|---|
| `POST /api/integrations/website/:brandProfileId/config` | Save `endpointUrl` + `format`. JSONB merge preserves token. |
| `POST /api/integrations/website/:brandProfileId/generate-token` | Generate / rotate `forge_pub_<32hex>`. Returns plaintext once. |
| `POST /api/integrations/website/:brandProfileId/test` | Fire sample payload at endpoint. Returns `{ok, status, latencyMs, responseBody}`. No publish_log write. |
| `DELETE /api/integrations/website/:brandProfileId` | Soft-disconnect (preserves creds). |

Publish handler branch for `channel === 'website'` sits between Ghost and the unknown-channel fallback. If the receiver returns JSON with a `url` field, it's used as `published_url` for the Publishing Queue's "View on site" link.

## Frontend

New `<MyWebsiteForm>` component:
- Endpoint URL input
- Format toggle (html / markdown / both)
- "Save config" button
- "Generate token" → reveals once with copy-to-clipboard + "I saved it" dismiss
- "Rotate token" with confirm dialog
- "Send test payload" + inline result panel (HTTP status / latency / response body)

Wired into `IntegrationsPage` via a special-case render path keyed on `ch.id === 'website'`. The existing `credentialFields` render is suppressed since we don't paste a token — Forge generates it.

## Documentation

`docs/MY_WEBSITE_INTEGRATION.md` ships copy-paste-ready receiver samples:

- **Node/Express + Postgres** (the Sandbox-GTM target — full DB upsert with timing-safe auth)
- **Next.js App Router** + `@vercel/postgres`
- **Filesystem write** for static-site rebuilds (with warning about serverless read-only runtimes)

Plus payload schema, env setup (`FORGE_BEARER_TOKEN`), `CREATE TABLE articles` schema, token rotation workflow, and a troubleshooting table.

## Sandbox-GTM rollout sequence

1. Merge this PR → Render redeploys Forge
2. In Forge UI: Brand Settings → Integrations → "My Website" tile
3. Enter `https://sandbox-gtm.com/api/forge/publish` + format `both` → Save
4. Generate token → copy it
5. In Sandbox-GTM's repo: paste the Node/Express receiver from the docs, run the `CREATE TABLE` migration, add `FORGE_BEARER_TOKEN` env var on Render, redeploy
6. Back in Forge: hit "Send test payload" → expect HTTP 200 + the response URL
7. Publish a real article to Sandbox-GTM via the Publishing Queue → confirm it appears in their articles table and renders on their site

## Test plan

- [ ] Render deploys cleanly (TypeScript passes, no new deps)
- [ ] Brand Settings → Integrations shows "My Website" tile (live status)
- [ ] Endpoint URL input persists to publishing_channels.credentials
- [ ] Generate token → shows plaintext once, masks afterward
- [ ] Rotate token → confirm dialog → new value generated
- [ ] Test publish without config → 400 error in UI
- [ ] Test publish with bogus URL → ERR_NAME_NOT_RESOLVED surfaced cleanly
- [ ] Test publish to a valid receiver → HTTP 200 + latency reported
- [ ] Actual publish via Publishing Queue writes to publish_log with channel='website'
- [ ] Receiver-returned `{ url }` shows up as `published_url`
- [ ] Disconnect → channel marked inactive; reconnect preserves creds

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_