### PR TITLE
fix(brand-settings): callout now matches light theme via CSS variables

### DIFF
--- a/src/pages/BrandSettingsPage.tsx
+++ b/src/pages/BrandSettingsPage.tsx
@@ -771,33 +771,37 @@ export default function BrandSettingsPage() {
                 {/* Hosting destinations callout — surfaces the default (Forge-
                     hosted) behavior up front so users aren't surprised when
                     articles publish to forgeintelligence.ai/articles/<brand>
-                    after they expected to see them on their own domain. */}
+                    after they expected to see them on their own domain.
+                    Uses theme CSS vars so it matches Brand Settings' light
+                    palette instead of fighting it. */}
                 <div style={{
-                  background: '#1a1a2e',
-                  border: '1px solid #2a2a4a',
-                  borderRadius: 8,
+                  background: 'var(--color-accent-muted)',
+                  border: '1px solid var(--color-border-subtle)',
+                  borderRadius: 'var(--radius-md, 8px)',
                   padding: '14px 16px',
                   marginBottom: 20,
                   fontSize: 13.5,
                   lineHeight: 1.55,
-                  color: '#cfcfcf',
+                  color: 'var(--color-text-secondary)',
                 }}>
-                  <div style={{ fontWeight: 600, color: '#fff', marginBottom: 6 }}>Where will my articles live?</div>
+                  <div style={{ fontWeight: 600, color: 'var(--color-text-emphasis)', marginBottom: 6 }}>
+                    Where will my articles live?
+                  </div>
                   <p style={{ margin: '0 0 8px' }}>
-                    <strong style={{ color: '#fff' }}>By default, Forge hosts your articles</strong> at{' '}
-                    <code style={{ background: '#0a0a0a', padding: '2px 5px', borderRadius: 3, fontSize: 12, color: '#f59e0b' }}>
+                    <strong style={{ color: 'var(--color-text-emphasis)' }}>By default, Forge hosts your articles</strong> at{' '}
+                    <code style={{ background: 'var(--color-bg-elevated)', padding: '2px 5px', borderRadius: 3, fontSize: 12, color: 'var(--color-accent)' }}>
                       forgeintelligence.ai/articles/&lt;brand&gt;/&lt;slug&gt;
                     </code>
                     . That's the destination if both fields below are blank and you haven't connected the My Website integration.
                   </p>
-                  <p style={{ margin: '6px 0 4px', color: '#aaa' }}>Two ways to host on your own domain instead:</p>
+                  <p style={{ margin: '6px 0 4px', color: 'var(--color-text-muted)' }}>Two ways to host on your own domain instead:</p>
                   <ol style={{ margin: '4px 0 0', paddingLeft: 20 }}>
                     <li style={{ marginBottom: 4 }}>
-                      <strong style={{ color: '#fff' }}>Set Article Base URL below.</strong> Forge still hosts the article HTML, but every URL we publish (canonical tags, social posts, UTM destinations) uses your domain. You configure a redirect or reverse-proxy on your side to serve the Forge-hosted content.
+                      <strong style={{ color: 'var(--color-text-emphasis)' }}>Set Article Base URL below.</strong> Forge still hosts the article HTML, but every URL we publish (canonical tags, social posts, UTM destinations) uses your domain. You configure a redirect or reverse-proxy on your side to serve the Forge-hosted content.
                     </li>
                     <li>
-                      <strong style={{ color: '#fff' }}>Connect the My Website integration.</strong> Forge pushes the article payload to a receiver on your site; you store and render it natively — no proxy needed.{' '}
-                      <a href="/docs/my-website" target="_blank" rel="noopener noreferrer" style={{ color: '#6366F1', textDecoration: 'none', borderBottom: '1px solid rgba(99,102,241,0.4)' }}>
+                      <strong style={{ color: 'var(--color-text-emphasis)' }}>Connect the My Website integration.</strong> Forge pushes the article payload to a receiver on your site; you store and render it natively — no proxy needed.{' '}
+                      <a href="/docs/my-website" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--color-accent)', textDecoration: 'none', borderBottom: '1px solid var(--color-accent-muted)', fontWeight: 600 }}>
                         Docs →
                       </a>
                     </li>


### PR DESCRIPTION
## Why

The hosting-destinations callout I added in #123 was styled with hardcoded **dark** colors (`#1a1a2e` bg, white text) — but Brand Settings is a **light** theme (white cards on lavender). Result: a dark indigo brick sitting inside a light page. Visually broken, even though the layout itself was correct.

## Fix

Swap every hardcoded color for the theme CSS variables already defined in `src/index.css`:

| Hardcoded | Variable |
|---|---|
| `#1a1a2e` (bg) | `var(--color-accent-muted)` (soft blue tint) |
| `#2a2a4a` (border) | `var(--color-border-subtle)` |
| `#fff` (titles, strong) | `var(--color-text-emphasis)` |
| `#cfcfcf` (body) | `var(--color-text-secondary)` |
| `#aaa` (sub label) | `var(--color-text-muted)` |
| `#f59e0b` (inline code) | `var(--color-accent)` |
| `#6366F1` (link) | `var(--color-accent)` |
| `rgba(99,102,241,0.4)` (underline) | `var(--color-accent-muted)` |

The callout now reads as part of the page rather than fighting it, and it'll auto-flip if the app ever ships a dark-mode variant that swaps the same variables.

## Test plan

- [ ] Render deploys
- [ ] Brand Settings → Publishing — callout now uses the page's light palette (soft blue tint bg, dark text, blue accent link)

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_