### PR TITLE
feat(ads-gen): persist packs + history drawer (no more pump-and-dump)

### DIFF
--- a/server.js
+++ b/server.js
@@ -7159,11 +7159,28 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
 // ─────────────────────────────────────────────────────────────────────────────
 // Stage 4.7 — Ads Generator (Google Ads RSA asset pack)
 // ─────────────────────────────────────────────────────────────────────────────
-// Generates a Responsive Search Ads asset pack — 15 headlines (≤30 chars) +
-// 4 descriptions (≤90 chars) + 2 path fields (≤15 chars) — anchored to the
-// brand's brain patterns, GEO territories, and Factual Ground. Sync (small
-// JSON output, no SSE needed). No persistence yet — PoC mode. Future stages
-// add P-Max asset variants and Google Ads API publishing.
+// Generates a complete Google Search campaign asset pack — headlines,
+// descriptions, paths, sitelinks, callouts, match-typed keywords — anchored
+// to the brand's brain patterns, GEO territories, and Factual Ground. Packs
+// are persisted to generated_ad_packs so the UI can show a history drawer
+// (no more pump-and-dump). Future stages add P-Max asset variants and
+// Google Ads API publishing.
+async function ensureGeneratedAdPacksTable() {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS generated_ad_packs (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      brand_profile_id UUID NOT NULL,
+      topic TEXT NOT NULL,
+      final_url TEXT,
+      pack_data JSONB NOT NULL,
+      overages INTEGER DEFAULT 0,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `).catch(() => {});
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_gap_brand_created ON generated_ad_packs(brand_profile_id, created_at DESC)`).catch(() => {});
+}
+
 app.post('/api/ads-generator/rsa', requireAuth, async (req, res) => {
   const { brandProfileId, topic, finalUrl } = req.body || {};
   if (!brandProfileId) return res.status(400).json({ success: false, error: 'brandProfileId required' });
@@ -7368,24 +7385,78 @@ Return ONLY the JSON object specified in the system prompt.`;
        (aiRes.usage?.input_tokens || 0) + (aiRes.usage?.output_tokens || 0), 0]
     ).catch(() => {});
 
-    res.json({
-      success: true,
-      pack: {
-        headlines,
-        descriptions,
-        paths,
-        sitelinks,
-        callouts,
-        keywords,
-        notes: String(parsed.notes || '').trim(),
-        finalUrl: finalUrl || '',
-        topic: String(topic).trim(),
-        generatedAt: new Date().toISOString(),
-      },
-      overages,
-    });
+    const pack = {
+      headlines,
+      descriptions,
+      paths,
+      sitelinks,
+      callouts,
+      keywords,
+      notes: String(parsed.notes || '').trim(),
+      finalUrl: finalUrl || '',
+      topic: String(topic).trim(),
+      generatedAt: new Date().toISOString(),
+    };
+
+    // Persist so the FE can show a history drawer and the user can open prior
+    // packs without regenerating (saves token spend on re-runs of the same topic).
+    let packId = null;
+    try {
+      await ensureGeneratedAdPacksTable();
+      const insRes = await pool.query(
+        `INSERT INTO generated_ad_packs (brand_profile_id, topic, final_url, pack_data, overages)
+         VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+        [brandProfileId, pack.topic, pack.finalUrl || null, JSON.stringify(pack), overages]
+      );
+      packId = insRes.rows[0]?.id || null;
+    } catch (e) { console.error('[ADS-GEN] persist failed (non-fatal):', e.message); }
+
+    res.json({ success: true, packId, pack, overages });
   } catch (e) {
     console.error('[ADS-GEN]', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
+// GET /api/ads-generator/recent/:brandProfileId — list past packs for the drawer
+app.get('/api/ads-generator/recent/:brandProfileId', requireAuth, async (req, res) => {
+  const { brandProfileId } = req.params;
+  if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
+  try {
+    await ensureGeneratedAdPacksTable();
+    const r = await pool.query(
+      `SELECT id, topic, final_url, pack_data, overages, created_at
+       FROM generated_ad_packs
+       WHERE brand_profile_id = $1
+       ORDER BY created_at DESC LIMIT 30`,
+      [brandProfileId]
+    );
+    res.json({ success: true, packs: r.rows.map(row => ({
+      id: row.id,
+      topic: row.topic,
+      finalUrl: row.final_url || '',
+      overages: row.overages || 0,
+      createdAt: row.created_at,
+      pack: row.pack_data,
+    })) });
+  } catch (e) {
+    console.error('[ADS-GEN-RECENT]', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
+// DELETE /api/ads-generator/pack/:packId — prune a single saved pack
+app.delete('/api/ads-generator/pack/:packId', requireAuth, async (req, res) => {
+  const { packId } = req.params;
+  try {
+    // Verify the pack belongs to a brand the user has access to before deleting.
+    const ownerRes = await pool.query(`SELECT brand_profile_id FROM generated_ad_packs WHERE id = $1`, [packId]);
+    if (!ownerRes.rows.length) return res.status(404).json({ error: 'Pack not found' });
+    if (!(await verifyBrandAccess(ownerRes.rows[0].brand_profile_id, req.userId))) return res.status(403).json({ error: 'Access denied' });
+    await pool.query(`DELETE FROM generated_ad_packs WHERE id = $1`, [packId]);
+    res.json({ success: true });
+  } catch (e) {
+    console.error('[ADS-GEN-DELETE]', e.message);
     res.status(500).json({ success: false, error: e.message });
   }
 });

--- a/src/pages/AdsGeneratorPage.tsx
+++ b/src/pages/AdsGeneratorPage.tsx
@@ -65,6 +65,24 @@ function AdsGeneratorContent() {
   const [pushingTopics, setPushingTopics] = useState(false);
   const [pushResult, setPushResult] = useState<{ inserted: number; skipped: number } | null>(null);
 
+  // Recent packs drawer. Mirrors Social Generator's history pattern — the
+  // drawer is collapsed by default; opens to show topic + finalUrl + date.
+  // "Open pack" rehydrates the existing pack UI without a server roundtrip
+  // because the full pack JSON ships with the list response.
+  interface RecentPack { id: string; topic: string; finalUrl: string; overages: number; createdAt: string; pack: AssetPack }
+  const [recentPacks, setRecentPacks] = useState<RecentPack[]>([]);
+  const [recentOpen, setRecentOpen] = useState(false);
+  const fetchRecent = async (brandId: string) => {
+    if (!brandId) return;
+    try {
+      const r = await fetch(`/api/ads-generator/recent/${brandId}`, {
+        headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+      });
+      const d = await r.json();
+      if (d.success) setRecentPacks(d.packs || []);
+    } catch { /* non-fatal */ }
+  };
+
   const brains: Brain[] = historyEntries.map(e => ({ id: e.id, brandName: e.brandName, brandUrl: e.brandUrl }));
   if (brains.length === 0 && activeBrand) {
     brains.push({ id: activeBrand.id, brandName: activeBrand.brandName || activeBrand.brandUrl, brandUrl: activeBrand.brandUrl });
@@ -75,6 +93,27 @@ function AdsGeneratorContent() {
     if (id) setSelectedBrainId(id);
   }, []);
   useEffect(() => { if (activeBrand?.id && !selectedBrainId) setSelectedBrainId(activeBrand.id); }, [activeBrand?.id]);
+  // Load recent packs whenever brand changes (or first arrives)
+  useEffect(() => { if (selectedBrainId && authToken) fetchRecent(selectedBrainId); }, [selectedBrainId, authToken]);
+
+  const openPack = (rp: RecentPack) => {
+    setPack(rp.pack);
+    setOverages(rp.overages);
+    setError('');
+    setRecentOpen(false);
+  };
+
+  const deleteRecentPack = async (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm('Delete this saved pack?')) return;
+    try {
+      const r = await fetch(`/api/ads-generator/pack/${id}`, {
+        method: 'DELETE',
+        headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+      });
+      if (r.ok) setRecentPacks(prev => prev.filter(p => p.id !== id));
+    } catch { /* non-fatal */ }
+  };
 
   const run = async () => {
     if (!selectedBrainId || !topic.trim() || running) return;
@@ -89,6 +128,8 @@ function AdsGeneratorContent() {
       if (!r.ok || !d.success) throw new Error(d.error || 'Generation failed');
       setPack(d.pack);
       setOverages(d.overages || 0);
+      // Refresh the recent drawer so the new pack appears immediately
+      if (selectedBrainId) fetchRecent(selectedBrainId);
     } catch (e) {
       setError((e as Error).message);
     } finally {
@@ -416,6 +457,77 @@ function AdsGeneratorContent() {
                 <KeywordColumn label="Exact" hint="wrap [brackets]" keywords={pack.keywords.exact} wrap={k => `[${k}]`} />
               </div>
             </section>
+          )}
+        </div>
+      )}
+
+      {/* Recent packs drawer — appears below input (when empty) or below
+          the rendered pack (when one is open). Collapsed by default to keep
+          the surface focused on the generation flow. */}
+      {recentPacks.length > 0 && (
+        <div style={{ marginTop: 24, borderTop: '1px solid var(--color-border, #e2e8f0)', paddingTop: 16 }}>
+          <button
+            onClick={() => setRecentOpen(o => !o)}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              padding: '8px 0', background: 'none', border: 'none', cursor: 'pointer',
+              fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary, #475569)',
+            }}
+          >
+            <span>Recent packs</span>
+            <span style={{
+              padding: '1px 8px', background: 'var(--color-accent-muted, #eef2ff)',
+              borderRadius: 999, fontSize: 11, color: 'var(--color-text-secondary, #475569)',
+            }}>{recentPacks.length}</span>
+            <span style={{ fontSize: 12, marginLeft: 'auto', color: 'var(--color-text-muted, #94a3b8)' }}>{recentOpen ? '−' : '+'}</span>
+          </button>
+          {recentOpen && (
+            <div style={{ display: 'grid', gap: 6, marginTop: 8 }}>
+              {recentPacks.map(rp => (
+                <button
+                  key={rp.id}
+                  onClick={() => openPack(rp)}
+                  style={{
+                    display: 'grid', gridTemplateColumns: '1fr auto auto auto', gap: 12,
+                    padding: 10, alignItems: 'center',
+                    background: 'var(--color-bg-card, #fff)',
+                    border: '1px solid var(--color-border, #e2e8f0)',
+                    borderRadius: 8, cursor: 'pointer', textAlign: 'left',
+                  }}
+                  title="Open this pack"
+                >
+                  <div>
+                    <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--color-text-primary, #1a1a1a)' }}>{rp.topic}</div>
+                    {rp.finalUrl && (
+                      <div style={{ fontSize: 11, color: 'var(--color-text-muted, #94a3b8)', marginTop: 2, wordBreak: 'break-all' }}>→ {rp.finalUrl}</div>
+                    )}
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--color-text-muted, #94a3b8)', whiteSpace: 'nowrap' }}>
+                    {(() => {
+                      const raw = String(rp.createdAt || '');
+                      const normalized = /T/.test(raw) ? raw : raw.replace(' ', 'T') + (/(Z|[+-]\d{2}:?\d{2})$/.test(raw) ? '' : 'Z');
+                      const d = new Date(normalized);
+                      return isNaN(d.getTime()) ? '—' : d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+                    })()}
+                  </div>
+                  {rp.overages > 0 && (
+                    <div style={{ fontSize: 10, color: '#92400E', background: '#FEF3C7', padding: '2px 6px', borderRadius: 4 }}>
+                      {rp.overages} over
+                    </div>
+                  )}
+                  <span
+                    onClick={(e) => deleteRecentPack(rp.id, e)}
+                    style={{
+                      fontSize: 11, color: 'var(--color-text-muted, #94a3b8)',
+                      padding: '4px 8px', borderRadius: 4, cursor: 'pointer',
+                    }}
+                    title="Delete pack"
+                  >
+                    ✕
+                  </span>
+                </button>
+              ))}
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
User report: Ads Generator output was discarded the moment the user navigated away. Mirrors the Social Generator's history pattern so prior packs are recoverable without regenerating (saves token spend on re-runs of the same topic and lets the user A/B compare past packs).

Backend:
- generated_ad_packs table (id, brand_profile_id, topic, final_url, pack_data JSONB, overages, created_at, updated_at). Indexed on (brand_profile_id, created_at DESC) for the recent-list query.
- POST /api/ads-generator/rsa now persists the full pack on success and returns the new packId in the response. Insert wrapped in try/catch so a DB failure doesn't kill the response — the pack still ships.
- GET /api/ads-generator/recent/:brandProfileId — returns last 30 packs for the brand, each with full pack JSON inlined so the drawer can open a prior pack without a second roundtrip.
- DELETE /api/ads-generator/pack/:packId — verifyBrandAccess before deleting so users can only prune packs from brands they own.

Frontend:
- Recent packs drawer below the main surface — mirrors SocialGenerator's collapsible pattern. Renders topic + finalUrl + date + overage badge per row. Click row → openPack() rehydrates the existing UI in place.
- Fetches the list on brand change and after every successful generation so a fresh pack appears immediately in the drawer.
- Per-row delete (×) with confirm guard; stopPropagation prevents the delete click from also opening the pack.

Future P-Max + image-generation outputs will land in the same drawer once those generators ship — same table, same shape, same UX.

https://claude.ai/code/session_012rR66joFscQqScTHav8d9i