### PR TITLE
feat(content-generator): typed topic → full pipeline (no GEO Strategist required)

### DIFF
--- a/server.js
+++ b/server.js
@@ -17538,6 +17538,134 @@ Generate 5-7 H2s that build a coherent argument. Align entities with schema requ
   }
 });
 
+// POST /api/geo/topic-brief/from-topic — Stage 2.1 entry point for user-typed topics
+// Body: { brandProfileId, topic, refinement? }
+//
+// Lets a user enter the pipeline at brief-creation without first running the
+// GEO Strategist. Useful when the user already knows what they want to write
+// about (e.g., an exec passes down a topic) — they type it on the Content
+// Generator page, hit "Build brief →", and we drop them at the Authenticity
+// Enricher with a fresh topic brief ready to enrich.
+//
+// We materialize a synthetic geo_opportunities row so the schema constraints
+// (geo_topic_briefs.opportunity_id NOT NULL → geo_opportunities) keep
+// holding. Downstream code that joins topic briefs to opportunities by ID
+// continues to work unchanged.
+app.post('/api/geo/topic-brief/from-topic', requireAuth, express.json(), async (req, res) => {
+  const { brandProfileId, topic, refinement } = req.body || {};
+  if (!brandProfileId) return res.status(400).json({ success: false, error: 'brandProfileId required' });
+  if (!topic || !topic.trim()) return res.status(400).json({ success: false, error: 'topic required' });
+
+  try {
+    const profileRes = await pool.query(
+      `SELECT id, brand_url, brand_name, version, profile_data, settings FROM brand_profiles WHERE id = $1`,
+      [brandProfileId]
+    );
+    if (!profileRes.rows.length) return res.status(404).json({ success: false, error: 'Brand not found' });
+    const profile = profileRes.rows[0];
+    const pd = profile.profile_data || {};
+    const voiceProfile = pd.voice_profile || pd.voiceProfile || {};
+    const personas = pd.personas || [];
+
+    // Same brain + factual context as the standard Build Briefs path
+    const patternsRes = await pool.query(
+      `SELECT pattern_type, description FROM brain_patterns WHERE brand_profile_id = $1 ORDER BY created_at DESC LIMIT 20`,
+      [brandProfileId]
+    );
+    const brainContext = patternsRes.rows.length
+      ? 'BRAIN PATTERNS (respect these):\n' + patternsRes.rows.map(p => `- [${p.pattern_type}] ${p.description}`).join('\n')
+      : 'No brain patterns yet.';
+    const fg = (profile.settings || {}).factualGround || {};
+    const factualContext = [
+      fg.whatWeDo && `What we do: ${fg.whatWeDo}`,
+      fg.whatWeDontDo && `What we don't do: ${fg.whatWeDontDo}`,
+      fg.methodology && `Methodology: ${fg.methodology.slice(0, 400)}`
+    ].filter(Boolean).join('\n\n');
+
+    // 1) Materialize a synthetic opportunity row so the FK on geo_topic_briefs
+    //    holds. Source is implicit (no quick_win, no platform_scores, no TAC)
+    //    — downstream readers treat it as a hand-entered topic.
+    const oppInsert = await pool.query(
+      `INSERT INTO geo_opportunities (brand_profile_id, brain_version, topic, status, status_changed_at)
+       VALUES ($1, $2, $3, 'briefed', NOW()) RETURNING id`,
+      [brandProfileId, profile.version || 1, topic.trim()]
+    );
+    const opportunityId = oppInsert.rows[0].id;
+
+    // 2) Run the brief builder. Prompt mirrors /api/geo/opportunities/build-briefs
+    //    so output shape stays identical and downstream parsers don't drift.
+    const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+    const briefRes = await anthropic.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 6144,
+      messages: [{ role: 'user', content: `${dateContext()}
+
+You are the Topic Brief Builder (Stage 2.1) for Forge Intelligence.
+
+BRAND: ${profile.brand_name}
+VOICE: ${JSON.stringify(voiceProfile).slice(0, 400)}
+PERSONAS: ${JSON.stringify(personas).slice(0, 400)}
+
+${factualContext ? 'FACTUAL GROUND (use verbatim):\n' + factualContext + '\n\n' : ''}${brainContext}
+
+TOPIC THE USER ENTERED: "${topic.trim()}"
+${refinement && refinement.trim() ? `USER REFINEMENT / ANGLE NOTES: "${refinement.trim()}"\n` : ''}
+NOTE: This topic was entered by the user directly (not surfaced by the GEO Strategist).
+There are no platform scores or topical-authority context for it yet — build the brief
+from the brand voice, personas, factual ground, and brain patterns above. If the topic
+is off-strategy for the brand, build it anyway but flag the tension in briefRationale.
+
+Build a GEO-optimized content brief for THIS SPECIFIC TOPIC. Return ONLY valid JSON:
+{
+  "h1": "string — compelling H1 with topic + differentiated angle",
+  "executiveSummary": "string — 2-3 sentences on what this article accomplishes",
+  "h2s": [{"heading":"string","intent":"string explaining why this section exists","geoAnchor":"string — key phrase for AI citation"}],
+  "entities": ["string"],
+  "faqStructure": [{"question":"string","answerDirection":"string"}],
+  "geoAnchors": ["string"],
+  "schemaRequirements": ["string"],
+  "targetPlatforms": ["string"],
+  "briefRationale": "string — why this angle, for this brand, now"
+}
+
+Generate 5-7 H2s that build a coherent argument. Align entities with schema requirements.`
+      }]
+    });
+
+    let briefData;
+    try {
+      const raw = briefRes.content[0].text;
+      briefData = JSON.parse(extractJSON(raw, 'object'));
+    } catch (parseErr) {
+      console.log('[FROM-TOPIC] parse warn for', topic, ':', parseErr.message);
+      briefData = {
+        h1: topic.trim(), executiveSummary: 'Brief generation incomplete — retry needed.',
+        h2s: [], entities: [], faqStructure: [], geoAnchors: [],
+        schemaRequirements: [], targetPlatforms: [], briefRationale: 'parse-error'
+      };
+    }
+
+    // 3) Persist the brief
+    const briefInsert = await pool.query(
+      `INSERT INTO geo_topic_briefs (opportunity_id, brand_profile_id, brief_data, brain_version, status)
+       VALUES ($1, $2, $3, $4, 'briefed') RETURNING id, created_at`,
+      [opportunityId, brandProfileId, JSON.stringify(briefData), profile.version || 1]
+    );
+
+    res.json({
+      success: true,
+      briefId: briefInsert.rows[0].id,
+      opportunityId,
+      topic: topic.trim(),
+      briefData,
+      createdAt: briefInsert.rows[0].created_at
+    });
+  } catch (e) {
+    console.error('[FROM-TOPIC] error:', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
 // GET /api/geo/topic-briefs/:brandProfileId — briefed topics (includes backlog)
 app.get('/api/geo/topic-briefs/:brandProfileId', requireAuth, async (req, res) => {
   try {

--- a/src/pages/ContentGeneratorPage.tsx
+++ b/src/pages/ContentGeneratorPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AppShell } from '../layouts/AppShell';
 import { useApp } from '../context/AppContext';
 import './ContentGeneratorPage.css';
@@ -135,7 +136,9 @@ function ContentGeneratorContent() {
   const [newIdeaNote, setNewIdeaNote] = useState('');
   const [savingIdea, setSavingIdea] = useState(false);
   const [preflight, setPreflight] = useState<{ status: string; signal?: string; confidence?: string; reframe?: string; reframeRationale?: string; reason?: string }>({ status: 'idle' });
+  const [buildingBrief, setBuildingBrief] = useState(false);
 
+  const navigate = useNavigate();
   const { historyEntries, activeBrand, authToken } = useApp();
   let brains: Brain[] = historyEntries.map(e => ({ id: e.id, brandName: e.brandName, brandUrl: e.brandUrl }));
 
@@ -252,6 +255,32 @@ function ContentGeneratorContent() {
     setIdeas(prev => prev.map(i => i.id === idea.id ? { ...i, status: 'in_progress' } : i));
     setIdeaDrawerOpen(false);
     setTimeout(() => document.querySelector<HTMLElement>('.cg-topic-input')?.focus(), 150);
+  };
+
+  // User typed a topic but hasn't selected an existing enriched brief — enter
+  // the pipeline at the brief-creation stage and hand off to the Authenticity
+  // Enricher (which auto-fires when arriving with ?topicBriefId=X).
+  const buildBriefFromTopic = async () => {
+    if (!activeBrand?.id || !topicPrompt.trim() || buildingBrief) return;
+    setBuildingBrief(true);
+    try {
+      const r = await fetch('/api/geo/topic-brief/from-topic', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          brandProfileId: activeBrand.id,
+          topic: topicPrompt.trim(),
+        }),
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d.error || 'Brief build failed');
+      navigate(`/app/authenticity-enricher?topicBriefId=${d.briefId}`);
+    } catch (e) {
+      console.error('[CG] from-topic brief build failed:', (e as Error).message);
+      alert(`Couldn't build brief from topic: ${(e as Error).message}`);
+    } finally {
+      setBuildingBrief(false);
+    }
   };
 
   const runGeneration = () => {
@@ -454,7 +483,8 @@ function ContentGeneratorContent() {
           <div className="geo-input-bar">
           <div style={{ flex: 1 }}>
             <input
-              className="geo-input cg-topic-input" placeholder="Optional: refine the angle within this brief"
+              className="geo-input cg-topic-input"
+              placeholder={selectedBriefId ? "Optional: refine the angle within the selected brief" : "Type a topic to start the pipeline (no GEO Strategist run required)"}
               value={topicPrompt}
               onChange={e => { setTopicPrompt(e.target.value); setPreflight({ status: 'idle' }); }}
               onBlur={checkTopic}
@@ -485,9 +515,27 @@ function ContentGeneratorContent() {
               </div>
             )}
           </div>
-          <button className="geo-run-btn" onClick={runGeneration} disabled={!selectedBrainId || !selectedBriefId}>
-            <FileText size={14} /> Generate Article
-          </button>
+          {/* Conditional CTA:
+                - Brief selected → "Generate Article" (proceed with that brief)
+                - No brief + typed topic → "Build brief →" (user-typed-topic
+                  entry into the pipeline; lands at Authenticity Enricher with
+                  the new brief auto-firing enrichment)
+                - Neither → disabled "Generate Article" with hint
+              The build-brief path replaces the dead-end UX where a typed topic
+              had no path forward unless the user backtracked to GEO Strategist. */}
+          {selectedBriefId ? (
+            <button className="geo-run-btn" onClick={runGeneration} disabled={!selectedBrainId}>
+              <FileText size={14} /> Generate Article
+            </button>
+          ) : topicPrompt.trim() ? (
+            <button className="geo-run-btn" onClick={buildBriefFromTopic} disabled={!selectedBrainId || buildingBrief}>
+              <FileText size={14} /> {buildingBrief ? 'Building brief…' : 'Build brief →'}
+            </button>
+          ) : (
+            <button className="geo-run-btn" disabled title="Select a brief or type a topic">
+              <FileText size={14} /> Generate Article
+            </button>
+          )}
           </div>
 
           {/* Advanced direction — only when user has typed a topic. Lets them


### PR DESCRIPTION
## Why

The topic input on the Content Generator page was labeled `"Optional: refine the angle within this brief"` — meaning a typed topic would overlay onto an already-selected brief instead of standing on its own. Result: the **"Generate Article" button stayed disabled unless a brief was selected**, and a user who typed a topic had no path forward unless they backtracked to GEO Strategist. Brian flagged this as *"crashing the topic into an existing brief and hoping it doesn't come out with three legs."*

The real user intent when typing in that field is *"I want to write about THIS — make it happen."* This PR makes that intent first-class.

## What

### New backend endpoint

```
POST /api/geo/topic-brief/from-topic
{ brandProfileId, topic, refinement? }
```

Lets a user enter the pipeline at brief-creation without running GEO Strategist first. Internally:

1. Loads brand profile + brain patterns + factual ground (mirrors the existing Build Briefs path)
2. **Materializes a synthetic `geo_opportunities` row** so `geo_topic_briefs.opportunity_id NOT NULL → geo_opportunities` FK keeps holding. No schema change needed.
3. Runs the same Claude Sonnet 4.6 brief-builder prompt with a note that the topic was user-entered (no platform scores or TAC available; build from brand voice + brain + factual). If the topic is off-strategy, the prompt asks Claude to flag the tension in `briefRationale` rather than refuse.
4. Returns `{ briefId, opportunityId, topic, briefData, createdAt }`

Output shape matches `/api/geo/opportunities/build-briefs` so downstream parsers don't drift.

### Frontend

| State | Input placeholder | CTA |
|---|---|---|
| Brief selected | "Optional: refine the angle within the selected brief" | **Generate Article** (existing behavior) |
| No brief + topic typed | "Type a topic to start the pipeline (no GEO Strategist run required)" | **Build brief →** (new path) |
| No brief + no topic | (same as above) | Generate Article, disabled with tooltip |

On "Build brief →": POST to the new endpoint, then `navigate('/app/authenticity-enricher?topicBriefId=<new>')` — which already auto-fires enrichment per the existing wiring. User lands back at Content Generator with the enriched brief selected and the standard generation path active.

## Why it matters strategically

> *"This is great for those execs who have stupid ideas that need hard compliance injection."* — Brian

The Brain Match preflight already runs on the topic input (signals strong/caution/avoid based on brand patterns); the new path means even off-thesis topics get processed through the full Authenticity Enricher → Content Generator → Compliance Gate pipeline, so brand intelligence still drives results — not bypassed by the exec's gut call.

## Test plan

- [ ] Render deploys + Anthropic key issue resolved (separate)
- [ ] Brand with brief selected → "Generate Article" works as before
- [ ] Brand with no brief + typed topic → "Build brief →" appears, click sends to Enricher with new brief auto-firing
- [ ] No brief + no topic → button stays disabled with tooltip
- [ ] Brain Match preflight fires on blur in both modes
- [ ] After full round-trip (Enricher completes → back to Content Generator), the freshly-enriched brief appears as a selectable card and the user can generate the article normally

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_