### PR TITLE
feat(docs): Share With AI — copy or download docs as AI-ready markdown

### DIFF
--- a/src/pages/DocsPage.css
+++ b/src/pages/DocsPage.css
@@ -89,6 +89,78 @@
   color: #d4d4d4;
 }
 
+/* ── Share With AI bar ──────────────────────────────────────────────────── */
+.docs-share-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  margin-bottom: 28px;
+  background: rgba(99, 102, 241, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 8px;
+  font-size: 13.5px;
+}
+
+.docs-share-bar-text {
+  color: #c4c4c4;
+}
+.docs-share-bar-text strong {
+  color: #fff;
+  font-weight: 600;
+}
+
+.docs-share-bar-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.docs-share-btn {
+  background: #6366F1;
+  color: #fff;
+  border: 1px solid #6366F1;
+  border-radius: 5px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.12s ease, border-color 0.12s ease;
+  white-space: nowrap;
+}
+.docs-share-btn:hover {
+  background: #4f51d6;
+  border-color: #4f51d6;
+}
+
+.docs-share-btn.docs-share-btn-secondary {
+  background: transparent;
+  color: #c4c4c4;
+  border-color: rgba(99, 102, 241, 0.45);
+}
+.docs-share-btn.docs-share-btn-secondary:hover {
+  background: rgba(99, 102, 241, 0.14);
+  border-color: #6366F1;
+  color: #fff;
+}
+
+@media (max-width: 600px) {
+  .docs-share-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .docs-share-bar-actions {
+    width: 100%;
+  }
+  .docs-share-btn {
+    flex: 1;
+    text-align: center;
+  }
+}
+
 /* Typography */
 .docs-article h1 {
   font-size: 32px;

--- a/src/pages/DocsPage.tsx
+++ b/src/pages/DocsPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useParams, Link, Navigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -39,6 +40,7 @@ export default function DocsPage() {
       <Sidebar activeSlug={slug} />
       <main className="docs-main">
         <article className="docs-article">
+          <ShareWithAI doc={doc} />
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
@@ -110,5 +112,74 @@ function Sidebar({ activeSlug }: { activeSlug: string }) {
         })}
       </nav>
     </aside>
+  );
+}
+
+// "Share With AI" — downloads the doc's markdown source so users can paste
+// or attach it to Claude / ChatGPT / Cursor / etc. for help setting up the
+// integration on their own stack. Adds a small AI-context preamble at the
+// top so the receiving assistant has framing about what the doc is and how
+// to act on it.
+function ShareWithAI({ doc }: { doc: { slug: string; title: string; description: string; content: string } }) {
+  const [copied, setCopied] = useState(false);
+
+  const buildShareableMarkdown = () => {
+    const preamble = `<!--
+Source: Forge Intelligence — ${doc.title} integration documentation
+URL: https://forgeintelligence.ai/docs/${doc.slug}
+Description: ${doc.description}
+
+You are helping a user set up the Forge Intelligence "${doc.title}" integration on their own website / application. Read the documentation below carefully. When the user asks for help:
+
+1. Ask which stack they're on (Node/Express, Next.js, static site, etc.) if it's not obvious from context.
+2. Use the matching sample receiver below as the starting point.
+3. Walk them through the env var setup, database migration, and deployment.
+4. Verify their receiver returns 200 OK and includes the optional { url } JSON in the response so Forge can populate the "View on site" link.
+5. Help them debug if "Send test payload" in the Forge UI fails — start by checking auth, then endpoint URL, then response shape.
+
+The documentation:
+-->
+
+`;
+    return preamble + doc.content;
+  };
+
+  const downloadMarkdown = () => {
+    const blob = new Blob([buildShareableMarkdown()], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `forge-${doc.slug}-for-ai.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(buildShareableMarkdown());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API blocked — fall back to downloading
+      downloadMarkdown();
+    }
+  };
+
+  return (
+    <div className="docs-share-bar">
+      <div className="docs-share-bar-text">
+        <strong>Setting this up on your stack?</strong> Hand this doc to your AI assistant.
+      </div>
+      <div className="docs-share-bar-actions">
+        <button className="docs-share-btn" onClick={copyToClipboard}>
+          {copied ? '✓ Copied' : 'Copy for AI'}
+        </button>
+        <button className="docs-share-btn docs-share-btn-secondary" onClick={downloadMarkdown}>
+          Download .md
+        </button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Why

The My Website integration requires customers to **implement a receiver on their own server** — by far the highest-friction step in the setup. Right now the docs just sit on the page; customers either DIY through them or screenshot bits into ChatGPT and hope it makes sense.

This PR adds a one-click way to hand the doc to an AI assistant in a format that's actually useful — markdown + a framing preamble that tells the AI what it's looking at and how to act on it.

## What

Indigo callout bar at the top of every doc page:

```
┌──────────────────────────────────────────────────────────────────────┐
│ Setting this up on your stack?  Hand this doc to your AI assistant.  │
│                                       [ Copy for AI ] [ Download .md ] │
└──────────────────────────────────────────────────────────────────────┘
```

Both actions produce the **same payload**: the doc's raw markdown prefixed with a short HTML-comment preamble:

```markdown
<!--
Source: Forge Intelligence — My Website integration documentation
URL: https://forgeintelligence.ai/docs/my-website
Description: Publish Forge articles to your own self-hosted site via authenticated webhook.

You are helping a user set up the Forge Intelligence "My Website"
integration on their own website / application. Read the
documentation below carefully. When the user asks for help:

1. Ask which stack they're on (Node/Express, Next.js, static site, etc.).
2. Use the matching sample receiver below as the starting point.
3. Walk them through the env var setup, database migration, and deployment.
4. Verify their receiver returns 200 OK and includes the optional { url }
   JSON in the response so Forge can populate the "View on site" link.
5. Help them debug if "Send test payload" in the Forge UI fails — start
   by checking auth, then endpoint URL, then response shape.

The documentation:
-->

# My Website
...
```

- **Copy for AI** → clipboard. Falls back to download if the clipboard API is blocked.
- **Download .md** → downloads as `forge-my-website-for-ai.md`.

## Implementation

- New `<ShareWithAI doc={doc} />` component at the top of `<article>` in `DocsPage.tsx`
- Same component runs on **every doc** (not specific to My Website) — future Concepts / Reference entries get the treatment automatically
- No new deps (uses native `Blob` + `URL.createObjectURL` for download, `navigator.clipboard` for copy)
- Mobile: stacks vertically, buttons stretch to full width

## Test plan

- [ ] Render deploys
- [ ] Navigate to `/docs/my-website` — share bar visible at the top
- [ ] **Copy for AI** → paste somewhere, confirm preamble + body present
- [ ] **Download .md** → file lands with name `forge-my-website-for-ai.md`, opens with the same content
- [ ] Paste into Claude/ChatGPT: ask "help me set this up on Next.js" and confirm the AI uses the Next.js receiver sample correctly
- [ ] Mobile view: bar stacks, buttons fill width

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_