### PR TITLE
fix(brand-settings): surface default article hosting behavior

### DIFF
--- a/src/pages/BrandSettingsPage.tsx
+++ b/src/pages/BrandSettingsPage.tsx
@@ -767,12 +767,49 @@ export default function BrandSettingsPage() {
                   <h2 className="bs-section-title">Publishing</h2>
                   <p className="bs-section-sub">Configure where your articles live and how URLs are built.</p>
                 </div>
+
+                {/* Hosting destinations callout — surfaces the default (Forge-
+                    hosted) behavior up front so users aren't surprised when
+                    articles publish to forgeintelligence.ai/articles/<brand>
+                    after they expected to see them on their own domain. */}
+                <div style={{
+                  background: '#1a1a2e',
+                  border: '1px solid #2a2a4a',
+                  borderRadius: 8,
+                  padding: '14px 16px',
+                  marginBottom: 20,
+                  fontSize: 13.5,
+                  lineHeight: 1.55,
+                  color: '#cfcfcf',
+                }}>
+                  <div style={{ fontWeight: 600, color: '#fff', marginBottom: 6 }}>Where will my articles live?</div>
+                  <p style={{ margin: '0 0 8px' }}>
+                    <strong style={{ color: '#fff' }}>By default, Forge hosts your articles</strong> at{' '}
+                    <code style={{ background: '#0a0a0a', padding: '2px 5px', borderRadius: 3, fontSize: 12, color: '#f59e0b' }}>
+                      forgeintelligence.ai/articles/&lt;brand&gt;/&lt;slug&gt;
+                    </code>
+                    . That's the destination if both fields below are blank and you haven't connected the My Website integration.
+                  </p>
+                  <p style={{ margin: '6px 0 4px', color: '#aaa' }}>Two ways to host on your own domain instead:</p>
+                  <ol style={{ margin: '4px 0 0', paddingLeft: 20 }}>
+                    <li style={{ marginBottom: 4 }}>
+                      <strong style={{ color: '#fff' }}>Set Article Base URL below.</strong> Forge still hosts the article HTML, but every URL we publish (canonical tags, social posts, UTM destinations) uses your domain. You configure a redirect or reverse-proxy on your side to serve the Forge-hosted content.
+                    </li>
+                    <li>
+                      <strong style={{ color: '#fff' }}>Connect the My Website integration.</strong> Forge pushes the article payload to a receiver on your site; you store and render it natively — no proxy needed.{' '}
+                      <a href="/docs/my-website" target="_blank" rel="noopener noreferrer" style={{ color: '#6366F1', textDecoration: 'none', borderBottom: '1px solid rgba(99,102,241,0.4)' }}>
+                        Docs →
+                      </a>
+                    </li>
+                  </ol>
+                </div>
+
                 <div className="bs-fields">
                   <div className="bs-field">
                     <label className="bs-label">Article Base URL <span className="bs-optional">BYO domain</span></label>
                     <input className="bs-input" value={form.article_base_url || ''} onChange={e => set('article_base_url', e.target.value)} placeholder="https://yoursite.com/articles" />
                     <span className="bs-field-hint">
-                      Leave blank to use Forge-hosted article pages at <code>forgeintelligence.ai/articles</code>.
+                      Leave blank to publish to Forge-hosted article pages at <code>forgeintelligence.ai/articles</code>.
                       Set this to your own domain and Forge will build all article URLs, UTM links, and canonical tags using it.
                     </span>
                   </div>


### PR DESCRIPTION
## Why

Users could publish for weeks without realizing that with no Article Base URL and no My Website integration connected, their articles land on `forgeintelligence.ai/articles/<brand>/<slug>` rather than their own domain. The existing field hint mentioned the default destination but buried it under the BYO-domain framing — easy to skim past.

## Fix

Adds a "Where will my articles live?" callout above the Article Base URL field that:

1. **States the Forge-hosted default explicitly**, with the literal URL shape so users know exactly what to expect
2. **Names the two ways to host on their own domain instead:**
   - Set Article Base URL (canonical/proxy approach, Forge still hosts the HTML but URLs point to your domain)
   - Connect My Website (Forge pushes payload to your receiver, you host natively — no proxy needed)
3. **Links to `/docs/my-website`** for the self-host path

Indigo-on-dark callout matching the MyWebsiteForm docs callout for visual consistency. Sits between the section header and the form fields so it's read before anyone fills in (or skips) the field.

Also tightened the field hint text — `"Leave blank to publish to..."` (active) instead of `"Leave blank to use..."` (passive).

## Test plan

- [ ] Render deploys
- [ ] Brand Settings → Publishing section shows the callout above the Article Base URL field
- [ ] Callout lists both paths, "Docs →" link in path 2 opens `/docs/my-website` in new tab
- [ ] Existing brands with `article_base_url` set still see the callout (it's always shown, not conditional — by design, so they know what blanking the field would do)

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_