### PR TITLE
fix(publishing-queue): show Reconnect link for auth-expired errors

### DIFF
--- a/src/pages/PublishingQueuePage.css
+++ b/src/pages/PublishingQueuePage.css
@@ -2145,6 +2145,22 @@
 .pq-retry-btn:hover { background: rgba(239,68,68,0.2); border-color: #EF4444; }
 .pq-retry-btn:disabled { opacity: 0.4; cursor: default; }
 
+/* Reconnect variant — fired when a publish error is auth-expired. Uses
+   amber instead of red because the action required is different
+   (re-authorize in Integrations, not "try again here"). Renders as a
+   link, not a button, since it navigates. */
+a.pq-retry-btn.pq-reconnect-btn {
+  display: inline-block;
+  background: rgba(245,158,11,0.12);
+  color: #F59E0B;
+  border-color: rgba(245,158,11,0.35);
+  text-decoration: none;
+}
+a.pq-retry-btn.pq-reconnect-btn:hover {
+  background: rgba(245,158,11,0.22);
+  border-color: #F59E0B;
+}
+
 /* ── Reviewer Dropdown ───────────────────────────────────────────────────── */
 .pq-reviewer-dropdown {
   position: absolute;

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -226,7 +226,7 @@ export default function PublishingQueuePage() {
   const [brandSettings, setBrandSettings] = useState<Record<string, { article_base_url?: string; article_url_suffix?: string; settings?: { siteTemplate?: any } }>>({});
   const [exportTab, setExportTab] = useState<'html' | 'markdown' | 'json' | 'link'>('html');
   const [copied, setCopied] = useState<string>('');
-  const [publishLog, setPublishLog] = useState<Record<string, { channel: string; live_status: string; published_url?: string; last_synced_at?: string }[]>>({});
+  const [publishLog, setPublishLog] = useState<Record<string, { channel: string; live_status: string; published_url?: string; last_synced_at?: string; error_message?: string }[]>>({});
   const [syncing, setSyncing] = useState<string | null>(null);
   const [republishing, setRepublishing] = useState<string | null>(null);
   const [reviewers, setReviewers] = useState<{id:string;name:string;email:string;title:string}[]>([]);
@@ -1623,16 +1623,44 @@ ${authorFooterHtml}
                               {republishing === repKey ? 'Republishing...' : '↺ Republish'}
                             </button>
                           )}
-                          {(res.status === 'error' || liveStatus === 'error') && (
-                            <button
-                              className="pq-retry-btn"
-                              onClick={() => handleRetry(item.id, ch)}
-                              disabled={republishing === repKey}
-                              title="Clear error and retry"
-                            >
-                              {republishing === repKey ? 'Resetting...' : '↺ Reset & Retry'}
-                            </button>
-                          )}
+                          {(res.status === 'error' || liveStatus === 'error') && (() => {
+                            // Auth-expired errors thrown by the publish handlers
+                            // ("X authentication expired. Please reconnect X in
+                            // Integrations." etc.) need a Reconnect link, not a
+                            // Reset & Retry button — retrying without fresh
+                            // credentials will fail the same way.
+                            const localLog = (publishLog[item.id] || []).find(l => l.channel === ch);
+                            const errMsg = localLog?.error_message || res.error || '';
+                            const isAuthError = /authentication expired|reconnect/i.test(errMsg);
+                            const label = CHANNEL_LABELS[ch]?.label || ch;
+                            if (isAuthError) {
+                              return (
+                                <>
+                                  <a className="pq-retry-btn pq-reconnect-btn" href="/app/integrations">
+                                    Reconnect {label} →
+                                  </a>
+                                  <span className="pq-result-error">Your {label} connection expired. Reconnect to publish.</span>
+                                </>
+                              );
+                            }
+                            return (
+                              <>
+                                <button
+                                  className="pq-retry-btn"
+                                  onClick={() => handleRetry(item.id, ch)}
+                                  disabled={republishing === repKey}
+                                  title="Clear error and retry"
+                                >
+                                  {republishing === repKey ? 'Resetting...' : '↺ Reset & Retry'}
+                                </button>
+                                {errMsg && (
+                                  <span className="pq-result-error" title={errMsg}>
+                                    {errMsg.length > 120 ? errMsg.slice(0, 120) + '…' : errMsg}
+                                  </span>
+                                )}
+                              </>
+                            );
+                          })()}
                           {res.error && liveStatus !== 'error' && liveStatus !== 'published' && <span className="pq-result-error">{res.error}</span>}
                           {res.message && liveStatus !== 'published' && !res.skipped && <span className="pq-result-msg">{res.message}</span>}
                         </div>
@@ -1971,16 +1999,44 @@ return (
                               {republishing === repKey ? 'Republishing...' : '↺ Republish'}
                             </button>
                           )}
