### PR TITLE
feat(ads-gen): expand to full Search campaign pack (sitelinks + callouts + keywords)

### DIFF
--- a/server.js
+++ b/server.js
@@ -7190,7 +7190,7 @@ app.post('/api/ads-generator/rsa', requireAuth, async (req, res) => {
     const voice = profileData.voice_profile || {};
     const personas = (profileData.personas || []).slice(0, 2);
 
-    const systemPrompt = `You are the Ads Generator for Forge Intelligence. You write Google Responsive Search Ads (RSA) asset packs anchored to a brand's intelligence layer — brain patterns, GEO territories, voice profile, Factual Ground.
+    const systemPrompt = `You are the Ads Generator for Forge Intelligence. You produce complete Google Search campaign asset packs — the full set Google now requires for a Search ad to run: headlines, descriptions, display paths, sitelinks, callouts, and keywords. Every asset is anchored to a brand's intelligence layer (brain patterns, GEO territories, voice profile, Factual Ground).
 
 OUTPUT — return ONLY valid JSON (no markdown, no code fences, no commentary):
 {
@@ -7203,6 +7203,21 @@ OUTPUT — return ONLY valid JSON (no markdown, no code fences, no commentary):
     // exactly 4 descriptions
   ],
   "paths": ["≤15 char path1", "≤15 char path2"],
+  "sitelinks": [
+    {
+      "linkText": "≤25 char clickable link label",
+      "description1": "≤35 char benefit/detail line 1",
+      "description2": "≤35 char benefit/detail line 2",
+      "finalUrl": "destination URL — leave empty string if the ad's Final URL should be used"
+    }
+    // exactly 6 sitelinks
+  ],
+  "callouts": ["≤25 char non-clickable promo phrase", /* exactly 8 callouts */],
+  "keywords": {
+    "broad":  ["broad-match keyword phrase", /* 8-12 entries */],
+    "phrase": ["phrase-match keyword phrase", /* 8-12 entries */],
+    "exact":  ["exact-match keyword phrase", /* 8-12 entries */]
+  },
   "notes": "1-2 sentences on the angle strategy across the pack"
 }
 
@@ -7220,12 +7235,33 @@ Descriptions:
 - Example PASS: "An 8-stage intelligence pipeline that conditions every word before generation." (80 chars). FAIL: "An 8-stage Context Agent Architecture that conditions every word before generation, powered by your brain." (108 chars).
 - If a sentence won't fit, split the idea or pick the punchier half. Do NOT submit a long version "for review" — that's a fail.
 
+Sitelinks:
+- linkText: AIM 18-22 chars, HARD CEILING 25 (Google clips past 25). Action phrasing — "See Pricing", "Read the May 7 Pillar", "Book a Demo".
+- description1 + description2: AIM 28-32 chars each, HARD CEILING 35 each. Treat as two short benefit lines that complement the link, NOT a sentence split across two lines.
+- finalUrl: leave as "" unless this sitelink deserves a different page than the ad's main Final URL (most sitelinks should differ — that's the point).
+- Example PASS: linkText "See the Pillar Article" (22), desc1 "May 7-8 Google AI Mode chain" (28), desc2 "Architecture, not volume" (24).
+- Exactly 6 sitelinks. Cover different intent paths (proof, pricing, product, founder story, latest pillar, FAQ).
+
+Callouts:
+- AIM 15-20 chars, HARD CEILING 25 each. Non-clickable promo phrases — short, punchy, benefit-led.
+- No articles ("the", "a"). No trailing punctuation.
+- Example PASS: "8-Stage Pipeline" (16), "Brand-Voice Locked" (18), "No Generic AI Slop" (18).
+- Exactly 8 callouts. Mix: feature, differentiator, social proof, urgency, brand-voice statement.
+
+Keywords:
+- 8-12 keywords per match type (broad, phrase, exact). 24-36 total across all three.
+- Plain keyword text only — NO match-type syntax. Do NOT wrap in quotes, brackets, or +modifiers. The downstream system applies the match type from the JSON key.
+- broad: looser variants, problem-language, persona pain phrases. e.g. "ai content that ranks", "fix generic ai copy".
+- phrase: 2-4 word commercial-intent phrases. e.g. "context agent architecture", "ai content intelligence platform".
+- exact: 1-3 word high-intent brand and category terms. e.g. "forge intelligence", "context agent architecture".
+- Lowercase. Do not duplicate the same phrase across match types unless intentional (e.g. brand terms in all three is fine).
+
 Path fields:
 - HARD CEILING 15 characters each. URL-safe (letters, numbers, hyphens only). Lowercase.
 
 Other:
