### PR TITLE
feat(alerts): topbar alerts bell + Get Help support form

### DIFF
--- a/init-schema.sql
+++ b/init-schema.sql
@@ -493,3 +493,39 @@ CREATE TABLE IF NOT EXISTS outreach_log (
   error_message TEXT,
   sent_at TIMESTAMPTZ DEFAULT NOW()
 );
+
+-- ── User Alerts & Support Tickets ────────────────────────────────────────────
+-- Surfaced through the topbar bell. Alerts are user-scoped (clerk_user_id).
+-- short_message is the only field shown to users; raw_message is admin-only.
+CREATE TABLE IF NOT EXISTS user_alerts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clerk_user_id TEXT NOT NULL,
+  brand_profile_id TEXT,
+  severity TEXT NOT NULL DEFAULT 'error',  -- 'error' | 'warn' | 'info'
+  area TEXT,                                -- e.g. 'content-generator', 'brand-profile'
+  short_message TEXT NOT NULL,              -- human-readable, capped ~200 chars
+  raw_message TEXT,                         -- truncated original, admin-only
+  http_status INT,
+  url TEXT,                                 -- page path where it happened
+  read_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_user_alerts_user_created
+  ON user_alerts (clerk_user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS support_tickets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clerk_user_id TEXT NOT NULL,
+  brand_profile_id TEXT,
+  user_email TEXT,
+  category TEXT,                            -- 'bug' | 'question' | 'feature' | 'other'
+  subject TEXT NOT NULL,
+  body TEXT NOT NULL,
+  attached_alert_ids JSONB DEFAULT '[]',
+  user_agent TEXT,
+  page_url TEXT,
+  status TEXT NOT NULL DEFAULT 'open',      -- 'open' | 'in_progress' | 'closed'
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_support_tickets_status_created
+  ON support_tickets (status, created_at DESC);

--- a/server.js
+++ b/server.js
@@ -864,6 +864,40 @@ async function initDB() {
     // Campaign analytics migrations
     await pool.query(`ALTER TABLE content_analytics ADD COLUMN IF NOT EXISTS campaign_id UUID`).catch(() => {});
     await pool.query(`ALTER TABLE publishing_queue ADD COLUMN IF NOT EXISTS campaign_id UUID`).catch(() => {});
+
+    // ── User Alerts & Support Tickets (topbar bell + Get Help form) ──
+    await pool.query(`CREATE TABLE IF NOT EXISTS user_alerts (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      clerk_user_id TEXT NOT NULL,
+      brand_profile_id TEXT,
+      severity TEXT NOT NULL DEFAULT 'error',
+      area TEXT,
+      short_message TEXT NOT NULL,
+      raw_message TEXT,
+      http_status INT,
+      url TEXT,
+      read_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_user_alerts_user_created
+      ON user_alerts (clerk_user_id, created_at DESC)`).catch(() => {});
+    await pool.query(`CREATE TABLE IF NOT EXISTS support_tickets (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      clerk_user_id TEXT NOT NULL,
+      brand_profile_id TEXT,
+      user_email TEXT,
+      category TEXT,
+      subject TEXT NOT NULL,
+      body TEXT NOT NULL,
+      attached_alert_ids JSONB DEFAULT '[]',
+      user_agent TEXT,
+      page_url TEXT,
+      status TEXT NOT NULL DEFAULT 'open',
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_support_tickets_status_created
+      ON support_tickets (status, created_at DESC)`).catch(() => {});
+    console.log('NeonDB: user_alerts + support_tickets tables ensured');
   } catch(e) { console.log('NeonDB: Brain tables note:', e.message); }
 
 
@@ -14955,6 +14989,261 @@ app.get('/api/admin/logs/recent', requireAuth, async (req, res) => {
 app.get('/api/admin/logs/errors', requireAuth, async (req, res) => {
   if (!SUPER_ADMIN_IDS.includes(req.userId)) return res.status(403).json({ error: 'Forbidden' });
   res.json({ success: true, errors: errorAggregates.slice().reverse(), total: errorAggregates.length });
+});
+
+
+// ── User-facing Alerts (topbar bell) ─────────────────────────────────────────
+// Scoped to clerk_user_id from the JWT. Never returns rows from other users.
+// short_message is the only field shown to end users; raw_message is admin-only.
+function truncateStr(s, max) {
+  if (s == null) return null;
+  const str = String(s);
+  return str.length > max ? str.slice(0, max) : str;
+}
+
+async function getActiveBrandIdForUser(userId) {
+  if (!userId) return null;
+  try {
+    const r = await pool.query(
+      `SELECT id FROM brand_profiles WHERE clerk_user_id = $1 AND is_active = true
+       ORDER BY updated_at DESC LIMIT 1`,
+      [userId]
+    );
+    return r.rows[0]?.id || null;
+  } catch { return null; }
+}
+
+// POST /api/alerts — store a client-reported alert
+app.post('/api/alerts', requireAuth, async (req, res) => {
+  try {
+    if (!req.userId) return res.status(401).json({ error: 'Unauthorized' });
+    const { severity, area, shortMessage, rawMessage, httpStatus, url } = req.body || {};
+    if (!shortMessage || typeof shortMessage !== 'string') {
+      return res.status(400).json({ error: 'shortMessage required' });
+    }
+    const allowedSev = ['error', 'warn', 'info'];
+    const sev = allowedSev.includes(severity) ? severity : 'error';
+    const shortMsg = truncateStr(shortMessage, 200);
+    const rawMsg = truncateStr(rawMessage, 2000);
+    const areaStr = truncateStr(area, 80);
+    const urlStr = truncateStr(url, 500);
+    const status = (typeof httpStatus === 'number' && Number.isFinite(httpStatus)) ? httpStatus : null;
+    const brandId = await getActiveBrandIdForUser(req.userId);
+
+    // De-dupe: same (user, short_message, area) inserted in last 60s -> return existing
+    const dup = await pool.query(
+      `SELECT id, clerk_user_id, brand_profile_id, severity, area, short_message,
+              http_status, url, read_at, created_at
+         FROM user_alerts
+         WHERE clerk_user_id = $1
+           AND short_message = $2
+           AND (area IS NOT DISTINCT FROM $3)
+           AND created_at > NOW() - INTERVAL '60 seconds'
+         ORDER BY created_at DESC LIMIT 1`,
+      [req.userId, shortMsg, areaStr]
+    );
+    if (dup.rows[0]) {
+      return res.json({ success: true, alert: dup.rows[0], deduped: true });
+    }
+
+    const ins = await pool.query(
+      `INSERT INTO user_alerts
+         (clerk_user_id, brand_profile_id, severity, area, short_message, raw_message, http_status, url)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id, clerk_user_id, brand_profile_id, severity, area, short_message,
+                 http_status, url, read_at, created_at`,
+      [req.userId, brandId, sev, areaStr, shortMsg, rawMsg, status, urlStr]
+    );
+    res.json({ success: true, alert: ins.rows[0] });
+  } catch (e) {
+    console.error('POST /api/alerts error:', e.message);
+    res.status(500).json({ success: false, error: 'Failed to store alert' });
+  }
+});
+
+// GET /api/alerts — last 50 alerts for current user, last 14 days
+app.get('/api/alerts', requireAuth, async (req, res) => {
+  try {
+    if (!req.userId) return res.status(401).json({ error: 'Unauthorized' });
+    const result = await pool.query(
+      `SELECT id, severity, area, short_message, http_status, url, read_at, created_at
+         FROM user_alerts
+         WHERE clerk_user_id = $1
+           AND created_at > NOW() - INTERVAL '14 days'
+         ORDER BY created_at DESC
+         LIMIT 50`,
+      [req.userId]
+    );
+    const alerts = result.rows.map(r => ({
+      id: r.id,
+      severity: r.severity,
+      area: r.area,
+      shortMessage: r.short_message,
+      httpStatus: r.http_status,
+      url: r.url,
+      readAt: r.read_at,
+      createdAt: r.created_at,
+    }));
+    const unreadCount = alerts.filter(a => !a.readAt).length;
+    res.json({ success: true, alerts, unreadCount });
+  } catch (e) {
+    console.error('GET /api/alerts error:', e.message);
+    res.status(500).json({ success: false, error: 'Failed to load alerts' });
+  }
+});
+
+// POST /api/alerts/read — mark alerts read (ids[] or all)
+app.post('/api/alerts/read', requireAuth, async (req, res) => {
+  try {
+    if (!req.userId) return res.status(401).json({ error: 'Unauthorized' });
+    const ids = Array.isArray(req.body?.ids) ? req.body.ids.filter(x => typeof x === 'string') : null;
+    if (ids && ids.length > 0) {
+      await pool.query(
+        `UPDATE user_alerts SET read_at = NOW()
+           WHERE clerk_user_id = $1 AND id = ANY($2::uuid[]) AND read_at IS NULL`,
+        [req.userId, ids]
+      );
+    } else {
+      await pool.query(
+        `UPDATE user_alerts SET read_at = NOW()
+           WHERE clerk_user_id = $1 AND read_at IS NULL`,
+        [req.userId]
+      );
+    }
+    res.json({ success: true });
+  } catch (e) {
+    console.error('POST /api/alerts/read error:', e.message);
+    res.status(500).json({ success: false, error: 'Failed to mark read' });
+  }
+});
+
+// POST /api/support/ticket — submit a support request (Get Help form)
+app.post('/api/support/ticket', requireAuth, async (req, res) => {
+  try {
+    if (!req.userId) return res.status(401).json({ error: 'Unauthorized' });
+    const { category, subject, body, attachedAlertIds } = req.body || {};
+    if (!subject || typeof subject !== 'string') return res.status(400).json({ error: 'subject required' });
+    if (!body || typeof body !== 'string') return res.status(400).json({ error: 'body required' });
+    const allowedCat = ['bug', 'question', 'feature', 'other'];
+    const cat = allowedCat.includes(category) ? category : 'other';
+    const subj = truncateStr(subject.trim(), 120);
+    const bodyStr = truncateStr(body.trim(), 2000);
+    const alertIds = Array.isArray(attachedAlertIds)
+      ? attachedAlertIds.filter(x => typeof x === 'string').slice(0, 20)
+      : [];
+    const userAgent = truncateStr(req.headers['user-agent'] || '', 500);
+    const pageUrl = truncateStr(req.body?.pageUrl || req.headers['referer'] || '', 500);
+    const userEmail = truncateStr(req.body?.userEmail || '', 200);
+
+    // Look up active brand for context
+    const brandQ = await pool.query(
+      `SELECT id, brand_name, brand_url FROM brand_profiles
+        WHERE clerk_user_id = $1 AND is_active = true
+        ORDER BY updated_at DESC LIMIT 1`,
+      [req.userId]
+    );
+    const brand = brandQ.rows[0] || null;
+
+    const ins = await pool.query(
+      `INSERT INTO support_tickets
+         (clerk_user_id, brand_profile_id, user_email, category, subject, body,
+          attached_alert_ids, user_agent, page_url)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9)
+       RETURNING id, created_at`,
+      [req.userId, brand?.id || null, userEmail, cat, subj, bodyStr,
+       JSON.stringify(alertIds), userAgent, pageUrl]
+    );
+    const ticketId = ins.rows[0].id;
+
+    // Pull attached alerts to embed in the email
+    let attached = [];
+    if (alertIds.length > 0) {
+      const ar = await pool.query(
+        `SELECT id, severity, area, short_message, raw_message, http_status, url, created_at
+           FROM user_alerts
+           WHERE clerk_user_id = $1 AND id = ANY($2::uuid[])
+           ORDER BY created_at DESC`,
+        [req.userId, alertIds]
+      );
+      attached = ar.rows;
+    }
+
+    // Fire-and-forget Resend email to Brian. Failures must NOT fail the request.
+    if (RESEND_API_KEY) {
+      const esc = (s) => String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const alertsHtml = attached.length
+        ? `<ul style="padding-left:18px;margin:8px 0">` + attached.map(a => `
+            <li style="margin:6px 0">
+              <strong>[${esc(a.severity)}]</strong>
+              <em>${esc(a.area || '-')}</em>
+              — ${esc(a.short_message)}
+              ${a.http_status ? `<span style="color:#94a3b8"> (HTTP ${esc(a.http_status)})</span>` : ''}
+              <div style="font-size:11px;color:#94a3b8">${esc(new Date(a.created_at).toISOString())} · ${esc(a.url || '')}</div>
+              ${a.raw_message ? `<pre style="background:#0F1720;color:#E2E8F0;padding:8px;border-radius:6px;font-size:11px;white-space:pre-wrap;margin:4px 0">${esc(String(a.raw_message).slice(0, 500))}</pre>` : ''}
+            </li>`).join('') + `</ul>`
+        : '<p style="color:#94a3b8;font-size:13px">No alerts attached.</p>';
+      const html = `<div style="font-family:Inter,system-ui,sans-serif;color:#0F1720;max-width:680px">
+        <p style="font-size:11px;letter-spacing:0.08em;text-transform:uppercase;color:#3563FF;margin:0 0 12px">Forge Intelligence — Support Ticket</p>
+        <h1 style="font-size:20px;margin:0 0 8px">${esc(subj)}</h1>
+        <p style="font-size:12px;color:#64748b;margin:0 0 16px">Ticket <code>${esc(ticketId)}</code> · Category: <strong>${esc(cat)}</strong></p>
+        <table style="font-size:13px;color:#1e293b;border-collapse:collapse;margin-bottom:16px">
+          <tr><td style="padding:4px 12px 4px 0;color:#64748b">User</td><td>${esc(userEmail || '(no email)')}<br><code style="font-size:11px;color:#94a3b8">${esc(req.userId)}</code></td></tr>
+          <tr><td style="padding:4px 12px 4px 0;color:#64748b">Brand</td><td>${esc(brand?.brand_name || '-')} <code style="font-size:11px;color:#94a3b8">${esc(brand?.id || '')}</code><br><span style="font-size:11px;color:#94a3b8">${esc(brand?.brand_url || '')}</span></td></tr>
+          <tr><td style="padding:4px 12px 4px 0;color:#64748b">Page</td><td><code style="font-size:11px">${esc(pageUrl)}</code></td></tr>
+          <tr><td style="padding:4px 12px 4px 0;color:#64748b">User Agent</td><td style="font-size:11px;color:#64748b">${esc(userAgent)}</td></tr>
+        </table>
+        <h3 style="font-size:14px;margin:16px 0 6px">Description</h3>
+        <div style="white-space:pre-wrap;background:#F8FAFC;border:1px solid #E2E8F0;padding:12px;border-radius:8px;font-size:13px;line-height:1.6">${esc(bodyStr)}</div>
+        <h3 style="font-size:14px;margin:16px 0 6px">Attached alerts (${attached.length})</h3>
+        ${alertsHtml}
+      </div>`;
+      fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + RESEND_API_KEY,
+          'Content-Type': 'application/json',
+          'User-Agent': 'Forge-Intelligence-Server/1.0',
+        },
+        body: JSON.stringify({
+          from: 'Forge Alerts <alerts@forgeintelligence.ai>',
+          to: ['brian@sandbox-xm.com'],
+          reply_to: userEmail || undefined,
+          subject: `[Forge Support] ${cat}: ${subj}`,
+          html,
+        }),
+      }).then(r => {
+        if (!r.ok) r.text().then(t => console.error('Support ticket email failed:', r.status, t.slice(0, 200)));
+      }).catch(err => console.error('Support ticket email error:', err.message));
+    } else {
+      console.log('Support ticket created (no RESEND_API_KEY, email skipped):', ticketId);
+    }
+
+    res.json({ success: true, ticketId });
+  } catch (e) {
+    console.error('POST /api/support/ticket error:', e.message);
+    res.status(500).json({ success: false, error: 'Failed to submit ticket' });
+  }
+});
+
+// GET /api/admin/support/tickets — super-admin only
+app.get('/api/admin/support/tickets', requireAuth, async (req, res) => {
+  if (!SUPER_ADMIN_IDS.includes(req.userId)) return res.status(403).json({ error: 'Forbidden' });
+  try {
+    const r = await pool.query(
+      `SELECT t.id, t.clerk_user_id, t.brand_profile_id, t.user_email, t.category,
+              t.subject, t.body, t.attached_alert_ids, t.user_agent, t.page_url,
+              t.status, t.created_at, bp.brand_name
+         FROM support_tickets t
+         LEFT JOIN brand_profiles bp ON bp.id = t.brand_profile_id
+         ORDER BY t.created_at DESC
+         LIMIT 100`
+    );
+    res.json({ success: true, tickets: r.rows, total: r.rows.length });
+  } catch (e) {
+    console.error('GET /api/admin/support/tickets error:', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
 });
 
 

--- a/src/components/AlertsBell.css
+++ b/src/components/AlertsBell.css
@@ -1,0 +1,208 @@
+/* AlertsBell — bell icon + dropdown panel.
+   Matches the visual language of TopBar.tsx's brand switcher / user menu. */
+
+.alerts-bell-root {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.alerts-bell-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.alerts-bell-btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.alerts-bell-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+  box-shadow: 0 0 0 2px #0F1720;
+  pointer-events: none;
+}
+
+.alerts-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 360px;
+  max-width: calc(100vw - 32px);
+  max-height: 480px;
+  display: flex;
+  flex-direction: column;
+  background: #1a1f2e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.5);
+  z-index: 999;
+  overflow: hidden;
+}
+
+.alerts-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.alerts-panel-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+.alerts-panel-link {
+  background: none;
+  border: none;
+  color: #818CF8;
+  font-size: 0.75rem;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+}
+.alerts-panel-link:hover { color: #A5B4FC; text-decoration: underline; }
+.alerts-panel-meta {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.alerts-help-cta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 14px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(99, 102, 241, 0.06));
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+.alerts-help-cta:hover { background: rgba(99, 102, 241, 0.28); }
+.alerts-help-cta-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #ffffff;
+  flex-shrink: 0;
+}
+.alerts-help-cta strong {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.alerts-help-cta-sub {
+  display: block;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.55);
+  margin-top: 1px;
+}
+
+.alerts-list {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.alerts-empty {
+  padding: 28px 16px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.alerts-row {
+  display: flex;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.alerts-row:last-child { border-bottom: none; }
+.alerts-row.unread {
+  background: rgba(99, 102, 241, 0.06);
+}
+.alerts-row.unread .alerts-row-msg { color: #ffffff; }
+
+.alerts-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  margin-top: 7px;
+  flex-shrink: 0;
+}
+.alerts-dot.error { background: #ef4444; }
+.alerts-dot.warn  { background: #f59e0b; }
+.alerts-dot.info  { background: #60a5fa; }
+
+.alerts-row-body { min-width: 0; flex: 1; }
+.alerts-row-msg {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.35;
+  word-break: break-word;
+}
+.alerts-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+  font-size: 0.68rem;
+}
+.alerts-tag {
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.65);
+  font-family: ui-monospace, monospace;
+}
+.alerts-tag.dim {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.4);
+  padding-left: 0;
+  padding-right: 0;
+}
+.alerts-time {
+  color: rgba(255, 255, 255, 0.4);
+  margin-left: auto;
+}
+
+/* Mobile: anchor panel to the right edge of the viewport */
+@media (max-width: 640px) {
+  .alerts-panel {
+    right: -10px;
+    width: 320px;
+  }
+}

--- a/src/components/AlertsBell.tsx
+++ b/src/components/AlertsBell.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from 'react';
+import { useApp, Alert } from '../context/AppContext';
+import { timeAgo } from '../lib/time';
+import GetHelpModal from './GetHelpModal';
+import './AlertsBell.css';
+
+const BellIcon = ({ size = 18 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+    <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+  </svg>
+);
+
+function severityClass(sev: Alert['severity']): string {
+  if (sev === 'error') return 'alerts-dot error';
+  if (sev === 'warn') return 'alerts-dot warn';
+  return 'alerts-dot info';
+}
+
+export default function AlertsBell() {
+  const { alerts, unreadAlertCount, markAlertsRead } = useApp();
+  const [open, setOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const displayBadge = unreadAlertCount > 9 ? '9+' : String(unreadAlertCount);
+
+  return (
+    <>
+      <div className="alerts-bell-root" ref={rootRef}>
+        <button
+          type="button"
+          className="alerts-bell-btn"
+          aria-label={`Alerts${unreadAlertCount > 0 ? ` (${unreadAlertCount} unread)` : ''}`}
+          onClick={() => setOpen(o => !o)}
+        >
+          <BellIcon />
+          {unreadAlertCount > 0 && (
+            <span className="alerts-bell-badge" aria-hidden>{displayBadge}</span>
+          )}
+        </button>
+
+        {open && (
+          <div className="alerts-panel" role="dialog" aria-label="Alerts">
+            <div className="alerts-panel-header">
+              <span className="alerts-panel-title">Alerts</span>
+              {unreadAlertCount > 0 ? (
+                <button
+                  type="button"
+                  className="alerts-panel-link"
+                  onClick={() => markAlertsRead()}
+                >
+                  Mark all read
+                </button>
+              ) : (
+                <span className="alerts-panel-meta">All caught up</span>
+              )}
+            </div>
+
+            <button
+              type="button"
+              className="alerts-help-cta"
+              onClick={() => { setHelpOpen(true); setOpen(false); }}
+            >
+              <span className="alerts-help-cta-icon">?</span>
+              <span>
+                <strong>Get Help</strong>
+                <span className="alerts-help-cta-sub">Send a note to the Forge team</span>
+              </span>
+            </button>
+
+            <div className="alerts-list">
+              {alerts.length === 0 ? (
+                <div className="alerts-empty">No alerts. You're all clear.</div>
+              ) : (
+                alerts.map(a => (
+                  <div key={a.id} className={`alerts-row${a.readAt ? '' : ' unread'}`}>
+                    <span className={severityClass(a.severity)} />
+                    <div className="alerts-row-body">
+                      <div className="alerts-row-msg">{a.shortMessage}</div>
+                      <div className="alerts-row-meta">
+                        {a.area && <span className="alerts-tag">{a.area}</span>}
+                        {a.httpStatus != null && <span className="alerts-tag dim">HTTP {a.httpStatus}</span>}
+                        <span className="alerts-time">{timeAgo(a.createdAt)}</span>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {helpOpen && <GetHelpModal onClose={() => setHelpOpen(false)} />}
+    </>
+  );
+}

--- a/src/components/GetHelpModal.css
+++ b/src/components/GetHelpModal.css
@@ -1,0 +1,244 @@
+/* GetHelpModal — mirrors GateModal visual style. */
+
+.gethelp-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 12, 22, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 16px;
+  animation: gh-fade-in 140ms ease;
+}
+@keyframes gh-fade-in { from { opacity: 0 } to { opacity: 1 } }
+
+.gethelp-modal {
+  width: 100%;
+  max-width: 520px;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  background: #1a1f2e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: inherit;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  animation: gh-pop 160ms ease;
+}
+@keyframes gh-pop {
+  from { transform: translateY(8px) scale(0.98); opacity: 0 }
+  to { transform: translateY(0) scale(1); opacity: 1 }
+}
+
+.gethelp-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 22px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.gethelp-eyebrow {
+  margin: 0 0 4px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #818CF8;
+}
+.gethelp-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #ffffff;
+  line-height: 1.3;
+}
+.gethelp-close {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.gethelp-close:hover { color: #ffffff; }
+
+.gethelp-form {
+  padding: 16px 22px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.gethelp-field { display: flex; flex-direction: column; gap: 6px; position: relative; }
+.gethelp-field label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.72);
+  letter-spacing: 0.02em;
+}
+.gethelp-field input,
+.gethelp-field select,
+.gethelp-field textarea {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 9px 11px;
+  color: #ffffff;
+  font-size: 0.875rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 120ms ease, background 120ms ease;
+  resize: vertical;
+}
+.gethelp-field input:focus,
+.gethelp-field select:focus,
+.gethelp-field textarea:focus {
+  border-color: #6366f1;
+  background: rgba(99, 102, 241, 0.08);
+}
+.gethelp-field input:disabled,
+.gethelp-field select:disabled,
+.gethelp-field textarea:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.gethelp-counter {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.4);
+  align-self: flex-end;
+}
+
+.gethelp-context {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.75rem;
+}
+.gethelp-context-row {
+  display: flex;
+  gap: 10px;
+  color: rgba(255, 255, 255, 0.7);
+}
+.gethelp-context-label {
+  color: rgba(255, 255, 255, 0.42);
+  width: 50px;
+  flex-shrink: 0;
+}
+.gethelp-context code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.7rem;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.gethelp-alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 160px;
+  overflow-y: auto;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 6px;
+}
+.gethelp-alert-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.78);
+}
+.gethelp-alert-row:hover { background: rgba(255, 255, 255, 0.04); }
+.gethelp-alert-row input { accent-color: #6366f1; }
+.gethelp-alert-msg {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gethelp-alert-tag {
+  font-size: 0.65rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.55);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+  flex-shrink: 0;
+}
+
+.gethelp-error {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: #fca5a5;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 0.78rem;
+}
+
+.gethelp-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+.gethelp-btn-primary,
+.gethelp-btn-secondary {
+  padding: 9px 18px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 120ms ease, transform 120ms ease;
+  border: none;
+}
+.gethelp-btn-primary {
+  background: #6366f1;
+  color: #ffffff;
+}
+.gethelp-btn-primary:hover:not(:disabled) { background: #4f46e5; }
+.gethelp-btn-primary:disabled { background: rgba(99, 102, 241, 0.35); cursor: not-allowed; }
+.gethelp-btn-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.8);
+}
+.gethelp-btn-secondary:hover:not(:disabled) { background: rgba(255, 255, 255, 0.12); }
+
+.gethelp-success {
+  padding: 32px 22px 28px;
+  text-align: center;
+}
+.gethelp-success-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px; height: 48px;
+  border-radius: 50%;
+  background: rgba(16, 185, 129, 0.18);
+  color: #34d399;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+.gethelp-success h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+  color: #ffffff;
+}
+.gethelp-success p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}

--- a/src/components/GetHelpModal.tsx
+++ b/src/components/GetHelpModal.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useUser } from '@clerk/clerk-react';
+import { useApp } from '../context/AppContext';
+import './GetHelpModal.css';
+
+interface GetHelpModalProps {
+  onClose: () => void;
+}
+
+type Category = 'bug' | 'question' | 'feature' | 'other';
+type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
+
+const SUBJECT_MAX = 120;
+const BODY_MAX = 2000;
+
+export default function GetHelpModal({ onClose }: GetHelpModalProps) {
+  const { user } = useUser();
+  const { alerts, activeBrand, authToken } = useApp();
+
+  const [category, setCategory] = useState<Category>('bug');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [attachedIds, setAttachedIds] = useState<Set<string>>(() => {
+    // Default: attach the most recent 5 alerts (server-confirmed ids only)
+    const recent = alerts
+      .filter(a => !a.id.startsWith('local-'))
+      .slice(0, 5)
+      .map(a => a.id);
+    return new Set(recent);
+  });
+  const [state, setState] = useState<SubmitState>('idle');
+  const [errMsg, setErrMsg] = useState('');
+
+  const recentAlerts = useMemo(
+    () => alerts.filter(a => !a.id.startsWith('local-')).slice(0, 5),
+    [alerts]
+  );
+
+  // Auto-close on success after 4s
+  useEffect(() => {
+    if (state !== 'success') return;
+    const t = setTimeout(onClose, 4000);
+    return () => clearTimeout(t);
+  }, [state, onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const userEmail = user?.primaryEmailAddress?.emailAddress || '';
+
+  const toggleAlert = (id: string) => {
+    setAttachedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const canSubmit = subject.trim().length > 0 && body.trim().length > 0 && state !== 'submitting';
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setState('submitting');
+    setErrMsg('');
+    try {
+      const res = await fetch('/api/support/ticket', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+        },
+        body: JSON.stringify({
+          category,
+          subject: subject.trim(),
+          body: body.trim(),
+          attachedAlertIds: Array.from(attachedIds),
+          pageUrl: window.location.href,
+          userEmail,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`HTTP ${res.status} ${text.slice(0, 120)}`);
+      }
+      const data = await res.json();
+      if (!data?.success) throw new Error(data?.error || 'Submit failed');
+      setState('success');
+    } catch (err) {
+      setState('error');
+      setErrMsg(err instanceof Error ? err.message : 'Submit failed. Please retry.');
+    }
+  };
+
+  return (
+    <div className="gethelp-backdrop" onClick={onClose}>
+      <div
+        className="gethelp-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Get Help"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="gethelp-header">
+          <div>
+            <p className="gethelp-eyebrow">Get Help</p>
+            <h2 className="gethelp-title">Send a note to the Forge team</h2>
+          </div>
+          <button type="button" className="gethelp-close" onClick={onClose} aria-label="Close">×</button>
+        </div>
+
+        {state === 'success' ? (
+          <div className="gethelp-success">
+            <div className="gethelp-success-icon">✓</div>
+            <h3>Thanks — we got it.</h3>
+            <p>
+              Brian will follow up
+              {userEmail ? <> at <strong>{userEmail}</strong></> : null}.
+            </p>
+          </div>
+        ) : (
+          <form className="gethelp-form" onSubmit={handleSubmit}>
+            <div className="gethelp-field">
+              <label htmlFor="gh-category">Category</label>
+              <select
+                id="gh-category"
+                value={category}
+                onChange={e => setCategory(e.target.value as Category)}
+                disabled={state === 'submitting'}
+              >
+                <option value="bug">Bug — something broke</option>
+                <option value="question">Question</option>
+                <option value="feature">Feature request</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+
+            <div className="gethelp-field">
+              <label htmlFor="gh-subject">Subject</label>
+              <input
+                id="gh-subject"
+                type="text"
+                value={subject}
+                onChange={e => setSubject(e.target.value.slice(0, SUBJECT_MAX))}
+                placeholder="One-line summary"
+                maxLength={SUBJECT_MAX}
+                disabled={state === 'submitting'}
+                required
+              />
+              <div className="gethelp-counter">{subject.length} / {SUBJECT_MAX}</div>
+            </div>
+
+            <div className="gethelp-field">
+              <label htmlFor="gh-body">Description</label>
+              <textarea
+                id="gh-body"
+                rows={5}
+                value={body}
+                onChange={e => setBody(e.target.value.slice(0, BODY_MAX))}
+                placeholder="What were you trying to do? What did you expect? What actually happened?"
+                maxLength={BODY_MAX}
+                disabled={state === 'submitting'}
+                required
+              />
+              <div className="gethelp-counter">{body.length} / {BODY_MAX}</div>
+            </div>
+
+            <div className="gethelp-context">
+              <div className="gethelp-context-row">
+                <span className="gethelp-context-label">Page</span>
+                <code>{window.location.pathname}</code>
+              </div>
+              {activeBrand && (
+                <div className="gethelp-context-row">
+                  <span className="gethelp-context-label">Brand</span>
+                  <span>{activeBrand.brandName || activeBrand.brandUrl}</span>
+                </div>
+              )}
+            </div>
+
+            {recentAlerts.length > 0 && (
+              <div className="gethelp-field">
+                <label>Attach recent alerts ({attachedIds.size} of {recentAlerts.length})</label>
+                <div className="gethelp-alerts">
+                  {recentAlerts.map(a => (
+                    <label key={a.id} className="gethelp-alert-row">
+                      <input
+                        type="checkbox"
+                        checked={attachedIds.has(a.id)}
+                        onChange={() => toggleAlert(a.id)}
+                        disabled={state === 'submitting'}
+                      />
+                      <span className="gethelp-alert-msg">{a.shortMessage}</span>
+                      {a.area && <span className="gethelp-alert-tag">{a.area}</span>}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {state === 'error' && (
+              <div className="gethelp-error">
+                {errMsg || "Submit failed. Please retry."}
+              </div>
+            )}
+
+            <div className="gethelp-actions">
+              <button
+                type="button"
+                className="gethelp-btn-secondary"
+                onClick={onClose}
+                disabled={state === 'submitting'}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="gethelp-btn-primary"
+                disabled={!canSubmit}
+              >
+                {state === 'submitting' ? 'Sending…' : 'Send to Forge team'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,7 @@
 import { useUser, SignOutButton, SignedIn, SignedOut } from '@clerk/clerk-react';
 import { useState, useEffect, useRef } from 'react';
 import { useApp } from '../context/AppContext';
+import AlertsBell from './AlertsBell';
 import './TopBar.css';
 
 // Lucide-style icons
@@ -229,6 +230,9 @@ export function TopBar({ pageTitle }: { pageTitle?: string }) {
             </span>
           </div>
         )}
+        <SignedIn>
+          <AlertsBell />
+        </SignedIn>
         <div className="user-area" style={{ position: 'relative' }} ref={menuRef}>
           <SignedOut>
             <a href="https://accounts.forgeintelligence.ai/sign-in" style={{ fontSize: '0.875rem', color: '#ffffff', textDecoration: 'none', fontWeight: 600, padding: '8px 20px', background: 'var(--color-accent)', border: 'none', borderRadius: 8, display: 'inline-block' }}>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,8 +1,26 @@
 import { useActiveBrand, ActiveBrand, BrandMini } from '../hooks/useActiveBrand';
 import { useAuth } from '@clerk/clerk-react';
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useRef, ReactNode } from 'react';
 import { ViewType, BrandProfile, AnalysisInput, ProcessingStage, HistoryEntry } from '../types';
 import { initialProcessingStages, sampleAnalysisInput } from '../data/mockData';
+import { humanize, AlertSeverity } from '../lib/humanizeError';
+
+export interface Alert {
+  id: string;
+  severity: AlertSeverity;
+  area: string | null;
+  shortMessage: string;
+  httpStatus: number | null;
+  url: string | null;
+  readAt: string | null;
+  createdAt: string;
+}
+
+export interface ReportErrorContext {
+  area?: string;
+  url?: string;
+  httpStatus?: number;
+}
 
 interface AppContextType {
   currentView: ViewType;
@@ -32,6 +50,12 @@ interface AppContextType {
   switchBrand: (brandId: string) => void;
   // 7-day full-access trial state. Null when not eligible.
   trial: { active: boolean; eligible: boolean; daysRemaining: number; endsAt: string | null } | null;
+  // Alerts (topbar bell)
+  alerts: Alert[];
+  unreadAlertCount: number;
+  reportError: (err: unknown, ctx?: ReportErrorContext) => void;
+  markAlertsRead: (ids?: string[]) => Promise<void>;
+  refetchAlerts: () => Promise<void>;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -138,6 +162,134 @@ export function AppProvider({ children }: { children: ReactNode }) {
     return () => clearInterval(interval);
   }, [isSignedIn, getToken]);
 
+  // ── Alerts (topbar bell) ────────────────────────────────────────────────────
+  // In-memory list; hydrated from /api/alerts on auth. Tracks ids we've already
+  // POSTed in this session to avoid re-posting local + server-confirmed alerts.
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const recentPostedRef = useRef<Map<string, number>>(new Map()); // key -> ts (ms)
+  const tokenRef = useRef<string>('');
+  useEffect(() => { tokenRef.current = authToken; }, [authToken]);
+
+  const refetchAlerts = useCallback(async () => {
+    const token = tokenRef.current;
+    if (!token) return;
+    try {
+      const res = await fetch('/api/alerts', { headers: { Authorization: `Bearer ${token}` } });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data?.success && Array.isArray(data.alerts)) {
+        setAlerts(data.alerts as Alert[]);
+      }
+    } catch { /* silent — alerts plumbing must never throw on its own */ }
+  }, []);
+
+  // Hydrate alerts when auth becomes available
+  useEffect(() => {
+    if (!authToken) { setAlerts([]); return; }
+    refetchAlerts();
+  }, [authToken, refetchAlerts]);
+
+  const markAlertsRead = useCallback(async (ids?: string[]) => {
+    const token = tokenRef.current;
+    // Optimistic update first
+    setAlerts(prev => prev.map(a => {
+      if (ids && ids.length > 0) {
+        return ids.includes(a.id) && !a.readAt ? { ...a, readAt: new Date().toISOString() } : a;
+      }
+      return a.readAt ? a : { ...a, readAt: new Date().toISOString() };
+    }));
+    if (!token) return;
+    try {
+      await fetch('/api/alerts/read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify(ids && ids.length > 0 ? { ids } : {}),
+      });
+    } catch { /* silent */ }
+  }, []);
+
+  const reportError = useCallback((err: unknown, ctx: ReportErrorContext = {}) => {
+    const result = humanize(err, ctx);
+    if (result.suppress) return;
+    const area = ctx.area ?? null;
+    const dedupeKey = `${area || ''}|${result.shortMessage}`;
+    const now = Date.now();
+    const last = recentPostedRef.current.get(dedupeKey);
+    if (last && now - last < 60_000) return; // local de-dupe matching server's 60s window
+    recentPostedRef.current.set(dedupeKey, now);
+
+    // Optimistic in-memory alert with a temp id; replaced when server returns its row.
+    const tempId = `local-${now}-${Math.random().toString(36).slice(2, 8)}`;
+    const localAlert: Alert = {
+      id: tempId,
+      severity: result.severity,
+      area,
+      shortMessage: result.shortMessage,
+      httpStatus: result.httpStatus ?? ctx.httpStatus ?? null,
+      url: ctx.url ?? (typeof window !== 'undefined' ? window.location.pathname : null),
+      readAt: null,
+      createdAt: new Date().toISOString(),
+    };
+    setAlerts(prev => [localAlert, ...prev].slice(0, 50));
+
+    const token = tokenRef.current;
+    if (!token) return; // can't persist for signed-out users
+    fetch('/api/alerts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        severity: result.severity,
+        area,
+        shortMessage: result.shortMessage,
+        rawMessage: result.rawMessage,
+        httpStatus: result.httpStatus ?? ctx.httpStatus ?? null,
+        url: ctx.url ?? (typeof window !== 'undefined' ? window.location.pathname : null),
+      }),
+    })
+      .then(async r => {
+        if (!r.ok) return;
+        const data = await r.json();
+        const serverAlert = data?.alert;
+        if (!serverAlert) return;
+        setAlerts(prev => {
+          // If server's id is already in the list (dedupe), drop the temp and keep server row.
+          const existsIdx = prev.findIndex(a => a.id === serverAlert.id);
+          const mapped: Alert = {
+            id: serverAlert.id,
+            severity: serverAlert.severity,
+            area: serverAlert.area,
+            shortMessage: serverAlert.short_message,
+            httpStatus: serverAlert.http_status ?? null,
+            url: serverAlert.url ?? null,
+            readAt: serverAlert.read_at ?? null,
+            createdAt: serverAlert.created_at,
+          };
+          const withoutTemp = prev.filter(a => a.id !== tempId);
+          if (existsIdx >= 0) return withoutTemp;
+          return [mapped, ...withoutTemp].slice(0, 50);
+        });
+      })
+      .catch(() => { /* silent — never escalate alert-pipeline failures */ });
+  }, []);
+
+  // Global window listeners — catches errors no try/catch handled
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onError = (e: ErrorEvent) => {
+      reportError(e.error ?? e.message, { area: 'global', url: window.location.pathname });
+    };
+    const onRejection = (e: PromiseRejectionEvent) => {
+      reportError(e.reason, { area: 'global', url: window.location.pathname });
+    };
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onRejection);
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onRejection);
+    };
+  }, [reportError]);
+
+  const unreadAlertCount = alerts.reduce((n, a) => n + (a.readAt ? 0 : 1), 0);
 
   const loadSampleData = () => setAnalysisInput(sampleAnalysisInput);
 
@@ -257,6 +409,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       isPaid, brandLoading, activeBrand, refetchBrand, authToken,
       allBrands, isSuperAdmin, switchBrand,
       trial,
+      alerts, unreadAlertCount, reportError, markAlertsRead, refetchAlerts,
     }}>
       {children}
     </AppContext.Provider>

--- a/src/lib/fetchWithAlert.ts
+++ b/src/lib/fetchWithAlert.ts
@@ -1,0 +1,51 @@
+// Lightweight fetch wrapper that auto-reports failures to the alerts store.
+// Pages opt in by importing this instead of `fetch` for user-initiated calls.
+// On non-OK responses or network errors, it calls reportError() with the
+// captured status, then throws (default) so existing try/catch keeps working.
+
+export type ReportErrorFn = (
+  err: unknown,
+  ctx: { area?: string; url?: string; httpStatus?: number }
+) => void;
+
+export interface FetchWithAlertOptions extends RequestInit {
+  area?: string;
+  /** When false, return the Response on non-2xx instead of throwing. Default: true. */
+  throwOnHttpError?: boolean;
+}
+
+export async function fetchWithAlert(
+  input: RequestInfo | URL,
+  init: FetchWithAlertOptions | undefined,
+  reportError: ReportErrorFn
+): Promise<Response> {
+  const area = init?.area;
+  const reqUrl =
+    typeof input === 'string' ? input :
+    input instanceof URL ? input.toString() :
+    input.url;
+  let res: Response;
+  try {
+    res = await fetch(input, init);
+  } catch (err) {
+    reportError(err, { area, url: window.location.pathname });
+    throw err;
+  }
+  if (!res.ok) {
+    let raw: string | undefined;
+    try {
+      const clone = res.clone();
+      const text = await clone.text();
+      raw = text.slice(0, 500);
+    } catch { /* ignore */ }
+    const fakeErr = new Error(`HTTP ${res.status} ${res.statusText || ''} ${raw || ''}`.trim()) as
+      Error & { status?: number; url?: string };
+    fakeErr.status = res.status;
+    fakeErr.url = reqUrl;
+    reportError(fakeErr, { area, url: window.location.pathname, httpStatus: res.status });
+    if (init?.throwOnHttpError !== false) {
+      throw fakeErr;
+    }
+  }
+  return res;
+}

--- a/src/lib/humanizeError.ts
+++ b/src/lib/humanizeError.ts
@@ -1,0 +1,97 @@
+// Translates any thrown/rejected value into a short, user-safe string.
+// Never returns raw stack traces, SQL, or internal paths. The verbose form
+// goes into `rawMessage` (admin-only) — see reportError() in AppContext.
+
+export type AlertSeverity = 'error' | 'warn' | 'info';
+
+export interface HumanizeContext {
+  area?: string;
+  url?: string;
+  httpStatus?: number;
+}
+
+export interface HumanizeResult {
+  shortMessage: string;
+  severity: AlertSeverity;
+  httpStatus?: number;
+  rawMessage?: string;
+  /** When true, the caller should NOT surface this alert (e.g. AbortError). */
+  suppress?: boolean;
+}
+
+function statusToMessage(status: number): { msg: string; sev: AlertSeverity } | null {
+  if (status === 401 || status === 403) {
+    return { msg: "You don't have access to that. Try signing in again.", sev: 'warn' };
+  }
+  if (status === 404) {
+    return { msg: "We couldn't find that — it may have been removed.", sev: 'warn' };
+  }
+  if (status === 408 || status === 504) {
+    return { msg: "That took too long. Please retry.", sev: 'warn' };
+  }
+  if (status === 429) {
+    return { msg: "You're going a little fast — slow down and retry.", sev: 'warn' };
+  }
+  if (status >= 500 && status < 600) {
+    return { msg: "Our server hiccupped. We logged it.", sev: 'error' };
+  }
+  if (status >= 400 && status < 500) {
+    return { msg: "That request didn't go through. Please retry.", sev: 'warn' };
+  }
+  return null;
+}
+
+function rawFromError(err: unknown): string | undefined {
+  if (err == null) return undefined;
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`.slice(0, 2000);
+  }
+  if (typeof err === 'string') return err.slice(0, 2000);
+  try { return JSON.stringify(err).slice(0, 2000); } catch { return String(err).slice(0, 2000); }
+}
+
+export function humanize(err: unknown, ctx: HumanizeContext = {}): HumanizeResult {
+  const raw = rawFromError(err);
+
+  // HTTP status hint (caller-provided or extracted from a Response)
+  let status: number | undefined = ctx.httpStatus;
+  if (status == null && typeof err === 'object' && err && 'status' in err) {
+    const s = (err as { status?: unknown }).status;
+    if (typeof s === 'number') status = s;
+  }
+  if (status != null) {
+    const mapped = statusToMessage(status);
+    if (mapped) {
+      return { shortMessage: mapped.msg, severity: mapped.sev, httpStatus: status, rawMessage: raw };
+    }
+  }
+
+  // Common message-substring heuristics
+  const msg = (err instanceof Error ? err.message : typeof err === 'string' ? err : '') || '';
+  const name = err instanceof Error ? err.name : '';
+
+  if (name === 'AbortError' || /aborted/i.test(msg)) {
+    return { shortMessage: 'Request cancelled.', severity: 'info', rawMessage: raw, suppress: true };
+  }
+  if (name === 'TimeoutError' || /timeout/i.test(msg)) {
+    return { shortMessage: 'That took too long. Please retry.', severity: 'warn', rawMessage: raw };
+  }
+  if (/NetworkError|Failed to fetch|Load failed|network request failed/i.test(msg)) {
+    return { shortMessage: 'Network issue — check your connection.', severity: 'warn', rawMessage: raw };
+  }
+  if (/quota|rate limit|too many requests/i.test(msg)) {
+    return { shortMessage: "You're going a little fast — slow down and retry.", severity: 'warn', rawMessage: raw };
+  }
+  if (/unauthorized|forbidden|not authenticated|invalid token/i.test(msg)) {
+    return { shortMessage: "You don't have access to that. Try signing in again.", severity: 'warn', rawMessage: raw };
+  }
+  if (/not found/i.test(msg)) {
+    return { shortMessage: "We couldn't find that — it may have been removed.", severity: 'warn', rawMessage: raw };
+  }
+
+  return {
+    shortMessage: "Something didn't work as expected. We've logged it.",
+    severity: 'error',
+    rawMessage: raw,
+  };
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,17 @@
+// Shared relative-time formatter. Extracted from AdminPage so both the
+// AlertsBell and the Admin Mission Control panel can use it.
+export function timeAgo(ts: string | number | Date): string {
+  const d = new Date(ts as never);
+  const diff = Date.now() - d.getTime();
+  if (!Number.isFinite(diff) || diff < 0) return 'just now';
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const days = Math.floor(h / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
+}

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -55,6 +55,16 @@ export default function AdminPage() {
   interface Deploy { id: string; status: string; commitMessage: string; commitId: string; createdAt: string; finishedAt: string; env: string; }
   const [deploys, setDeploys] = useState<{ production: Deploy[]; development: Deploy[] }>({ production: [], development: [] });
 
+  // Support tickets (Get Help submissions)
+  interface SupportTicket {
+    id: string; clerk_user_id: string; brand_profile_id: string | null; user_email: string | null;
+    category: string; subject: string; body: string; status: string; created_at: string;
+    page_url: string | null; user_agent: string | null; brand_name: string | null;
+    attached_alert_ids: string[];
+  }
+  const [tickets, setTickets] = useState<SupportTicket[]>([]);
+  const [expandedTicket, setExpandedTicket] = useState<string | null>(null);
+
   const loadData = useCallback(async () => {
     try {
       const token = await getToken();
@@ -117,6 +127,22 @@ export default function AdminPage() {
     };
     fetchDeploys();
     const interval = setInterval(fetchDeploys, 60000);
+    return () => clearInterval(interval);
+  }, [getToken]);
+
+  // Fetch support tickets every 60s
+  useEffect(() => {
+    const fetchTickets = async () => {
+      const token = await getToken();
+      if (!token) return;
+      try {
+        const r = await fetch('/api/admin/support/tickets', { headers: { 'Authorization': `Bearer ${token}` } });
+        const d = await r.json();
+        if (d.success && Array.isArray(d.tickets)) setTickets(d.tickets);
+      } catch(e) { console.error('Support tickets fetch error:', e); }
+    };
+    fetchTickets();
+    const interval = setInterval(fetchTickets, 60000);
     return () => clearInterval(interval);
   }, [getToken]);
 
@@ -445,6 +471,68 @@ export default function AdminPage() {
                   </div>
                 </div>
               </div>
+            </div>
+
+            {/* Support Tickets — user-submitted Get Help forms */}
+            <div className="mc-panel" style={{ gridColumn: '1 / -1' }}>
+              <div className="mc-panel-header">
+                <span className="mc-panel-title">SUPPORT TICKETS</span>
+                <span className="mc-panel-meta">{tickets.length} total</span>
+              </div>
+              {tickets.length === 0 ? (
+                <div className="mc-empty" style={{ padding: '20px 4px' }}>No tickets yet.</div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 480, overflowY: 'auto' }}>
+                  {tickets.map(t => {
+                    const isOpen = expandedTicket === t.id;
+                    const catColor =
+                      t.category === 'bug' ? '#ef4444' :
+                      t.category === 'feature' ? '#8b5cf6' :
+                      t.category === 'question' ? '#3b82f6' : '#64748b';
+                    return (
+                      <div key={t.id} style={{ border: '1px solid var(--color-border, #e2e8f0)', borderRadius: 8, background: 'var(--color-bg, #f8fafc)' }}>
+                        <button
+                          type="button"
+                          onClick={() => setExpandedTicket(isOpen ? null : t.id)}
+                          style={{
+                            width: '100%', display: 'flex', alignItems: 'center', gap: 10,
+                            padding: '10px 12px', background: 'none', border: 'none', cursor: 'pointer',
+                            fontFamily: 'inherit', textAlign: 'left',
+                          }}
+                        >
+                          <span style={{
+                            fontSize: 10, fontWeight: 700, color: '#ffffff', background: catColor,
+                            padding: '2px 8px', borderRadius: 4, textTransform: 'uppercase', letterSpacing: '0.05em',
+                          }}>{t.category}</span>
+                          <span style={{ fontSize: 13, fontWeight: 600, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--color-text, #1e293b)' }}>
+                            {t.subject}
+                          </span>
+                          <span style={{ fontSize: 11, color: '#64748b' }}>
+                            {t.brand_name || t.user_email || '—'}
+                          </span>
+                          <span style={{ fontSize: 11, color: '#94a3b8' }}>{timeAgo(t.created_at)}</span>
+                        </button>
+                        {isOpen && (
+                          <div style={{ borderTop: '1px solid var(--color-border, #e2e8f0)', padding: '10px 12px', fontSize: 12 }}>
+                            <div style={{ marginBottom: 8, color: '#64748b' }}>
+                              <div><strong>User:</strong> {t.user_email || '(no email)'} <code style={{ fontSize: 10, color: '#94a3b8' }}>{t.clerk_user_id}</code></div>
+                              <div><strong>Brand:</strong> {t.brand_name || '—'} <code style={{ fontSize: 10, color: '#94a3b8' }}>{t.brand_profile_id || ''}</code></div>
+                              <div><strong>Page:</strong> <code style={{ fontSize: 10 }}>{t.page_url || '—'}</code></div>
+                              <div><strong>Status:</strong> {t.status}</div>
+                              <div><strong>Attached alerts:</strong> {Array.isArray(t.attached_alert_ids) ? t.attached_alert_ids.length : 0}</div>
+                            </div>
+                            <div style={{
+                              whiteSpace: 'pre-wrap', background: '#ffffff',
+                              border: '1px solid var(--color-border, #e2e8f0)', borderRadius: 6,
+                              padding: 10, fontSize: 12, lineHeight: 1.6, color: 'var(--color-text, #1e293b)',
+                            }}>{t.body}</div>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
             </div>
 
           </>

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -76,7 +76,7 @@ function sameDay(a: Date, b: Date): boolean {
 
 function CalendarPage() {
   useWideLayout();
-  const { activeBrand } = useApp();
+  const { activeBrand, reportError } = useApp();
   const [items, setItems] = useState<QueueItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [viewDate, setViewDate] = useState(() => {
@@ -102,7 +102,7 @@ function CalendarPage() {
         else if (Array.isArray(d.queue)) setItems(d.queue);
         else if (Array.isArray(d)) setItems(d);
       })
-      .catch(err => console.error('[calendar] fetch failed:', err))
+      .catch(err => { console.error('[calendar] fetch failed:', err); reportError(err, { area: 'calendar' }); })
       .finally(() => setLoading(false));
   }, [activeBrand?.id]);
 

--- a/src/pages/CampaignGeneratorPage.tsx
+++ b/src/pages/CampaignGeneratorPage.tsx
@@ -102,7 +102,7 @@ function CampaignGeneratorContent() {
   const [streamBuffer, setStreamBuffer] = useState('');
   const [error, setError] = useState('');
   const esRef = useRef<EventSource | null>(null);
-  const { historyEntries, activeBrand } = useApp();
+  const { historyEntries, activeBrand, reportError } = useApp();
 
   const brains: Brain[] = historyEntries.map(e => ({ id: e.id, brandName: e.brandName, brandUrl: e.brandUrl }));
 
@@ -373,6 +373,7 @@ function CampaignGeneratorContent() {
       });
     } catch (err: any) {
       console.error('[RESTART]', err.message);
+      reportError(err, { area: 'campaign-generator' });
     } finally {
       setIsRestarting(false);
     }

--- a/src/pages/ComplianceGatePage.tsx
+++ b/src/pages/ComplianceGatePage.tsx
@@ -149,7 +149,7 @@ function HighlightedBody({ body, flag }: { body: string; flag: any }) {
 }
 
 function ComplianceGateContent() {
-  const { activeBrand, authToken } = useApp();
+  const { activeBrand, authToken, reportError } = useApp();
   const { getToken } = useAuth();
 
 
@@ -308,6 +308,7 @@ function ComplianceGateContent() {
       setDismissedFlags(p => ({ ...p, [sectionIdx]: true }));
     } catch(e) {
       console.error('Dismiss flag error:', e);
+      reportError(e, { area: 'compliance-gate' });
     }
   };
 
@@ -511,6 +512,7 @@ function ComplianceGateContent() {
       }
     } catch (err) {
       console.error('[rewrite-selection]', err);
+      reportError(err, { area: 'compliance-gate' });
     } finally {
       setRewriteSelLoading(false);
     }

--- a/src/pages/GeoStrategistPage.tsx
+++ b/src/pages/GeoStrategistPage.tsx
@@ -76,7 +76,7 @@ const STAGES = [
 ];
 
 function GeoStrategistContent() {
-  const { setCurrentView, historyEntries, activeBrand, authToken } = useApp();
+  const { setCurrentView, historyEntries, activeBrand, authToken, reportError } = useApp();
   const { getToken } = useAuth();
   const [selectedBrainId, setSelectedBrainId] = useState('');
   const [isRunning, setIsRunning] = useState(false);
@@ -216,6 +216,7 @@ function GeoStrategistContent() {
     } catch(e: any) {
       // Preserve the full error object + stack in console so a repeat is diagnosable
       console.error('[buildBriefsForSelected] failed:', e, { name: e?.name, message: e?.message });
+      reportError(e, { area: 'geo-strategist' });
       setBriefBuildError(e?.message || 'Brief build failed — check console for details.');
     } finally {
       setBuildingBriefs(false);

--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -455,7 +455,7 @@ function RedditAllowedSubreddits({
 }
 
 export default function IntegrationsPage() {
-  const { isPaid, brandLoading, activeBrand } = useApp();
+  const { isPaid, brandLoading, activeBrand, reportError } = useApp();
   
   const selectedBrand = activeBrand?.id || '';
   const [savedChannels, setSavedChannels] = useState<Record<ChannelId, SavedChannel | null>>({
@@ -616,6 +616,7 @@ export default function IntegrationsPage() {
       } catch(e: any) {
         console.error('[Pipedream Connect Catch]', e);
         if (e?.message !== 'User closed the connect dialog') {
+          reportError(e, { area: 'integrations' });
           setError(`Could not connect ${channel.label}: ${e?.message || JSON.stringify(e)}`);
         }
       }

--- a/src/pages/PerformanceDashboardPage.tsx
+++ b/src/pages/PerformanceDashboardPage.tsx
@@ -114,7 +114,7 @@ function Sparkline({ data, key: _k }: { data: number[]; key?: string }) {
 
 
 export default function PerformanceDashboardPage() {
-  const { isPaid, brandLoading, activeBrand, authToken } = useApp();
+  const { isPaid, brandLoading, activeBrand, authToken, reportError } = useApp();
   
   // brandProfileId and ah computed before hooks — not hooks themselves
   const brandProfileId = activeBrand?.id ?? '';
@@ -356,7 +356,7 @@ export default function PerformanceDashboardPage() {
       const r = await fetch(`/api/analytics/webflow-seo/${brandProfileId}`, { headers: h });
       const d = await r.json();
       if (d.success) setWfSeo(d);
-    } catch(e) { console.error('Webflow SEO fetch error:', e); }
+    } catch(e) { console.error('Webflow SEO fetch error:', e); reportError(e, { area: 'performance' }); }
     finally { setWfSeoLoading(false); }
   };
 

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -177,7 +177,7 @@ interface QueueItem {
 interface ConnectedChannel { channel: string; }
 
 export default function PublishingQueuePage() {
-  const { isPaid, activeBrand, brandLoading, authToken } = useApp();
+  const { isPaid, activeBrand, brandLoading, authToken, reportError } = useApp();
   const activeBrandId = activeBrand?.id ?? null;
   const ah: Record<string, string> = authToken ? { Authorization: `Bearer ${authToken}` } : {};
   
@@ -364,14 +364,14 @@ export default function PublishingQueuePage() {
     try {
       await fetch(`/api/publishing/queue/${item.id}/archive`, { method: 'POST', headers: ah });
       loadQueue();
-    } catch(e) { console.error('Archive failed', e); }
+    } catch(e) { console.error('Archive failed', e); reportError(e, { area: 'publishing-queue' }); }
   };
 
   const unarchiveItem = async (item: QueueItem) => {
     try {
       await fetch(`/api/publishing/queue/${item.id}/unarchive`, { method: 'POST', headers: ah });
       setItems(prev => prev.map(i => i.id === item.id ? { ...i, status: 'staged' } : i));
-    } catch(e) { console.error('Unarchive failed', e); }
+    } catch(e) { console.error('Unarchive failed', e); reportError(e, { area: 'publishing-queue' }); }
   };
 
   const archiveCampaign = async (campId: string, campaignName: string) => {
@@ -387,7 +387,7 @@ export default function PublishingQueuePage() {
       setSuccessMsg(`Campaign archived — ${data.archivedCount} article${data.archivedCount === 1 ? '' : 's'}`);
       setTimeout(() => setSuccessMsg(''), 4000);
       loadQueue();
-    } catch(e) { console.error('Archive campaign failed', e); }
+    } catch(e) { console.error('Archive campaign failed', e); reportError(e, { area: 'publishing-queue' }); }
   };
 
   const unarchiveCampaign = async (campId: string, campaignName: string) => {
@@ -402,7 +402,7 @@ export default function PublishingQueuePage() {
       setSuccessMsg(`Campaign "${campaignName}" restored — ${data.restoredCount} article${data.restoredCount === 1 ? '' : 's'}`);
       setTimeout(() => setSuccessMsg(''), 4000);
       loadQueue();
-    } catch(e) { console.error('Unarchive campaign failed', e); }
+    } catch(e) { console.error('Unarchive campaign failed', e); reportError(e, { area: 'publishing-queue' }); }
   };
 
   const loadQueue = useCallback(async () => {

--- a/src/pages/SocialGeneratorPage.tsx
+++ b/src/pages/SocialGeneratorPage.tsx
@@ -834,6 +834,7 @@ function SocialGeneratorContent() {
 
 // ─── Post card with inline edit + queue ─────────────────────────────────────
 function PostCard({ post, authToken, xConnected, onUpdate }: { post: SocialPost; authToken: string | null; xConnected: boolean; onUpdate: (p: SocialPost) => void }) {
+  const { reportError } = useApp();
   const [isEditing, setIsEditing] = useState(false);
   const [editedBody, setEditedBody] = useState(post.user_edited_body || post.body);
   const [saving, setSaving] = useState(false);
@@ -881,6 +882,7 @@ function PostCard({ post, authToken, xConnected, onUpdate }: { post: SocialPost;
       // AbortError fires when the user dismisses the share sheet — not an error to surface.
       if (e instanceof Error && e.name === 'AbortError') return;
       console.error('[share-image] failed:', e);
+      reportError(e, { area: 'social-generator' });
       alert(`Couldn't share the image: ${e instanceof Error ? e.message : 'unknown error'}`);
     }
   };


### PR DESCRIPTION
> _This PR was opened by an AI agent ([OpenHands](https://docs.openhands.dev/)) on behalf of the requester. Human review required before merge._

## Summary

Adds a user-facing **Alerts** surface to Forge Intelligence:

- A **bell icon in the topbar** (signed-in users only) with an unread badge.
- A **dropdown panel** showing the user's recent errors as short, plain-English messages — never raw stack traces.
- A **"Get Help" button** in the panel that opens a small form which submits a support ticket to Brian via Resend, with the user's recent alerts auto-attached as context.

Driven by the plan in `.agents_tmp/PLAN.md`. Implements all 10 steps end-to-end.

## What's in the box

### Database — `init-schema.sql` + `initDB()`
Two new tables, created idempotently so existing deploys self-migrate:
- `user_alerts` — user-scoped, indexed on `(clerk_user_id, created_at DESC)`. Stores both the user-safe `short_message` and the admin-only `raw_message`.
- `support_tickets` — indexed on `(status, created_at DESC)`. `attached_alert_ids` is JSONB.

### Backend endpoints — `server.js`
All gated by the existing `requireAuth` (Clerk JWT). User-facing endpoints **never** return rows that don't belong to `req.userId`.

| Endpoint | Notes |
|---|---|
| `POST /api/alerts` | Stores a client-reported alert. Truncates fields (`short_message` ≤ 200, `raw_message` ≤ 2000). Server-side 60-second de-dupe on `(clerk_user_id, short_message, area)` — returns the existing row instead of inserting a duplicate. |
| `GET /api/alerts` | Last 50 alerts for the current user, last 14 days, newest first. Returns `unreadCount`. |
| `POST /api/alerts/read` | Marks read by id list, or all unread if no body. Only touches rows owned by the user (`id = ANY($2::uuid[])`). |
| `POST /api/support/ticket` | Validates inputs, persists the ticket, then fires a Resend email to Brian with the user's email, brand, page, UA, body and attached alerts (raw_message truncated to 500 chars, HTML-escaped). Email failures are logged but never fail the request. |
| `GET /api/admin/support/tickets` | Super-admin only. Latest 100 tickets, brand name joined. |

### Frontend
New client modules:
- `src/lib/humanizeError.ts` — Maps HTTP status / error name / common substrings to short user-safe strings. Suppresses `AbortError`. Returns `{ shortMessage, severity, rawMessage }`.
- `src/lib/time.ts` — Extracted `timeAgo()` from `AdminPage`, now reused by `AlertsBell`.
- `src/lib/fetchWithAlert.ts` — Opt-in fetch wrapper that auto-reports non-2xx responses and network errors. Pages can adopt incrementally.

`src/context/AppContext.tsx` is extended with:
- `alerts: Alert[]`, `unreadAlertCount`, `reportError(err, ctx)`, `markAlertsRead(ids?)`, `refetchAlerts()`.
- Hydrates from `/api/alerts` when `authToken` becomes available.
- Optimistic in-memory rows with temp ids, reconciled with the server's UUID on POST response.
- Client-side 60s de-dupe matching the server window — no double-up between local optimistic alert and server-confirmed row.
- Global `window.error` + `unhandledrejection` listeners feeding `reportError`.

UI components:
- `src/components/AlertsBell.tsx` + `.css` — Bell button with badge (9+ cap), dark-theme dropdown matching the existing TopBar dropdowns, click-outside-to-close, "Mark all read" link, prominent "Get Help" CTA, severity dot + area tag + relative time per row, empty state.
- `src/components/GetHelpModal.tsx` + `.css` — Category select, Subject + Description with live char counters, page + brand context shown inline, last-5-alerts checklist (default-checked), success/error inline states, auto-close 4s after success, Escape-to-close.
- `src/components/TopBar.tsx` — Renders `<AlertsBell />` inside `topbar-right` between the cache indicator and the user avatar, wrapped in `<SignedIn>`.

### Admin panel — `src/pages/AdminPage.tsx`
- Polls `/api/admin/support/tickets` every 60s.
- New **SUPPORT TICKETS** panel at the bottom of Mission Control: color-coded category badge (bug/feature/question/other), subject row with brand + relative time, expandable detail with user / brand / page / status / attached-alert count / full description.

### Page migrations (Step 9)
Added `reportError(e, { area: '<page-slug>' })` to the existing catch sites in nine pages — most importantly the silent ones in `PublishingQueuePage` (the four archive/unarchive flows that previously only `console.error`'d). The pages are:

`GeoStrategistPage`, `ComplianceGatePage` (×2), `PublishingQueuePage` (×4), `CalendarPage`, `SocialGeneratorPage` (inside `PostCard`, which has its own `useApp()`), `CampaignGeneratorPage`, `PerformanceDashboardPage`, `IntegrationsPage`.

Pages not yet migrated are still covered by the global `window` listeners; they can be migrated incrementally without touching the framework.

## Security review

- All user-facing endpoints scoped by `clerk_user_id` from the verified Clerk JWT — no cross-tenant leakage.
- `short_message` (humanized, ≤ 200 chars) is the **only** field surfaced in the UI; `raw_message` (≤ 2 KB) stays admin-only.
- HTML escaping on every email-interpolated field (`&`, `<`, `>`).
- Server-side input validation: category + severity enums, length truncation on every TEXT field, explicit `::uuid[]` casting for `ids`.
- Resend failures are logged-and-continue so the ticket is still persisted even if the outbound email fails.

## Validation

- `node --check server.js` → OK
- `npx tsc --noEmit` → clean
- `npm run build` → success (308 KB CSS / 1.77 MB JS, same warning profile as `development`)

## Manual smoke-test checklist (from the plan)

1. Sign in as a non-admin → bell appears, no badge.
2. Trigger a failure → badge increments within ~1s, dropdown shows a friendly message with the correct area tag.
3. Refresh → alert persists (server-hydrated), badge state preserved.
4. **Mark all read** → badge clears; survives reload.
5. **Get Help** form → success state, ticket exists in `support_tickets`, Brian receives the email.
6. Sign in as a different user → does NOT see the previous user's alerts.
7. Super-admin → bell works AND `/api/admin/support/tickets` returns the ticket in the Admin panel.
8. Trigger the same error 5× in 30s → only one row (server de-dupe).
9. `throw new Error('boom')` from console → captured by the global listener, surfaced through the bell.

## Files changed

- **Modified:** `init-schema.sql`, `server.js`, `src/components/TopBar.tsx`, `src/context/AppContext.tsx`, `src/pages/AdminPage.tsx`, plus 8 page files for the catch-site migrations.
- **New:** `src/components/AlertsBell.{tsx,css}`, `src/components/GetHelpModal.{tsx,css}`, `src/lib/humanizeError.ts`, `src/lib/time.ts`, `src/lib/fetchWithAlert.ts`.

## Out of scope (deliberate)

- No new vendor (Sentry/Bugsnag) — keeps the bell snappy and the dependency tree clean, per the plan's rejected alternatives.
- Remaining silent-`console.error` sites in pages not listed above are still caught by the global `window` listeners and can be migrated in follow-up PRs without touching the alert framework itself.

@BrianBMorgan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/941b8347-7955-47af-a8ca-7f4aaf43414d)