### PR TITLE
feat(ads-gen): push keywords to Topic Queue from Ads Generator

### DIFF
--- a/server.js
+++ b/server.js
@@ -17268,6 +17268,50 @@ app.post('/api/topic-ideas', requireAuth, async (req, res) => {
   } catch(e) { res.status(500).json({ success: false, error: e.message }); }
 });
 
+// POST /api/topic-ideas/bulk — push a list of topics in one round-trip.
+// Used by the Ads Generator to send Google-flagged "low-volume" keywords
+// straight into the Topic Queue as content opportunities (the GEO play:
+// keywords with no search volume are uncommoditized territory the brand
+// should be creating content for, not bidding ads on).
+// Dedupes against the brand's existing ideas by case-insensitive topic match
+// to keep repeated pushes idempotent.
+app.post('/api/topic-ideas/bulk', requireAuth, async (req, res) => {
+  const { brandProfileId, topics, note: defaultNote } = req.body || {};
+  if (!brandProfileId) return res.status(400).json({ success: false, error: 'brandProfileId required' });
+  if (!Array.isArray(topics) || !topics.length) return res.status(400).json({ success: false, error: 'topics array required' });
+
+  try {
+    const existing = await pool.query(
+      `SELECT LOWER(topic) AS t FROM topic_ideas WHERE brand_profile_id = $1`,
+      [brandProfileId]
+    );
+    const seen = new Set(existing.rows.map(r => r.t));
+    const toInsert = [];
+    for (const item of topics) {
+      const topic = String((typeof item === 'string' ? item : item?.topic) || '').trim();
+      if (!topic) continue;
+      const key = topic.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const note = String((typeof item === 'object' ? item?.note : '') || defaultNote || '').trim() || null;
+      toInsert.push({ topic, note });
+    }
+    if (!toInsert.length) return res.json({ success: true, inserted: 0, skipped: topics.length });
+
+    // Single multi-row INSERT — atomic, one round-trip
+    const values = toInsert.map((_, i) => `($1, $${i * 2 + 2}, $${i * 2 + 3})`).join(', ');
+    const params = [brandProfileId, ...toInsert.flatMap(t => [t.topic, t.note])];
+    const r = await pool.query(
+      `INSERT INTO topic_ideas (brand_profile_id, topic, note) VALUES ${values} RETURNING id, topic`,
+      params
+    );
+    res.json({ success: true, inserted: r.rows.length, skipped: topics.length - r.rows.length, ideas: r.rows });
+  } catch(e) {
+    console.error('[TOPIC-IDEAS-BULK]', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
 // PATCH /api/topic-ideas/:id — update status (idea → in_progress → generated)
 app.patch('/api/topic-ideas/:id', requireAuth, async (req, res) => {
   const { status, topic, note } = req.body;

--- a/src/pages/AdsGeneratorPage.tsx
+++ b/src/pages/AdsGeneratorPage.tsx
@@ -58,6 +58,12 @@ function AdsGeneratorContent() {
   const [overages, setOverages] = useState(0);
   const [error, setError] = useState('');
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  // Push-to-Topic-Queue state. Lets the user send Google-flagged low-volume
+  // keywords straight into the Topic Queue as content opportunities (the GEO
+  // play: keywords with no search volume are uncommoditized territory the
+  // brand should be creating content for, not bidding on).
+  const [pushingTopics, setPushingTopics] = useState(false);
+  const [pushResult, setPushResult] = useState<{ inserted: number; skipped: number } | null>(null);
 
   const brains: Brain[] = historyEntries.map(e => ({ id: e.id, brandName: e.brandName, brandUrl: e.brandUrl }));
   if (brains.length === 0 && activeBrand) {
@@ -137,6 +143,40 @@ function AdsGeneratorContent() {
       ...pack.keywords.exact.map(k => `[${k}]`),
     ];
     copy(lines.join('\n'), 'all-kw');
+  };
+
+  // Push all keywords (deduped across match types) into the brand's Topic
+  // Queue so the team can spin them up as content briefs. Match type is meta
+  // for ads, not for content — so we dedupe by raw phrase.
+  const pushKeywordsToTopicQueue = async () => {
+    if (!pack || !selectedBrainId || pushingTopics) return;
+    const all = Array.from(new Set([
+      ...pack.keywords.broad,
+      ...pack.keywords.phrase,
+      ...pack.keywords.exact,
+    ].map(k => k.trim()).filter(Boolean)));
+    if (!all.length) return;
+    setPushingTopics(true);
+    setPushResult(null);
+    try {
+      const r = await fetch('/api/topic-ideas/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}) },
+        body: JSON.stringify({
+          brandProfileId: selectedBrainId,
+          topics: all,
+          note: `From Ads Generator — "${pack.topic}" keyword set. GEO play: low-volume Google keyword = uncommoditized content territory to own.`,
+        }),
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d.error || 'Push failed');
+      setPushResult({ inserted: d.inserted, skipped: d.skipped });
+    } catch (e) {
+      setPushResult({ inserted: 0, skipped: 0 });
+      setError(`Couldn't push to Topic Queue: ${(e as Error).message}`);
+    } finally {
+      setPushingTopics(false);
+    }
   };
 
   return (
@@ -344,8 +384,32 @@ function AdsGeneratorContent() {
             <section>
               <div style={sectionHeader}>
                 <span>Keywords · {pack.keywords.broad.length + pack.keywords.phrase.length + pack.keywords.exact.length} total · match-typed for bulk paste</span>
-                <button onClick={copyAllKeywords} style={smallBtn}><Copy size={12} /> {copiedKey === 'all-kw' ? 'Copied' : 'Copy all (match-typed)'}</button>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <button
+                    onClick={pushKeywordsToTopicQueue}
+                    disabled={pushingTopics}
+                    style={smallBtn}
+                    title="Send these keywords to the Topic Queue as content opportunities — the GEO play for low-volume terms"
+                  >
+                    {pushingTopics ? '…' : '↗'} {pushingTopics ? 'Pushing…' : 'Push to Topic Queue'}
+                  </button>
+                  <button onClick={copyAllKeywords} style={smallBtn}><Copy size={12} /> {copiedKey === 'all-kw' ? 'Copied' : 'Copy all (match-typed)'}</button>
+                </div>
               </div>
+              {pushResult && (
+                <div style={{
+                  padding: '8px 12px',
+                  marginBottom: 8,
+                  background: 'var(--color-accent-muted, #eef2ff)',
+                  border: '1px solid var(--color-border, #e2e8f0)',
+                  borderRadius: 6,
+                  fontSize: 12,
+                  color: 'var(--color-text-secondary, #475569)',
+                }}>
+                  Pushed <strong>{pushResult.inserted}</strong> new {pushResult.inserted === 1 ? 'topic' : 'topics'} to the Topic Queue
+                  {pushResult.skipped > 0 && <> · {pushResult.skipped} skipped as duplicates</>}.
+                </div>
+              )}
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10 }}>
                 <KeywordColumn label="Broad" hint="bare phrases" keywords={pack.keywords.broad} wrap={k => k} />
                 <KeywordColumn label="Phrase" hint='wrap "quotes"' keywords={pack.keywords.phrase} wrap={k => `"${k}"`} />


### PR DESCRIPTION
## Summary
- Closes the loop on Google-flagged "low search volume" keywords. These are typically the brand's coined vocabulary — uncommoditized content territory the brand should be creating for, not bidding ads on.
- New "Push to Topic Queue" button on the Keywords section sends the deduped keyword set straight into the Topic Queue as content opportunities, tagged with a note pointing back to the Ads Generator run and the GEO rationale.
- The team converts each into a brief; Forge builds content around the language; once organic publishing lifts search volume, the same keywords become ad-eligible automatically.

## Backend
`POST /api/topic-ideas/bulk` — atomic multi-row insert with case-insensitive dedup against the brand's existing ideas (idempotent on repeat pushes). Accepts plain string array or `{topic, note}` objects. Returns inserted / skipped counts.

## Frontend
"Push to Topic Queue" button next to "Copy all (match-typed)" in the Keywords section header. Dedupes across broad/phrase/exact (match type is meta for ads, not content). Success banner shows inserted + skipped counts.

## Test plan
- [ ] Generate an Ads pack → click "Push to Topic Queue" → success banner shows N inserted.
- [ ] Navigate to Topic Queue → all keywords present as topic ideas with the source note.
- [ ] Click "Push to Topic Queue" again on the same pack → 0 inserted, N skipped (dedup works).
- [ ] Generate a different topic → push → only the new keywords land in queue.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_