-                          {(res.status === 'error' || liveStatus === 'error') && (
-                            <button
-                              className="pq-retry-btn"
-                              onClick={() => handleRetry(item.id, ch)}
-                              disabled={republishing === repKey}
-                              title="Clear error and retry"
-                            >
-                              {republishing === repKey ? 'Resetting...' : '↺ Reset & Retry'}
-                            </button>
-                          )}
+                          {(res.status === 'error' || liveStatus === 'error') && (() => {
+                            // Auth-expired errors thrown by the publish handlers
+                            // ("X authentication expired. Please reconnect X in
+                            // Integrations." etc.) need a Reconnect link, not a
+                            // Reset & Retry button — retrying without fresh
+                            // credentials will fail the same way.
+                            const localLog = (publishLog[item.id] || []).find(l => l.channel === ch);
+                            const errMsg = localLog?.error_message || res.error || '';
+                            const isAuthError = /authentication expired|reconnect/i.test(errMsg);
+                            const label = CHANNEL_LABELS[ch]?.label || ch;
+                            if (isAuthError) {
+                              return (
+                                <>
+                                  <a className="pq-retry-btn pq-reconnect-btn" href="/app/integrations">
+                                    Reconnect {label} →
+                                  </a>
+                                  <span className="pq-result-error">Your {label} connection expired. Reconnect to publish.</span>
+                                </>
+                              );
+                            }
+                            return (
+                              <>
+                                <button
+                                  className="pq-retry-btn"
+                                  onClick={() => handleRetry(item.id, ch)}
+                                  disabled={republishing === repKey}
+                                  title="Clear error and retry"
+                                >
+                                  {republishing === repKey ? 'Resetting...' : '↺ Reset & Retry'}
+                                </button>
+                                {errMsg && (
+                                  <span className="pq-result-error" title={errMsg}>
+                                    {errMsg.length > 120 ? errMsg.slice(0, 120) + '…' : errMsg}
+                                  </span>
+                                )}
+                              </>
+                            );
+                          })()}
                           {res.error && liveStatus !== 'error' && liveStatus !== 'published' && <span className="pq-result-error">{res.error}</span>}
                           {res.message && liveStatus !== 'published' && !res.skipped && <span className="pq-result-msg">{res.message}</span>}
                         </div>


### PR DESCRIPTION
## Symptom

When a publish fails because the platform's OAuth token expired (Render logs):

```
[X] Token refresh failed: Value passed for the token was invalid.
[X] Cleared expired tokens for brand dd482396-... — user must reconnect
```

…the UI only shows a "↺ Reset & Retry" button. Clicking it doesn't help — the server has already cleared the credentials, so retrying lands at the same wall. The user has no signal that they need to **disconnect + reconnect in Integrations**.

## Root cause

Server-side publish handlers already throw a clean message in this case:

```js
throw new Error('X authentication expired. Please reconnect X in Integrations.');
```

Two frontend bugs kept it from the user:

1. **`publishLog` state type omitted `error_message`** — `/api/publishing/log` returns it (`server.js:1259`) but the React state interface dropped the field. So even when present, it was lost on assignment.
2. **Error render shows the retry button unconditionally** — no detection of WHY the publish failed, no surfacing of the actual error text. (`liveStatus === 'error'` actually short-circuits the existing `res.error` display, which is why nothing showed.)

## Fix

| Condition | UI shows |
|---|---|
| `error_message` matches `/authentication expired\|reconnect/i` | **Amber "Reconnect <Channel> →"** link to `/app/integrations`, plus copy "Your <Channel> connection expired. Reconnect to publish." |
| Any other error | **Red "Reset & Retry"** button (existing behavior) **plus** the actual error_message text (truncated to 120 chars with full text in `title`) so the user finally sees what failed |

Applied at both render sites (campaigns view + standalone-items view). CSS adds a `.pq-reconnect-btn` amber variant to visually distinguish "this needs a different action" from generic retry.

## Test plan

- [ ] Render deploys
- [ ] Force an auth-expired error (revoke X via the platform settings, attempt to publish) — UI shows amber Reconnect link instead of red Reset & Retry
- [ ] Click the link → lands on `/app/integrations`
- [ ] Any non-auth error (network, 5xx, validation) still gets Reset & Retry plus the error_message text
- [ ] No regression for currently-failing X / LinkedIn / Facebook posts that aren't auth issues

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_