### PR TITLE
feat(content-gen): self-as-case-study rule — drop humility when brand is the proof

### DIFF
--- a/server.js
+++ b/server.js
@@ -6953,8 +6953,31 @@ ${(() => {
 `
       : '';
 
+    // Self-as-case-study detection: when the brand's own name appears in Brain
+    // pattern evidence/tags or Factual Ground, the brand IS the proof source
+    // for at least one claim in this article. Flag it so the system prompt's
+    // "Self-as-Case-Study Rule" fires and the writer drops epistemic hedges on
+    // first-party validated outcomes. (Alpha shipped with blanket humility to
+    // keep brands from over-claiming; mature brand brains earn the right to
+    // stand on their documented evidence.)
+    const brandName = profileData?.brand_name || profile.brand_name || '';
+    const brandHost = (() => {
+      try { return new URL(profileData?.brand_url || profile.brand_url || '').hostname.replace(/^www\./, ''); }
+      catch { return ''; }
+    })();
+    const selfAsCaseStudy = brandName && [
+      ...patternsRes.rows.map(p => `${p.description || ''} ${JSON.stringify(p.tags || '')}`),
+      JSON.stringify(factualGround || {})
+    ].some(text => {
+      const hay = text.toLowerCase();
+      return hay.includes(brandName.toLowerCase()) || (brandHost && hay.includes(brandHost.toLowerCase()));
+    });
+    const selfAsCaseStudyBlock = selfAsCaseStudy
+      ? `\nSELF-AS-CASE-STUDY DETECTED: Brain evidence or Factual Ground references "${brandName}" directly. Apply the Self-as-Case-Study Rule from the system prompt — drop epistemic hedges on first-party validated outcomes, let the architectural claim stand. Keep hedges for unverified third-party claims.\n`
+      : '';
+
         const userPrompt = `Generate a long-form article using the following Brand Intelligence context.
-${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${factualGroundBlock}${territoriesBlock}
+${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${territoriesBlock}
 BRAND PROFILE:
 ${trimTo(profileData, 6000)}
 

--- a/src/agents/stage4_content_generator/system_prompt.md
+++ b/src/agents/stage4_content_generator/system_prompt.md
@@ -85,3 +85,18 @@ Answers must be 2-4 sentences, drawn from article body (do not introduce new cla
 - Never use competitor brand names as anchors unless explicitly in the competitive gap map.
 - Never write a generic intro. Open with the persona's specific trigger event.
 - Never produce a section with confidence "green" if there is no Brain evidence supporting it.
+
+## Self-as-Case-Study Rule
+When the brand is the proof source — i.e. the supporting evidence in Brain patterns, Factual Ground, or named events references the brand itself (the brand's own article, the brand's own product, a dated outcome the brand produced) — DROP epistemic hedges on that specific claim. The evidence chain is documented and first-party; treat it like any other cited fact.
+
+Hedges to DROP when the brand is the case study:
+- "one documented outcome, not a controlled study"
+- "epistemic honesty matters"
+- "is its own first case"
+- "additional client-facing evidence is not yet public"
+- "is not yet proven across [other contexts]"
+- Any phrasing that frames the brand's own validated outcome as merely anecdotal.
+
+Hedges to KEEP for unverified third-party claims, projected outcomes, or claims without Brain support.
+
+The architectural / methodological claim stands on what the brand actually built and shipped — say so plainly. Reserve epistemic caution for places where caution is actually warranted.


### PR DESCRIPTION
## Summary
- Alpha shipped with blanket epistemic humility ("one documented outcome, not a controlled study", "is its own first case") to keep brands from over-claiming when evidence was thin.
- Now that brand brains are maturing — Brain patterns extracted from real published articles, Factual Ground populated with first-party events — the hedges dull the punch on validated outcomes the brand actually produced.
- This change adds a **Self-as-Case-Study Rule** to the Content Generator: when the brand's own name or domain appears in Brain pattern evidence/tags or Factual Ground, the writer drops the humility scaffold for that claim and lets the architectural fact stand. Hedges stay for unverified third-party claims.

## Files
- `src/agents/stage4_content_generator/system_prompt.md` — adds the rule with an explicit list of hedges to drop vs. keep.
- `server.js` — scans Brain pattern descriptions + tags and Factual Ground for the brand name / brand domain at userPrompt build time; emits a `SELF-AS-CASE-STUDY DETECTED` directive that activates the rule.

## Test plan
- [ ] Generate an article for Forge Intelligence on a topic where Brain patterns cite the May 7 pillar — confirm the proof section drops "one documented outcome / not a controlled study / is its own first case" phrasing.
- [ ] Generate an article for a brand with no first-party evidence in Brain — confirm hedges are still present (humility scaffold preserved when warranted).
- [ ] Server logs unchanged on the detection path (no perf cost — string scan over already-loaded data).

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_