### PR TITLE
fix(topbar): show 'Ads Generator' on /app/ads-generator instead of fallback

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -51,6 +51,7 @@ const viewTitles: Record<string, string> = {
   'geo-strategist': 'GEO Strategist',
   'authenticity-enricher': 'Authenticity Enricher',
   'content-generator': 'Content Generator',
+  'ads-generator': 'Ads Generator',
 };
 
 const pathTitles: Record<string, string> = {
@@ -58,6 +59,7 @@ const pathTitles: Record<string, string> = {
   '/app/authenticity-enricher':  'Authenticity Enricher',
   '/app/content-generator':      'Content Generator',
   '/app/social-generator':       'Social Generator',
+  '/app/ads-generator':          'Ads Generator',
   '/app/campaign-generator':     'Campaign Generator',
   '/app/compliance-gate':        'Compliance Gate',
   '/app/integrations':           'Integrations',

--- a/src/pages/AdsGeneratorPage.tsx
+++ b/src/pages/AdsGeneratorPage.tsx
@@ -143,7 +143,7 @@ function AdsGeneratorContent() {
     <div className="geo-content">
       <div className="geo-header">
         <div>
-          <div className="geo-eyebrow">Stage 4.7 · PoC</div>
+          <div className="geo-eyebrow">Stage 4.7 — Google Ads</div>
           <h1 className="geo-title">Ads Generator</h1>
           <p className="geo-description">
             Complete Google Search campaign asset pack — 15 headlines, 4 descriptions, 2 display paths, 6 sitelinks, 8 callouts, and match-typed keywords — anchored to your brain, GEO territories, and Factual Ground. Paste straight into Google Ads or export the full pack as CSV.


### PR DESCRIPTION
## Summary
- `/app/ads-generator` was rendering "New Analysis" in the topbar because the route wasn't in `TopBar.pathTitles` or `viewTitles`. Title resolver fell through to `viewTitles[currentView]` which defaulted to 'New Analysis'.
- Adds the missing mapping in both maps.

## Test plan
- [ ] Navigate to `/app/ads-generator` → topbar reads "Ads Generator".

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_