### PR TITLE
fix(brand-settings): wrap long URLs in callout to restore mobile padding

### DIFF
--- a/src/pages/BrandSettingsPage.css
+++ b/src/pages/BrandSettingsPage.css
@@ -177,6 +177,7 @@
   padding: 1px 5px;
   border-radius: 3px;
   color: var(--color-accent);
+  word-break: break-all;
 }
 
 /* URL preview */

--- a/src/pages/BrandSettingsPage.tsx
+++ b/src/pages/BrandSettingsPage.tsx
@@ -789,7 +789,7 @@ export default function BrandSettingsPage() {
                   </div>
                   <p style={{ margin: '0 0 8px' }}>
                     <strong style={{ color: 'var(--color-text-emphasis)' }}>By default, Forge hosts your articles</strong> at{' '}
-                    <code style={{ background: 'var(--color-bg-elevated)', padding: '2px 5px', borderRadius: 3, fontSize: 12, color: 'var(--color-accent)' }}>
+                    <code style={{ background: 'var(--color-bg-elevated)', padding: '2px 5px', borderRadius: 3, fontSize: 12, color: 'var(--color-accent)', wordBreak: 'break-all' }}>
                       forgeintelligence.ai/articles/&lt;brand&gt;/&lt;slug&gt;
                     </code>
                     . That's the destination if both fields below are blank and you haven't connected the My Website integration.


### PR DESCRIPTION
## Why

User reported the right side of every Brand Settings card had no padding on mobile after #123 — Save Changes button + all section cards bleeding to the screen edge.

## Root cause

The inline `<code>` element in my hosting callout contains an unbreakable URL:

```
forgeintelligence.ai/<brand>/<slug>
```

On a narrow viewport that string is wider than the card. With no `word-break` rule the URL forced the card to expand past the viewport. `.app-content` has `overflow-x: hidden`, so the overflow got **clipped** — making every card AND the flex-end Save Changes button appear to lose their right padding.

(The existing `.bs-url-preview-value` rule lower in the page already had `word-break: break-all`. My new callout's code was the only spot the long URL wasn't wrapped.)

## Fix

1. **Inline style** on the callout's URL code: `wordBreak: 'break-all'` so the URL wraps mid-string when space is tight
2. **CSS rule** for `.bs-field-hint code`: added `word-break: break-all` as belt-and-suspenders for any other long URL that ends up in a field hint later (currently just `forgeintelligence.ai/articles` which fits, but trivial to add a longer one and re-trip the bug)

## Test plan

- [ ] Render deploys
- [ ] Brand Settings on mobile: cards have right padding restored, Save Changes button sits within the page, callout URL wraps cleanly
- [ ] Brand Settings on desktop: callout URL still on one line (won't fit a break since `break-all` only kicks in when needed)

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_