### PR TITLE
fix(publishing): respect brand.article_base_url across FB / Reddit / Medium / My Website

### DIFF
--- a/server.js
+++ b/server.js
@@ -11680,7 +11680,7 @@ Output only the post text.` }]
 
           // ── Priority 0: Zernio publish path ──
           if (creds.zernioAccountId) {
-            const articleUrl = `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`;
+            const articleUrl = forgeArticleUrl;
             const utmUrl = `${articleUrl}${utmString ? '?' + utmString : ''}`;
             const fbPostCopyOverride = (req.body.postCopy || {})[channel];
             let fbMessage;
@@ -11745,7 +11745,7 @@ Output only the post text.` }]
           // existing Connect flow when the customer authorized Pipedream's pre-approved app).
           const pipedreamWorkflowUrl = process.env.FACEBOOK_PIPEDREAM_WORKFLOW_URL;
           if (pipedreamWorkflowUrl && pipedreamAccountId) {
-            const articleUrlWf = `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`;
+            const articleUrlWf = forgeArticleUrl;
             const utmUrlWf = `${articleUrlWf}${utmString ? '?' + utmString : ''}`;
             const fbPostCopyOverrideWf = (req.body.postCopy || {})[channel];
             let fbMessageWf;
@@ -11799,7 +11799,7 @@ Output only the post text.` }]
 
           // Legacy path: pipedreamProxy via Pipedream Connect (existing infrastructure) — falls through if no workflow URL.
                     
-          const articleUrl = `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`;
+          const articleUrl = forgeArticleUrl;
           const utmUrl = `${articleUrl}${utmString ? '?' + utmString : ''}`;
 
           // Priority 1: user-edited/generated post copy from the UI.
@@ -11906,7 +11906,7 @@ Output only the post text.` }]
             throw new Error(`Subreddit '${requestedSub}' is not in your allowed list. Add it under Integrations → Reddit → Allowed subreddits before publishing.`);
           }
 
-          const articleUrl = `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`;
+          const articleUrl = forgeArticleUrl;
           const utmUrl = `${articleUrl}${utmString ? '?' + utmString : ''}`;
 
           // For Reddit link posts, `content` is the post TITLE (not a body). Reddit titles
@@ -12009,7 +12009,7 @@ Output only the post text.` }]
           const authorId = meData.data?.id;
           if (!authorId) throw new Error('Could not retrieve Medium author ID');
 
-          const articleUrl = `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`;
+          const articleUrl = forgeArticleUrl;
           const utmUrl = `${articleUrl}${utmString ? '?' + utmString : ''}`;
 
           // Build HTML content from article sections
@@ -12139,7 +12139,7 @@ ${canonicalNote}`,
             title: article.title,
             excerpt,
             heroImageUrl: article.hero_image_url || articleJson.hero_image_url || null,
-            canonical: `https://${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}/articles/${brandSlug}/${articleSlug}`,
+            canonical: forgeArticleUrl,
             publishedAt: new Date().toISOString(),
             meta: {
               description: articleJson.metaDescription || excerpt,


### PR DESCRIPTION
## Symptom

Facebook posts for Sandbox-GTM are linking to `forgeintelligence.ai/articles/sandbox-gtm-com/...` instead of the brand's configured **Article Base URL** in Brand Settings (`sandbox-gtm.com/the-sandbox/...`). Wrong domain, wrong UTM destination for the customer's analytics, broken brand consistency.

## Root cause

A brand-aware `forgeArticleUrl` is already computed once at the top of the publish loop (`server.js:11201-11205`):

```js
const articleBaseUrl = brand.article_base_url
  ? brand.article_base_url.replace(/\/+$/, '')
  : `https://${articleBaseDomain}/articles/${brandSlug}`;
const articleUrlSuffix = (brand.article_url_suffix || '').trim();
const forgeArticleUrl = `${articleBaseUrl}/${articleSlug}${articleUrlSuffix}`;
```

LinkedIn and X use it. Five later-added channels + the My Website canonical field re-derive the URL from scratch from `BASE_DOMAIN`, ignoring `article_base_url` AND `article_url_suffix`:

| Channel | Site |
|---|---|
| Facebook (Zernio) | `server.js:11683` |
| Facebook (Pipedream workflow) | `server.js:11748` |
| Facebook (Pipedream legacy) | `server.js:11802` |
| Reddit (Zernio) | `server.js:11909` |
| Medium | `server.js:12012` |
| My Website (`canonical` field) | `server.js:12142` |

## Fix

Single string replace_all — every one of those sites now references `forgeArticleUrl`. Zero behavior change for brands without `article_base_url` (fallback path produces the same URL as the old hand-built one); correct behavior for brands with one.

For **My Website** specifically: the `canonical` we send in the webhook payload now points to where the article actually lives on the customer's domain — important for SEO since the receiver inserts the article into the customer's own articles table.

## Test plan

- [ ] Render deploys
- [ ] Sandbox-GTM Facebook publish — confirm the URL in the post body is `sandbox-gtm.com/the-sandbox/<slug>`, not `forgeintelligence.ai/articles/sandbox-gtm-com/...`
- [ ] Sandbox-GTM My Website publish — `canonical` in the payload received by Sandbox-GTM's receiver matches their `article_base_url`
- [ ] Regression: a brand with **no** `article_base_url` set still publishes with the Forge-hosted URL (fallback path unchanged)
- [ ] Regression: Reddit + Medium posts (if anyone uses them) also pick up the brand URL

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_