-- Exactly 15 headlines, exactly 4 descriptions, exactly 2 paths.
-- Each headline must be DIFFERENT in angle — do not write 15 paraphrases of the same line. Cover: feature, benefit, persona pain, proof point, CTA, brand-voice statement, differentiator, urgency, named framework, social proof, question, comparison.
+- Exact counts: 15 headlines, 4 descriptions, 2 paths, 6 sitelinks, 8 callouts, 24-36 keywords total.
+- Each headline / sitelink / callout must be DIFFERENT in angle — do not paraphrase the same line repeatedly. Cover: feature, benefit, persona pain, proof point, CTA, brand-voice statement, differentiator, urgency, named framework, social proof, question, comparison.
 - Never use competitor names unless explicitly in the brand's competitive gap map.
 - Never fabricate stats, awards, or credentials.
 
@@ -7261,7 +7297,9 @@ Return ONLY the JSON object specified in the system prompt.`;
     const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
     const aiRes = await client.messages.create({
       model: 'claude-sonnet-4-6',
-      max_tokens: 3000,
+      // Bumped from 3000 → 4500 to fit expanded asset pack (sitelinks + callouts
+      // + keywords nearly double the JSON payload vs RSA-only).
+      max_tokens: 4500,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }]
     });
@@ -7277,22 +7315,52 @@ Return ONLY the JSON object specified in the system prompt.`;
 
     // Server-side char-limit enforcement. Flag any overages instead of silently
     // truncating — the user needs to know if Claude blew a budget so they can
-    // regen rather than ship a clipped headline.
-    const headlines = (parsed.headlines || []).map(h => ({
-      text: String(h.text || '').trim(),
-      anchor: String(h.anchor || '').trim(),
-      length: String(h.text || '').trim().length,
-      overLimit: String(h.text || '').trim().length > 30,
-    }));
-    const descriptions = (parsed.descriptions || []).map(d => ({
-      text: String(d.text || '').trim(),
-      anchor: String(d.anchor || '').trim(),
-      length: String(d.text || '').trim().length,
-      overLimit: String(d.text || '').trim().length > 90,
-    }));
+    // regen rather than ship a clipped asset.
+    const mkAsset = (text, anchor, cap) => {
+      const t = String(text || '').trim();
+      return { text: t, anchor: String(anchor || '').trim(), length: t.length, overLimit: t.length > cap };
+    };
+    const headlines = (parsed.headlines || []).map(h => mkAsset(h.text, h.anchor, 30));
+    const descriptions = (parsed.descriptions || []).map(d => mkAsset(d.text, d.anchor, 90));
     const paths = (parsed.paths || []).slice(0, 2).map(p => String(p || '').trim().toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 15));
 
