### PR TITLE
fix(x-oauth): migrate authorize + token endpoints from twitter.com → x.com

### DIFF
--- a/server.js
+++ b/server.js
@@ -9154,7 +9154,13 @@ app.get('/api/x/auth', requireAuth, (req, res) => {
   // With media.write, brands upload media + post tweets via their own OAuth 2.0 token,
   // eliminating the cross-account problem with system OAuth 1.0a creds.
   const scopes = ['tweet.write', 'tweet.read', 'users.read', 'offline.access', 'media.write'].join('%20');
-  const authUrl = `https://twitter.com/i/oauth2/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${scopes}&state=${state}&code_challenge=${codeChallenge}&code_challenge_method=S256`;
+  // X migrated the OAuth endpoints to x.com — the legacy twitter.com/i/oauth2/authorize
+  // still serves but chains through their domain-migration redirect, which breaks the
+  // session cookie set during login (cookie lands on one domain, next redirect targets
+  // the other → "to use this app you have to be logged in" infinite loop). Use the
+  // canonical x.com URL throughout the OAuth path. See:
+  //   https://developer.x.com/en/docs/authentication/oauth-2-0/authorization-code
+  const authUrl = `https://x.com/i/oauth2/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${scopes}&state=${state}&code_challenge=${codeChallenge}&code_challenge_method=S256`;
 
   res.json({ authUrl });
 });
@@ -9175,7 +9181,7 @@ app.get('/auth/x/callback', async (req, res) => {
 
   try {
     // Exchange code for tokens
-    const tokenRes = await fetch('https://api.twitter.com/2/oauth2/token', {
+    const tokenRes = await fetch('https://api.x.com/2/oauth2/token', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -9329,7 +9335,7 @@ async function uploadXMedia({ imageUrl, oauth2Token, oauth1Header, additionalOwn
 async function refreshXOAuth2Token(refreshToken) {
   const clientId = process.env.X_OAUTH2CLIENT_ID;
   const clientSecret = process.env.X_OAUTH2CLIENT_SECRET;
-  const tokenRes = await fetch('https://api.twitter.com/2/oauth2/token', {
+  const tokenRes = await fetch('https://api.x.com/2/oauth2/token', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## Symptom

User reported a hard infinite loop on Connect X — fresh browser, no cached cookies, successful Twitter login, then back to **"To use this App you have to be logged in to X."** Reproduced across multiple browser clears and a totally different browser entirely. Not a cookie / account-state issue.

## Root cause

Forge was building the OAuth authorize URL against `twitter.com/i/oauth2/authorize` and the token exchange against `api.twitter.com/2/oauth2/token`. **X has migrated those to `x.com`.**

The legacy `twitter.com` URLs still respond, but Twitter chains them through a domain-migration redirect — which breaks the session cookie set during login:

```
1. Forge → twitter.com/i/oauth2/authorize?...
2. twitter.com → 301 → x.com/i/oauth2/authorize?...
3. x.com authorize: no x.com session cookie → redirect to login
4. User logs in — cookie lands on x.com (or twitter.com, depending on the redirect chain)
5. Login flow returns to the URL it was originally called from (twitter.com)
6. twitter.com → 301 → x.com authorize again
7. x.com authorize: still no compatible session cookie → "login required" again
8. Infinite loop
```

X's own docs example uses `x.com` directly — that's the canonical path now:
https://developer.x.com/en/docs/authentication/oauth-2-0/authorization-code

## Fix

Three URL swaps, OAuth path only:

| File:Line | Before | After |
|---|---|---|
| `server.js:9163` | `twitter.com/i/oauth2/authorize` | `x.com/i/oauth2/authorize` |
| `server.js:9184` | `api.twitter.com/2/oauth2/token` (exchange) | `api.x.com/2/oauth2/token` |
| `server.js:9338` | `api.twitter.com/2/oauth2/token` (refresh) | `api.x.com/2/oauth2/token` |

**NOT changed**: runtime API endpoints (`api.twitter.com/2/tweets`, `api.twitter.com/2/users/me`, `upload.twitter.com/1.1/media/upload.json`, etc.). These work today; the migration chain doesn't bite the same way for stateless API calls; scope-creeping the URL audit into a working flow is asking for trouble. Move them later if evidence shows they're broken.

## Test plan

- [ ] Render deploys
- [ ] User reopens a clean browser session, logs into the Forge Twitter account on x.com once
- [ ] Click Connect X in Forge Integrations → should land on X authorize screen first try → click Authorize → return to Forge with `?x_connected=true`
- [ ] Verify `publish_log` shows successful tweets from that account on next test publish

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_