### PR TITLE
fix(publishing/website): use metaDescription for excerpt to stop duplicate-paragraph render

### DIFF
--- a/server.js
+++ b/server.js
@@ -12125,7 +12125,14 @@ ${canonicalNote}`,
           const markdownContent = sections.map(s =>
             `${s.heading ? `## ${s.heading}\n\n` : ''}${s.body || s.content || ''}`
           ).join('\n\n');
-          const excerpt = (sections[0]?.body || sections[0]?.content || '').replace(/<[^>]+>/g, '').slice(0, 200);
+          // Prefer the article's own meta description for excerpt — it's the
+          // hand-curated short summary. Falls back to a slice of the first
+          // section body only when the description is missing. Without this
+          // preference, receivers that render `excerpt` as a subtitle/lead
+          // end up showing the first paragraph twice (once as subtitle,
+          // once as the opening body paragraph).
+          const excerpt = (articleJson.metaDescription || '').trim()
+            || (sections[0]?.body || sections[0]?.content || '').replace(/<[^>]+>/g, '').slice(0, 200);
 
           const payload = {
             slug: articleSlug,
@@ -12135,7 +12142,7 @@ ${canonicalNote}`,
             canonical: `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`,
             publishedAt: new Date().toISOString(),
             meta: {
-              description: articleJson.meta_description || excerpt,
+              description: articleJson.metaDescription || excerpt,
               ogImage: article.hero_image_url || articleJson.hero_image_url || null,
               utm: utmParams,
             },


### PR DESCRIPTION
## Symptom

Test publish to Sandbox-GTM landed cleanly (publish-side handshake worked) but the rendered article showed **the same opening paragraph twice** — once as a subtitle/lead and once at the start of the body. Confirmed visually in the side-by-side: Forge's own article view shows the meta description as the lead ("Learn how to build an audit-ready..."), but Sandbox-GTM's view showed the first body paragraph ("The quarterly pipeline review is three days away...") in both slots.

## Root cause

Two bugs in the `channel === 'website'` publish handler:

**1.** `excerpt` was derived from a 200-char slice of the first section body:

```js
const excerpt = (sections[0]?.body || ...).slice(0, 200);
```

That's identical content to the body's opening — receivers that render `excerpt` as a subtitle/lead end up showing the same paragraph twice.

**2.** `meta.description` was reading `articleJson.meta_description` (snake_case) but the actual field on `article_json` is `metaDescription` (camelCase, per `server.js:1018, 9563, 16544`). So `meta.description` was always falling through to `excerpt`.

## Fix

```js
const excerpt = (articleJson.metaDescription || '').trim()
  || (sections[0]?.body || ...).slice(0, 200);   // fallback only when missing

meta: {
  description: articleJson.metaDescription || excerpt,  // camelCase
  ...
}
```

Payload shape now matches what Forge's own article view shows: title → `metaDescription` as lead → hero → body. Receivers that render excerpt and body separately stop duplicating the opening paragraph.

## Test plan

- [ ] Render deploys
- [ ] Re-publish the same Sandbox-GTM article via My Website
- [ ] Sandbox-GTM render should show metaDescription as lead (different content from body opening), then hero, then body — no duplication

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_