-    const overages = [...headlines, ...descriptions].filter(x => x.overLimit).length;
+    const sitelinks = (parsed.sitelinks || []).map(s => {
+      const linkText = String(s.linkText || '').trim();
+      const description1 = String(s.description1 || '').trim();
+      const description2 = String(s.description2 || '').trim();
+      return {
+        linkText, description1, description2,
+        finalUrl: String(s.finalUrl || '').trim(),
+        linkTextLength: linkText.length,
+        description1Length: description1.length,
+        description2Length: description2.length,
+        overLimit: linkText.length > 25 || description1.length > 35 || description2.length > 35,
+      };
+    });
+
+    const callouts = (parsed.callouts || []).map(c => {
+      const t = String(c || '').trim();
+      return { text: t, length: t.length, overLimit: t.length > 25 };
+    });
+
+    // Keywords: trim, lowercase, dedupe-within-match-type, strip stray syntax
+    // (e.g. quotes/brackets) so the user can apply match types cleanly downstream.
+    const cleanKeywordList = (arr) => {
+      const seen = new Set();
+      return (arr || [])
+        .map(k => String(k || '').trim().toLowerCase().replace(/^[\["+]+|["+\]]+$/g, '').trim())
+        .filter(k => k && !seen.has(k) && (seen.add(k), true));
+    };
+    const keywords = {
+      broad: cleanKeywordList(parsed.keywords?.broad),
+      phrase: cleanKeywordList(parsed.keywords?.phrase),
+      exact: cleanKeywordList(parsed.keywords?.exact),
+    };
+
+    const overages =
+      [...headlines, ...descriptions].filter(x => x.overLimit).length +
+      sitelinks.filter(s => s.overLimit).length +
+      callouts.filter(c => c.overLimit).length;
 
     await pool.query(
       `INSERT INTO agent_activity_log (agent_name, brand_profile_id, status, tokens_used, latency_ms) VALUES ($1, $2, $3, $4, $5)`,
@@ -7306,6 +7374,9 @@ Return ONLY the JSON object specified in the system prompt.`;
         headlines,
         descriptions,
         paths,
+        sitelinks,
+        callouts,
+        keywords,
         notes: String(parsed.notes || '').trim(),
         finalUrl: finalUrl || '',
         topic: String(topic).trim(),

--- a/src/pages/AdsGeneratorPage.tsx
+++ b/src/pages/AdsGeneratorPage.tsx
@@ -6,10 +6,26 @@ import './ContentGeneratorPage.css';
 interface Brain { id: string; brandName: string; brandUrl: string }
 
 interface PackItem { text: string; anchor: string; length: number; overLimit: boolean }
+interface Sitelink {
+  linkText: string;
+  description1: string;
+  description2: string;
+  finalUrl: string;
+  linkTextLength: number;
+  description1Length: number;
+  description2Length: number;
+  overLimit: boolean;
+}
+interface Callout { text: string; length: number; overLimit: boolean }
+interface KeywordSet { broad: string[]; phrase: string[]; exact: string[] }
+
 interface AssetPack {
   headlines: PackItem[];
   descriptions: PackItem[];
   paths: string[];
+  sitelinks: Sitelink[];
+  callouts: Callout[];
+  keywords: KeywordSet;
   notes: string;
   finalUrl: string;
   topic: string;
@@ -82,25 +98,46 @@ function AdsGeneratorContent() {
     } catch {}
   };
 
-  // Google Ads bulk-upload CSV — one row per asset. Format matches Google Ads
-  // Editor / Google Ads UI's bulk-upload spec at the asset level so the user
-  // can paste headlines/descriptions in directly without per-row reformatting.
+  // Google Ads bulk-upload CSV — one row per asset, with the columns each asset
+  // type needs. The Google Ads bulk-upload spec uses one column set per asset
+  // type and ignores blank columns for types that don't use them, so a single
+  // wide CSV works for all 6 asset types here.
   const downloadCSV = () => {
     if (!pack) return;
-    const rows: string[] = ['Asset Type,Asset Text,Final URL,Path 1,Path 2'];
-    pack.headlines.forEach(h => rows.push(`Headline,"${h.text.replace(/"/g, '""')}","${pack.finalUrl}","${pack.paths[0] || ''}","${pack.paths[1] || ''}"`));
-    pack.descriptions.forEach(d => rows.push(`Description,"${d.text.replace(/"/g, '""')}","${pack.finalUrl}","${pack.paths[0] || ''}","${pack.paths[1] || ''}"`));
+    const esc = (s: string) => `"${(s || '').replace(/"/g, '""')}"`;
+    const header = 'Asset Type,Asset Text,Description 1,Description 2,Final URL,Path 1,Path 2,Match Type';
+    const rows: string[] = [header];
+    pack.headlines.forEach(h => rows.push(`Headline,${esc(h.text)},,,${esc(pack.finalUrl)},${esc(pack.paths[0] || '')},${esc(pack.paths[1] || '')},`));
+    pack.descriptions.forEach(d => rows.push(`Description,${esc(d.text)},,,${esc(pack.finalUrl)},${esc(pack.paths[0] || '')},${esc(pack.paths[1] || '')},`));
+    pack.sitelinks.forEach(s => rows.push(`Sitelink,${esc(s.linkText)},${esc(s.description1)},${esc(s.description2)},${esc(s.finalUrl || pack.finalUrl)},,,`));
+    pack.callouts.forEach(c => rows.push(`Callout,${esc(c.text)},,,,,,`));
+    pack.keywords.broad.forEach(k => rows.push(`Keyword,${esc(k)},,,,,,Broad`));
+    pack.keywords.phrase.forEach(k => rows.push(`Keyword,${esc(k)},,,,,,Phrase`));
+    pack.keywords.exact.forEach(k => rows.push(`Keyword,${esc(k)},,,,,,Exact`));
     const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `rsa-pack-${pack.topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40)}.csv`;
