### PR TITLE
fix(topic-queue): build brief from topic, route to Enricher (matches PR #146)

### DIFF
--- a/src/pages/TopicQueuePage.tsx
+++ b/src/pages/TopicQueuePage.tsx
@@ -37,12 +37,14 @@ const PlusIcon = () => (
   </svg>
 );
 
-function TopicRow({ t, ah, onUpdate, onDelete, onSend }: {
+function TopicRow({ t, ah, onUpdate, onDelete, onSend, sending, anySending }: {
   t: TopicIdea;
   ah: () => Record<string, string>;
   onUpdate: (id: string, fields: Partial<TopicIdea>) => void;
   onDelete: (id: string) => void;
   onSend: (t: TopicIdea) => void;
+  sending: boolean;
+  anySending: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [editTopic, setEditTopic] = useState(t.topic);
@@ -124,8 +126,13 @@ function TopicRow({ t, ah, onUpdate, onDelete, onSend }: {
               ● {STATUS_LABEL[t.status]}
             </span>
             {t.status !== 'generated' && (
-              <button className="tq-action-btn tq-send-btn" onClick={() => onSend(t)}>
-                Send to Generator <ArrowIcon />
+              <button
+                className="tq-action-btn tq-send-btn"
+                onClick={() => onSend(t)}
+                disabled={anySending}
+                title={anySending && !sending ? 'Another brief is building — wait for it to finish' : 'Build the brief and continue to Authenticity Enricher'}
+              >
+                {sending ? 'Building brief…' : <>Build brief <ArrowIcon /></>}
               </button>
             )}
             <button className="tq-action-btn tq-delete-btn" onClick={() => onDelete(t.id)}>
@@ -147,6 +154,10 @@ export default function TopicQueuePage() {
   const [topics, setTopics] = useState<TopicIdea[]>([]);
   const [filter, setFilter] = useState<Filter>('all');
   const [topic, setTopic] = useState('');
+  // Tracks which row is mid-brief-build so the button can disable + label.
+  // Single string instead of a Set because we serialize one brief build at a
+  // time — the GEO endpoint is LLM-bound and parallel runs waste API spend.
+  const [sendingId, setSendingId] = useState<string | null>(null);
   const [note, setNote] = useState('');
   const [adding, setAdding] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -188,14 +199,30 @@ export default function TopicQueuePage() {
     setTopics(prev => prev.filter(t => t.id !== id));
   };
 
-  const sendToGenerator = (t: TopicIdea) => {
-    fetch(`/api/topic-ideas/${t.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', ...ah() },
-      body: JSON.stringify({ status: 'in_progress' }),
-    });
-    setTopics(prev => prev.map(x => x.id === t.id ? { ...x, status: 'in_progress' } : x));
-    window.location.href = `/app/content-generator?topic=${encodeURIComponent(t.topic)}&brand=${t.brand_profile_id}`;
+  const sendToGenerator = async (t: TopicIdea) => {
+    if (sendingId) return;
+    setSendingId(t.id);
+    try {
+      const r = await fetch('/api/geo/topic-brief/from-topic', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ah() },
+        body: JSON.stringify({ brandProfileId: t.brand_profile_id, topic: t.topic }),
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d.error || 'Brief build failed');
+      // Mark in_progress only after the brief builds successfully — avoids
+      // status drift if the brief call fails and the user retries.
+      fetch(`/api/topic-ideas/${t.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...ah() },
+        body: JSON.stringify({ status: 'in_progress' }),
+      });
+      setTopics(prev => prev.map(x => x.id === t.id ? { ...x, status: 'in_progress' } : x));
+      window.location.href = `/app/authenticity-enricher?topicBriefId=${d.briefId}`;
+    } catch (e) {
+      alert(`Couldn't build brief from topic: ${(e as Error).message}`);
+      setSendingId(null);
+    }
   };
 
   const counts = {
@@ -257,7 +284,7 @@ export default function TopicQueuePage() {
         ) : (
           <div className="tq-list">
             {filtered.map(t => (
-              <TopicRow key={t.id} t={t} ah={ah} onUpdate={handleUpdate} onDelete={deleteTopic} onSend={sendToGenerator} />
+              <TopicRow key={t.id} t={t} ah={ah} onUpdate={handleUpdate} onDelete={deleteTopic} onSend={sendToGenerator} sending={sendingId === t.id} anySending={!!sendingId} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
Same dead-end UX the Content Generator had (fixed in #146). Topic Queue's "Send to Generator" was redirecting to `/app/content-generator?topic=…&brand=…`, leaving the user stuck on a page that requires a selected enriched brief to actually run. This routes Topic Queue through the brief-build path so a click goes:

**Topic row → POST `/api/geo/topic-brief/from-topic` → Authenticity Enricher (auto-fires) → continues through the pipeline.**

## Changes
- `sendToGenerator` is now async; builds the brief, then navigates to `/app/authenticity-enricher?topicBriefId=<id>`.
- Status moves to `in_progress` only after the brief build succeeds (avoids drift on failure + retry).
- Per-row `sending` state + `anySending` guard. Serializes brief builds (GEO endpoint is LLM-bound, parallel runs waste spend) and disables sibling buttons with a hover-explanation while one is active.
- Button label "Send to Generator" → "Build brief →" to match the Content Generator's conditional CTA.

## Triggered by
The 6 new GSC-coined-vocabulary pillars I dropped into the Topic Queue today — every one hit the dead-end on click.

## Test plan
- [ ] Open `/app/topic-queue` on a brand with at least one queued topic.
- [ ] Click "Build brief →" → button reads "Building brief…", page lands at `/app/authenticity-enricher?topicBriefId=…`, enrichment fires.
- [ ] Trigger two builds in quick succession on different rows → second is disabled with hover tooltip until first finishes.
- [ ] Force a failure (e.g. invalid brand) → alert fires, button re-enables, status stays `idea` instead of drifting to `in_progress`.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i

---
_Generated by [Claude Code](https://claude.ai/code/session_012rR66joFscQqScTHav8d9i)_