### PR TITLE
fix(integrations): surface docs link in My Website form

### DIFF
--- a/src/components/MyWebsiteForm.tsx
+++ b/src/components/MyWebsiteForm.tsx
@@ -98,6 +98,39 @@ export default function MyWebsiteForm({ brandProfileId, saved, onChange }: MyWeb
 
   return (
     <div className="int-form-section int-website-form">
+      {/* Docs callout — prominent because this integration requires the
+          customer to implement a receiver on their side, and they need
+          the payload schema + sample code to do it right. */}
+      <div style={{
+        padding: '10px 14px',
+        background: '#1a1a2e',
+        border: '1px solid #2a2a4a',
+        borderRadius: 6,
+        marginBottom: 20,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        fontSize: 13,
+      }}>
+        <span style={{ color: '#aaa' }}>
+          Setting this up requires implementing a receiver on your site.
+        </span>
+        <a
+          href="/docs/my-website"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            color: '#6366F1',
+            textDecoration: 'none',
+            fontWeight: 600,
+            whiteSpace: 'nowrap',
+            borderBottom: '1px solid rgba(99, 102, 241, 0.4)',
+          }}
+        >
+          Read the docs →
+        </a>
+      </div>
+
       {/* Endpoint URL */}
       <div className="int-form-label">Receiver endpoint URL</div>
       <input


### PR DESCRIPTION
## Why

The setup-guide step that linked to `/docs/my-website` never rendered. The `SetupGuide` tooltip is embedded inside the standard `credentialFields` form section, which is suppressed for the website channel (`ch.id !== 'website'`) because website has its own custom MyWebsiteForm. Net effect: the docs link the customer needs to wire up their receiver was invisible.

## Fix

Drop a prominent docs callout at the top of MyWebsiteForm:

```
┌─────────────────────────────────────────────────────────────┐
│ Setting this up requires implementing a receiver on your    │
│ site.                                  [ Read the docs → ]  │
└─────────────────────────────────────────────────────────────┘
```

Indigo accent matching the rest of the docs / brand styling. Opens `/docs/my-website` in a new tab. Sits above the endpoint URL field so it's the first thing a user sees when they expand the tile.

## Test plan

- [ ] Render deploys
- [ ] Brand Settings → Integrations → My Website → expand → docs callout visible at top
- [ ] Clicking "Read the docs →" opens `/docs/my-website` in a new tab

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_