+    a.download = `search-pack-${pack.topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40)}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };
 
   const copyAllHeadlines = () => pack && copy(pack.headlines.map(h => h.text).join('\n'), 'all-h');
   const copyAllDescriptions = () => pack && copy(pack.descriptions.map(d => d.text).join('\n'), 'all-d');
+  const copyAllCallouts = () => pack && copy(pack.callouts.map(c => c.text).join('\n'), 'all-co');
+  // Match-typed keyword export: applies Google Ads bulk-add syntax — phrase
+  // gets quotes, exact gets brackets, broad is bare. User can paste straight
+  // into the Google Ads keyword bulk-add textarea.
+  const copyAllKeywords = () => {
+    if (!pack) return;
+    const lines = [
+      ...pack.keywords.broad,
+      ...pack.keywords.phrase.map(k => `"${k}"`),
+      ...pack.keywords.exact.map(k => `[${k}]`),
+    ];
+    copy(lines.join('\n'), 'all-kw');
+  };
 
   return (
     <div className="geo-content">
@@ -109,7 +146,7 @@ function AdsGeneratorContent() {
           <div className="geo-eyebrow">Stage 4.7 · PoC</div>
           <h1 className="geo-title">Ads Generator</h1>
           <p className="geo-description">
-            Google Responsive Search Ads asset pack — 15 headlines, 4 descriptions, 2 display paths — anchored to your brain, GEO territories, and Factual Ground. Paste straight into Google Ads or export as CSV.
+            Complete Google Search campaign asset pack — 15 headlines, 4 descriptions, 2 display paths, 6 sitelinks, 8 callouts, and match-typed keywords — anchored to your brain, GEO territories, and Factual Ground. Paste straight into Google Ads or export the full pack as CSV.
           </p>
         </div>
       </div>
@@ -251,6 +288,71 @@ function AdsGeneratorContent() {
               </div>
             </section>
           )}
+
+          {pack.sitelinks && pack.sitelinks.length > 0 && (
+            <section>
+              <div style={sectionHeader}>
+                <span>Sitelinks · {pack.sitelinks.length} · link 25 / desc 35 max</span>
+              </div>
+              <div style={{ display: 'grid', gap: 8 }}>
+                {pack.sitelinks.map((s, i) => (
+                  <SitelinkRow
+                    key={`sl${i}`}
+                    index={i + 1}
+                    sitelink={s}
+                    fallbackUrl={pack.finalUrl}
+                    onCopy={() => copy(`${s.linkText}\n${s.description1}\n${s.description2}\n${s.finalUrl || pack.finalUrl}`, `sl${i}`)}
+                    copied={copiedKey === `sl${i}`}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {pack.callouts && pack.callouts.length > 0 && (
+            <section>
+              <div style={sectionHeader}>
+                <span>Callouts · {pack.callouts.length} · 25 char max</span>
+                <button onClick={copyAllCallouts} style={smallBtn}><Copy size={12} /> {copiedKey === 'all-co' ? 'Copied' : 'Copy all'}</button>
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {pack.callouts.map((c, i) => (
+                  <button
+                    key={`co${i}`}
+                    onClick={() => copy(c.text, `co${i}`)}
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 6,
+                      padding: '6px 10px', fontSize: 13,
+                      background: c.overLimit ? '#FEE2E2' : 'var(--color-bg-card, #fff)',
+                      border: c.overLimit ? '1px solid #FCA5A5' : '1px solid var(--color-border, #e2e8f0)',
+                      borderRadius: 6, cursor: 'pointer',
+                      color: c.overLimit ? '#991B1B' : 'inherit',
+                    }}
+                    title={`${c.length}/25${c.overLimit ? ' — over limit' : ''}`}
+                  >
+                    {c.text}
+                    <span style={{ fontSize: 10, color: c.overLimit ? '#991B1B' : 'var(--color-text-muted, #94a3b8)', fontFamily: 'ui-monospace, monospace' }}>
+                      {copiedKey === `co${i}` ? '✓' : `${c.length}`}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {pack.keywords && (pack.keywords.broad.length + pack.keywords.phrase.length + pack.keywords.exact.length > 0) && (
+            <section>
+              <div style={sectionHeader}>
+                <span>Keywords · {pack.keywords.broad.length + pack.keywords.phrase.length + pack.keywords.exact.length} total · match-typed for bulk paste</span>
+                <button onClick={copyAllKeywords} style={smallBtn}><Copy size={12} /> {copiedKey === 'all-kw' ? 'Copied' : 'Copy all (match-typed)'}</button>
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10 }}>
+                <KeywordColumn label="Broad" hint="bare phrases" keywords={pack.keywords.broad} wrap={k => k} />
+                <KeywordColumn label="Phrase" hint='wrap "quotes"' keywords={pack.keywords.phrase} wrap={k => `"${k}"`} />
+                <KeywordColumn label="Exact" hint="wrap [brackets]" keywords={pack.keywords.exact} wrap={k => `[${k}]`} />
+              </div>
+            </section>
+          )}
         </div>
       )}
 
@@ -282,6 +384,60 @@ function AssetRow({ index, text, anchor, length, limit, overLimit, onCopy, copie
         <button onClick={onCopy} style={{ ...smallBtn, padding: '4px 8px' }}>
           <Copy size={12} /> {copied ? 'Copied' : 'Copy'}
         </button>
+      </div>
+    </div>
+  );
+}
+
+function SitelinkRow({ index, sitelink, fallbackUrl, onCopy, copied }: {
+  index: number; sitelink: Sitelink; fallbackUrl: string; onCopy: () => void; copied: boolean;
+}) {
+  const s = sitelink;
+  const ltColor = s.linkTextLength > 25 ? '#EF4444' : s.linkTextLength > 22 ? '#F5B942' : '#10B981';
+  const d1Color = s.description1Length > 35 ? '#EF4444' : s.description1Length > 32 ? '#F5B942' : '#10B981';
+  const d2Color = s.description2Length > 35 ? '#EF4444' : s.description2Length > 32 ? '#F5B942' : '#10B981';
+  return (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '24px 1fr auto', gap: 10, alignItems: 'flex-start',
+      padding: 10, background: 'var(--color-bg-card, #fff)',
+      border: s.overLimit ? '1px solid #FCA5A5' : '1px solid var(--color-border, #e2e8f0)',
+      borderRadius: 8,
+    }}>
+      <div style={{ fontSize: 11, color: 'var(--color-text-muted, #94a3b8)', paddingTop: 2 }}>{index}</div>
+      <div>
+        <div style={{ fontSize: 14, fontWeight: 600, lineHeight: 1.4, color: s.linkTextLength > 25 ? '#991B1B' : 'inherit' }}>{s.linkText}</div>
+        <div style={{ fontSize: 13, color: s.description1Length > 35 ? '#991B1B' : 'var(--color-text-secondary, #475569)', marginTop: 2 }}>{s.description1}</div>
+        <div style={{ fontSize: 13, color: s.description2Length > 35 ? '#991B1B' : 'var(--color-text-secondary, #475569)' }}>{s.description2}</div>
+        <div style={{ fontSize: 11, color: 'var(--color-text-muted, #94a3b8)', marginTop: 4, wordBreak: 'break-all' }}>
+          → {s.finalUrl || fallbackUrl || '(uses ad Final URL)'}
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+        <div style={{ fontSize: 10, color: ltColor, fontFamily: 'ui-monospace, monospace' }}>link {s.linkTextLength}/25</div>
+        <div style={{ fontSize: 10, color: d1Color, fontFamily: 'ui-monospace, monospace' }}>d1 {s.description1Length}/35</div>
+        <div style={{ fontSize: 10, color: d2Color, fontFamily: 'ui-monospace, monospace' }}>d2 {s.description2Length}/35</div>
+        <button onClick={onCopy} style={{ ...smallBtn, padding: '4px 8px', marginTop: 4 }}>
+          <Copy size={12} /> {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function KeywordColumn({ label, hint, keywords, wrap }: {
+  label: string; hint: string; keywords: string[]; wrap: (k: string) => string;
+}) {
+  return (
+    <div style={{ background: 'var(--color-bg-card, #fff)', border: '1px solid var(--color-border, #e2e8f0)', borderRadius: 8, padding: 10 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
+        <div style={{ fontSize: 12, fontWeight: 600 }}>{label}</div>
+        <div style={{ fontSize: 10, color: 'var(--color-text-muted, #94a3b8)' }}>{hint} · {keywords.length}</div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: 13, fontFamily: 'ui-monospace, monospace' }}>
+        {keywords.length === 0
+          ? <div style={{ color: 'var(--color-text-muted, #94a3b8)', fontStyle: 'italic' }}>(none)</div>
+          : keywords.map((k, i) => <div key={`${label}-${i}`} style={{ color: 'var(--color-text-secondary, #475569)' }}>{wrap(k)}</div>)
+        }
       </div>
     </div>
   );


### PR DESCRIPTION
## Stacking note

Stacked on top of **#152** (char-budget tightening). Merge #152 first, then this rebases cleanly onto main.

## Summary

Google now requires Search campaigns to ship with the broader asset set. Stage 4.7 Ads Generator now produces the full pack:

- 6 **sitelinks** — linkText (≤25) + description1 (≤35) + description2 (≤35) + optional per-sitelink Final URL
- 8 **callouts** — ≤25 char non-clickable promo phrases (chip grid)
- 24-36 **keywords** across broad / phrase / exact match types, with bulk-paste syntax preview and one-click "Copy all (match-typed)" that emits the correct Google Ads syntax

## Backend changes

- Prompt expanded with per-asset-type char budgets, aim/ceiling pairs, worked PASS/FAIL examples for sitelinks and callouts, anti-duplication rules across match types for keywords.
- Per-field length tracking on sitelinks (linkText/d1/d2 each checked independently), per-callout limit check, keyword dedup + lowercase + strip-stray-syntax.
- `max_tokens` bumped 3000 → 4500 to fit larger JSON payload.
- Overage counter spans all asset types.

## Frontend changes

- New `SitelinkRow` component with per-field budget indicators.
- New `KeywordColumn` component (3 columns: broad bare / phrase quoted / exact bracketed).
- Callout chips with inline char count, click-to-copy.
- Wide CSV export (8 columns) handles all 6 asset types in one file.
- Header copy updated to reflect new scope.

## Test plan
- [ ] Generate a Forge pack for "Context Agent Architecture" → verify all 6 sections render with content (15 / 4 / 2 / 6 / 8 / 24+).
- [ ] Verify no overages (red borders) on default generation.
- [ ] Click a callout chip → copies the phrase.
- [ ] "Copy all (match-typed)" keyword button → paste into a text editor, verify quotes on phrase and brackets on exact match.
- [ ] CSV export → paste into Google Ads Editor, verify each asset type lands in the right campaign field.

## Out of scope
- Persistence of generated packs (still PoC mode).
- Google Ads API publishing (Stage 3 of the roadmap).
- Structured snippets (deliberately deferred — user picked sitelinks/callouts/keywords only).

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_