### PR TITLE
feat(sitemap): add /about, /docs, /docs/&lt;slug&gt;, and legal pages

### DIFF
--- a/server.js
+++ b/server.js
@@ -15997,11 +15997,34 @@ app.get('/sitemap.xml', async (req, res) => {
   const isProduction = req.hostname === 'forgeintelligence.ai';
   if (!isProduction) return res.status(404).send('No sitemap for dev');
 
+  const now = new Date().toISOString();
+
+  // Static public surface — every route in src/main.tsx that's intended for
+  // public indexing. Anything gated (/app/*) or post-signup (/welcome) is
+  // deliberately omitted.
   const urls = [
-    { loc: 'https://forgeintelligence.ai/', priority: '1.0', changefreq: 'weekly', lastmod: new Date().toISOString() },
-    { loc: 'https://forgeintelligence.ai/product', priority: '0.9', changefreq: 'weekly', lastmod: new Date().toISOString() },
-    { loc: 'https://forgeintelligence.ai/faq', priority: '0.85', changefreq: 'monthly', lastmod: new Date().toISOString() },
+    { loc: 'https://forgeintelligence.ai/',               priority: '1.0',  changefreq: 'weekly',  lastmod: now },
+    { loc: 'https://forgeintelligence.ai/product',        priority: '0.9',  changefreq: 'weekly',  lastmod: now },
+    { loc: 'https://forgeintelligence.ai/about',          priority: '0.85', changefreq: 'monthly', lastmod: now },
+    { loc: 'https://forgeintelligence.ai/faq',            priority: '0.85', changefreq: 'monthly', lastmod: now },
+    { loc: 'https://forgeintelligence.ai/docs',           priority: '0.7',  changefreq: 'monthly', lastmod: now },
+    { loc: 'https://forgeintelligence.ai/privacy',        priority: '0.3',  changefreq: 'yearly',  lastmod: now },
+    { loc: 'https://forgeintelligence.ai/terms',          priority: '0.3',  changefreq: 'yearly',  lastmod: now },
+    { loc: 'https://forgeintelligence.ai/acceptable-use', priority: '0.3',  changefreq: 'yearly',  lastmod: now },
   ];
+
+  // Doc slugs — hand-mirrored from src/docs/index.ts. Server-side enumeration
+  // would need a TS loader; cheaper to keep this list in sync at PR-review time
+  // (it grows ~1 entry per integration shipped).
+  const docSlugs = ['my-website'];
+  for (const slug of docSlugs) {
+    urls.push({
+      loc: `https://forgeintelligence.ai/docs/${slug}`,
+      priority: '0.6',
+      changefreq: 'monthly',
+      lastmod: now,
+    });
+  }
 
   // Pull the Forge Intelligence brand's own published articles so Google indexes them.
   // Only this brand's articles (not customer brands) — customer articles live on their own domains.


### PR DESCRIPTION
## Summary
A lot has shipped recently that wasn't in the sitemap. Adds the missing public surface so Google + AI crawlers can discover everything we've built.

## Additions
- **`/about`** — just shipped in #158, needs to be indexed
- **`/docs`** — customer-facing integration docs surface
- **`/docs/my-website`** — only doc slug today (list is hand-mirrored from `src/docs/index.ts` and grows ~1 entry per integration shipped)
- **`/privacy`, `/terms`, `/acceptable-use`** — legal pages; Google likes them indexed for trust signals (low priority, yearly changefreq)

## Priority tuning
- 1.0 homepage, 0.9 product, 0.85 about + faq (key SEO + AI synthesis surfaces)
- 0.7 docs index, 0.7 articles, 0.6 individual doc pages
- 0.3 legal (indexed but not promoted)

## Minor cleanup
Hoisted `lastmod` to a single `now` const at the top — previous code called `new Date().toISOString()` per row, which produced microsecond drift across entries in the same response. Cosmetic but cleaner.

## Test plan
- [ ] After deploy: `curl https://forgeintelligence.ai/sitemap.xml | grep -c '<url>'` → 8 static + 1 doc + N Forge articles
- [ ] Re-submit sitemap in Google Search Console to nudge re-crawl
- [ ] Verify Google Ads landing-page check on `/about` resolves clean (also confirms #158 deployed)

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_