### PR TITLE
fix(publishing-queue): surface 'website' channel in publish-to selector

### DIFF
--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -123,6 +123,7 @@ const CHANNEL_LABELS: Record<string, { label: string; color: string }> = {
   reddit:    { label: 'Reddit',     color: '#FF4500' },
   medium:    { label: 'Medium',     color: '#A8A8A8' },
   ghost:     { label: 'Ghost',      color: '#738A94' },
+  website:   { label: 'My Website', color: '#6366F1' },
 };
 const ALL_CHANNELS = Object.keys(CHANNEL_LABELS);
 
@@ -464,7 +465,7 @@ export default function PublishingQueuePage() {
         .then(r => r.json())
         .then(d => {
           if (d.success) {
-            const PUBLISH_ONLY = ['wordpress','webflow','hubspot','linkedin','x','facebook','reddit','medium','ghost'];
+            const PUBLISH_ONLY = ['wordpress','webflow','hubspot','linkedin','x','facebook','reddit','medium','ghost','website'];
             setConnectedChannels(prev => ({
               ...prev,
               [bid]: d.channels.map((c: ConnectedChannel) => c.channel).filter((ch: string) => PUBLISH_ONLY.includes(ch))


### PR DESCRIPTION
## Why

#117 added the "My Website" channel everywhere except the Publishing Queue UI's chip selector — the channel was fully functional server-side, just invisible in the publish-to picker. Two-line wiring fix.

## What

`src/pages/PublishingQueuePage.tsx`:

1. `CHANNEL_LABELS` gets `website: { label: 'My Website', color: '#6366F1' }` (indigo matches the IntegrationsPage tile)
2. `PUBLISH_ONLY` whitelist (used to filter the connected-channels list down to actual publish destinations) gets `'website'` appended

## Test plan

- [ ] Render deploys
- [ ] Publishing Queue for a brand with My Website connected shows the **My Website** chip in the publish-to selector
- [ ] Picking it + Publish writes a `channel='website'` row to publish_log and POSTs to the customer's receiver

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_