### PR TITLE
Event Intelligence Platform — Phase 0 scaffold (review only)

### DIFF
--- a/platform/.env.example
+++ b/platform/.env.example
@@ -1,0 +1,26 @@
+# ── Core ──
+NODE_ENV=development
+PORT=8080
+
+# ── Database (Neon Postgres) ──
+# postgresql://USER:PASSWORD@HOST/db?sslmode=require
+DATABASE_URL=
+
+# ── Auth (Clerk) — JWT verified against JWKS ──
+# https://YOUR-INSTANCE.clerk.accounts.dev/.well-known/jwks.json
+CLERK_JWKS_URL=
+# Optional issuer check, e.g. https://YOUR-INSTANCE.clerk.accounts.dev
+CLERK_ISSUER=
+
+# ── Intelligence (Anthropic Claude) ──
+ANTHROPIC_API_KEY=
+
+# ── Connector Fabric ──
+# Nango holds the OAuth token vault; we store only connection references.
+NANGO_SECRET_KEY=
+NANGO_HOST=https://api.nango.dev
+# Pipedream for long-tail webhooks/automations
+PIPEDREAM_API_KEY=
+
+# ── Email (Resend) ──
+RESEND_API_KEY=

--- a/platform/.gitignore
+++ b/platform/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log
+.DS_Store

--- a/platform/PLAN.md
+++ b/platform/PLAN.md
@@ -1,0 +1,150 @@
+# Event Intelligence Orchestration Platform — MVP Plan
+
+> Working codename: **"Throughline"** (placeholder — the product's value is maintaining one consistent throughline from first touchpoint to closed pipeline). Final name TBD.
+
+---
+
+## Context — why we're building this
+
+Event-tech stacks are fragmented: organizers run Cvent/RainFocus + a mobile app + a matchmaking tool + lead capture + a CRM, and **the data dies between tools**. Swoogo's 2025 Eventscape quantifies it: **44% don't connect their event platform to a CRM, 69% don't connect it to marketing automation** — so event signal never reaches where pipeline/ROI is measured. Event leaders describe this as "the missing link."
+
+The opportunity is a **vendor-neutral, Bring-Your-Own-Tools "system of intelligence"**: a central environment where any event tool connects via API/webhook (two-way, near plug-and-play), and forensic-grade AI keeps **KPIs, goals, voice, audience, content, and context consistent from the first touchpoint through the post-event sales pipeline.**
+
+**Critical reuse insight:** Forge Intelligence (this repo) is *already* a working system of intelligence — in marketing, not events. It has a compounding **Brain** (`brain_patterns`/`brain_mistakes`), a human-in-the-loop **Compliance Gate** (consistency enforcement), a **connector layer** with per-channel vaulted credentials, an analytics→pattern feedback loop, multi-model Claude routing, and an MCP server. The MVP largely **re-points these proven patterns at the event lifecycle** rather than inventing from scratch. Forge then plugs in as **Layer 8 (event journalism)**.
+
+**Locked decisions (from founder):**
+- **New standalone repo** (Forge's `server.js` is ~19.5K lines and near its scaling limit; the event data model is fundamentally different).
+- **MVP = the "consistency thread"**: one unified event record + AI that keeps KPIs/voice/audience/content/context consistent first-touch → handoff.
+- **First connectors = owned IP**: Sandbox-GTM + Engage (full API control, dogfoodable).
+- **Intel content-intelligence code** (Layer 3 / call-for-papers): founder grants repo access; port relevant pieces.
+
+---
+
+## Honest market read (informs positioning, not just flavor)
+
+- **Where it's crowded:** the *narrative* "AI orchestration for events." RainFocus **Nexus** ("system of specialized AI agents"), Cvent (which **acquired Goldcast, Dec 2025**) and Goldcast's "agentic AI" / AI Event Analyst are planting flags — **but inside their own walled gardens.**
+- **Where the genuine, defensible gap is:** a **neutral layer that ingests competing tools simultaneously** (Cvent + Brella + HubSpot + Salesforce + Attio), maintains lifecycle consistency, and **drives post-event sales-readiness + clean CRM handoff** — the weakest-served, highest-value link, and the part incumbents are structurally disincentivized to build.
+- **Positioning:** *"Switzerland for your event stack" + own the handoff.* Defensibility = genuine cross-tool neutrality + the sales-readiness/attribution layer, **not** another agentic-content feature.
+- **Top risk:** incumbents use **data-access control** to box out neutral middleware. Mitigation: anchor on **owned IP first** (Sandbox-GTM/Engage), prefer **open-API tools** (HubSpot, Salesforce, Attio, Swapcard, Brella) for early connectors, and degrade gracefully to webhooks/CSV where APIs are partner-gated (RainFocus, Whova).
+
+---
+
+## Product thesis
+
+> Define the event's **North-Star** once (goals, KPIs, target audience/ICP, brand voice, key messages). Connect your existing tools. The platform builds a **unified event record** across them and runs **forensic AI** that continuously flags where reality is drifting from the North-Star — then converts post-event engagement into **sales-ready, CRM-handed-off pipeline.**
+
+Three pillars carry equal weight per the founder: **Quality, UX, Infosec.**
+
+---
+
+## Architecture — six MVP pillars
+
+**1. Event Brain / North-Star (Layer 1 — owned IP).** The source of truth everything is measured against: event goals, structured KPIs, target audience/ICP, brand voice profile, key messages/themes. Plus a light **audience-intelligence** pass (enrich target accounts — the under-served "ABM-for-events" sub-gap). *Ports Forge's `voice_profile` + `settings.factualGround` (Factual Ground) + Territory injection + Brain-First Protocol.*
+
+**2. Connector Fabric (BYO tools — buy the plumbing).** **Nango** as the backbone for durable two-way syncs of core objects (managed OAuth/token vault, unified proxy, typed syncs, self-hostable, SOC 2 Type II). **Pipedream** for long-tail webhooks/automations. MVP wires **Sandbox-GTM + Engage** first; framework designed so HubSpot/Swapcard/Cvent slot in next. *Ports Forge's `publishing_channels` credential pattern, `publish_log`, `/api/webhooks/*` handlers, and the "probe before pivot" rule.* **Lesson from Forge:** don't rebuild gated OAuth pushes naively (HubSpot tier-gate burned 4 rebuilds) — lean on Nango + webhooks.
+
+**3. Unified Event Record (golden record — owned IP).** CDP-for-events data layer on Neon/Postgres: Event → Sessions → Contacts ↔ Accounts, with **identity resolution** (deterministic email/phone + probabilistic fuzzy), survivorship rules, person→account rollup, and **lifecycle stages** (registered → checked-in → session-attended → lead-scanned → opportunity). Anonymous→known resolution is first-class.
+
+**4. Consistency Engine (the "forensic AI" — owned IP, the daily wow).** Multi-model Claude agents continuously compare cross-tool reality against the North-Star and emit **consistency signals / drift alerts**: e.g., "registered audience skews off-ICP," "mobile-app copy drifts from stated value prop," "session content doesn't ladder to KPI X." Human-in-the-loop review. *Ports Forge's Compliance Gate (`/api/compliance/critique|rewrite-section|approve`) + `decay_alerts` + Brain-First Protocol.* Model routing mirrors Forge: **Opus 4.7** for deep consistency reasoning, **Sonnet** for mid-tier analysis, **Haiku** for fast signal checks.
+
+**5. Sales Readiness & Handoff (Layer 7 — owned IP, the differentiator).** Score attendee/account engagement across *all* connected tools, decide sales-readiness, hand off enriched records to CRM (HubSpot first). *Ports Forge's analytics→pattern loop (`content_analytics`, `precog_outcomes`, `/api/analytics/extract-patterns`).* This is the market's weakest link — even a thin version is the killer demo.
+
+**6. Forge Intelligence as Layer 8 (journalism — owned IP, light MVP integration).** Forge ingests the event record + North-Star and produces on-voice recaps/journalism via its existing publishing engine. MVP = a connected module, not a rebuild.
+
+---
+
+## Reuse map — port these proven Forge patterns into the new repo
+
+| New-repo capability | Forge source to port |
+|---|---|
+| North-Star / voice consistency | `voice_profile`, `brand_profiles.settings.factualGround`, Territory injection (`README.md` "Key Architecture Additions") |
+| Cross-event learning Brain | `brain_patterns`, `brain_mistakes`, `agent_coordination`, `agent_activity_log` (`init-schema.sql`); Brain-First Protocol (`README.md` "Brain Architecture") |
+| Consistency Engine (AI critique + human loop) | Compliance Gate endpoints in `server.js`: `/api/compliance/critique`, `/rewrite-section`, `/find-sources`, `/approve` |
+| Connector credentials + webhooks | `publishing_channels` (per-channel JSONB creds, UTM template, `test_status`), `publish_log`, `/api/webhooks/*` |
+| Engagement scoring / drift | `content_analytics`, `decay_alerts`, `precog_outcomes`, `/api/analytics/extract-patterns` |
+| Multi-model routing | `README.md` "LLM Routing" table (Opus/Sonnet/Haiku economics) |
+| Auth + tenant scoping | Clerk JWT template, `requireAuth`/`softAuth`, brand-scoped → tenant-scoped filtering |
+| External AI access | existing `/mcp` JSON-RPC read-only server |
+| Design system | 12-directive system (`README.md` "UI Design System": dark base, Intelligence Blue, calm UX, **no emojis**) |
+| Hardening utilities | `sanitizeJson()`, SSE streaming pattern, `forgeScrape` (for audience/account enrichment) |
+
+**Anti-pattern to avoid:** do **not** reproduce Forge's single-file 19.5K-line `server.js`. Start modular (routes/services/connectors/agents as separate modules) — Forge itself flags this as its main scaling debt.
+
+---
+
+## New-repo data model (high level, Neon/Postgres)
+
+`organizations` (tenant) · `users`+`memberships` (RBAC, Clerk-mapped) · `events` (holds North-Star JSONB: goals/voice/ICP/themes) · `event_kpis` (structured targets) · `connections` (Nango connection id, provider, scopes, status — analogous to `publishing_channels`) · `contacts` (golden person) · `accounts` (company rollup) · `identity_links` (resolution) · `sessions` + `session_attendance` · `engagements` (normalized cross-tool activity stream) · `consistency_signals` (drift alerts) · `readiness_scores` (per contact/account) · `handoffs` (CRM push log) · `playbook_patterns`/`playbook_mistakes` (cross-event Brain) · `audit_log` (infosec) · `agent_runs` (AI audit).
+
+---
+
+## Build vs Buy (per founder rule: anything not owned-IP/MVP = 100% third party)
+
+- **Build (owned IP):** Pre-event intelligence/North-Star (L1), Connector Fabric orchestration logic, Unified Event Record (L3 data), Consistency Engine, Sales Readiness & Handoff (L7), Event Journalism via Forge (L8). Call-for-papers/content intelligence (L3) seeded from the Intel repo.
+- **Buy / integrate (third party):** Event mgmt — Cvent/RainFocus (+ Sandbox-GTM owned); Matchmaking — Brella/Swapcard/Grip; Mobile — EventMobi/Whova; CRM — HubSpot/Salesforce/Attio; Community — Swapcard/Gradual; Lead capture — iCapture/Engage(owned). **Plumbing:** Nango + Pipedream (iPaaS), Clerk (auth), Resend (email), Render (host), Neon (DB), Claude (intelligence). *Note: "Xtag" couldn't be verified as a real product — likely iCapture/Popl/momencio; confirm before listing.*
+
+---
+
+## Infosec (equal pillar — enterprise-safe by SMB-accessible)
+
+- **Inherited compliance story (day 1):** Neon, Render, and Clerk are each **SOC 2 Type II** — credible foundation before our own audit.
+- **Ship immediately:** SSO/SAML (Clerk), **RBAC**, **audit logging** (`audit_log`), encryption in transit + at rest (TLS + Neon), data retention + PII minimization, secrets management. **Store connector tokens in Nango's vault, not in our DB** (improves on Forge's JSONB-creds approach).
+- **Program:** start SOC 2 Type I → Type II via Vanta/Drata (~6–12 mo, ~$20–100k); publish sub-processor list + DPA; document an ISMS-lite.
+- **Known gap to flag:** **Clerk lacks native SCIM** (enterprise user-deprovisioning blocker) — plan a WorkOS fallback for SCIM-heavy enterprise deals.
+- Per-tenant data isolation enforced on every query (port Forge's brand-scoped `WHERE` discipline → tenant-scoped).
+
+## UX (equal pillar)
+
+- **Onboarding wizard:** set North-Star in minutes → connect first tool via Nango embedded auth (plug-and-play feel) → see the unified record populate.
+- **Home = Consistency Dashboard:** live drift signals, KPI-vs-reality, readiness pipeline. Calm, forensic, not noisy.
+- **SMB-accessible:** self-serve signup, sensible defaults, one-click connectors. **Enterprise-safe:** SSO, RBAC, audit, isolation.
+- Port Forge's design system (dark foundation `#0F1720`, Intelligence Blue `#3563FF`, Lucide icons, no emojis, calm motion).
+
+---
+
+## Phased roadmap (relative sequencing; spans the consistency thread)
+
+- **Phase 0 — Foundations:** new modular repo; Render + Neon + Clerk; design-system port; infosec baseline (RBAC, audit, encryption); Nango + Pipedream accounts wired.
+- **Phase 1 — Event Brain / North-Star (L1):** North-Star wizard (goals/KPIs/voice/ICP) + light audience enrichment via `forgeScrape`/Perplexity.
+- **Phase 2 — Connector Fabric + Unified Record:** Sandbox-GTM + Engage via Nango; normalize into golden record; identity resolution; lifecycle stages.
+- **Phase 3 — Consistency Engine:** Claude agents emit drift signals; Consistency Dashboard; human-in-the-loop review (ported Compliance Gate).
+- **Phase 4 — Sales Readiness & Handoff (L7):** engagement scoring across tools; readiness scores; **HubSpot handoff** (open API, webhooks on all tiers).
+- **Phase 5 — Forge as L8:** event record + North-Star → on-voice journalism via Forge's publishing engine.
+
+*MVP demo line = Phases 0–4 on owned IP + HubSpot; Phase 5 is the storytelling flourish.*
+
+---
+
+## Verification (end-to-end)
+
+1. **Dogfood with a real Sandbox-GTM event** (founder owns it): set a North-Star, connect Sandbox-GTM + Engage + a **HubSpot sandbox** via Nango.
+2. Confirm the **unified record** populates (registrations → check-ins → lead scans) with correct identity resolution and person→account rollup.
+3. Confirm the **Consistency Engine** surfaces at least one true drift signal against the North-Star (e.g., off-ICP registrants).
+4. Trigger a **sales-readiness handoff**: a scored contact lands in the HubSpot sandbox as an enriched record.
+5. Generate a **Forge recap** on-voice from the event record.
+6. **Connector resilience:** simulate a webhook-only/CSV tool to prove graceful degradation when an API is gated.
+7. **Infosec checks:** verify tenant isolation (no cross-org leakage), audit-log entries, and that connector tokens live in Nango's vault, not our DB.
+8. Validate HubSpot interactions via the GitHub/CRM sandbox + Nango test connections; add automated tests for identity resolution + readiness scoring.
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Incumbents (RainFocus/Cvent) restrict API access to box out neutral middleware | Anchor on owned IP first; design fabric to degrade to webhooks/CSV; lead with the handoff layer they won't build |
+| Partner-gated APIs (RainFocus, Whova) slow integration | MVP uses open APIs (Sandbox-GTM, HubSpot, Salesforce, Attio, Swapcard, Brella) |
+| Pipedream's Workday acquisition (roadmap/independence risk) | Keep core durable syncs in **Nango** (self-hostable); Pipedream only for long-tail |
+| Clerk SCIM gap blocks enterprise deals | Plan WorkOS path; document interim manual provisioning |
+| Scope creep across 8 layers | MVP = consistency thread on owned IP + 1 CRM; all other layers are post-MVP connectors |
+| Crowded "agentic events" narrative | Differentiate on **neutrality + handoff**, not agentic content |
+
+---
+
+## Open follow-ups (not blockers to start)
+
+- Final product name (replace "Throughline" placeholder).
+- Intel content-intelligence **repo access** (founder to grant) — port CFP/abstract + scoring logic for L3.
+- Pursue Cvent/RainFocus **partner/sandbox API access** for the connector roadmap.
+- Confirm true identity of "Xtag" lead-capture tool.
+- Budget/timeline/team size to convert relative phases into a dated schedule.

--- a/platform/README.md
+++ b/platform/README.md
@@ -1,0 +1,67 @@
+# Event Intelligence Orchestration Platform
+
+> Working codename: **"Throughline"** (placeholder). A vendor-neutral, Bring-Your-Own-Tools **system of intelligence** for the event lifecycle. Connect the event tools you already use; forensic AI keeps **KPIs, goals, voice, audience, content and context consistent from the first touchpoint through the post-event sales pipeline** — then turns engagement into sales-ready, CRM-handed-off pipeline.
+
+This is **Phase 0 scaffolding** — the modular foundation the MVP builds on. It currently lives in a self-contained `platform/` subfolder of the Forge-Intelligence repo and is structured to extract cleanly into its own repository later.
+
+## Why this exists
+
+Event-tech stacks are fragmented and the data dies between tools (Swoogo 2025: 44% of organizers don't connect their event platform to a CRM, 69% don't connect to marketing automation). Incumbents (RainFocus Nexus, Cvent+Goldcast) are building "agentic" intelligence — but only inside their own walled gardens. The gap is a **neutral layer that ingests competing tools simultaneously** and owns the **post-event sales-readiness/handoff** link nobody else does well.
+
+Much of the intelligence machinery is ported from **Forge Intelligence**, which is already a working "system of intelligence" for marketing (compounding Brain, human-in-the-loop consistency gate, connector layer, multi-model Claude routing). Forge plugs in as **Layer 8 (event journalism)**.
+
+## Architecture — six pillars
+
+| Pillar | Module | Status |
+|--------|--------|--------|
+| 1. Event Brain / North-Star (Layer 1) | `src/modules/northstar` | scaffold |
+| 2. Connector Fabric (BYO tools) | `src/modules/connectors` | scaffold (registry live) |
+| 3. Unified Event Record (golden record) | `src/modules/record` | scaffold (identity utils live) |
+| 4. Consistency Engine (forensic AI) | `src/modules/consistency` | scaffold |
+| 5. Sales Readiness & Handoff (Layer 7) | `src/modules/readiness` | scaffold |
+| 6. Forge as Layer 8 (journalism) | external (Forge) | future |
+
+## Stack
+
+Node 22 · TypeScript · Express · Neon (Postgres) · Clerk (JWT/JWKS auth) · Nango (connector token vault) · Pipedream (long-tail automations) · Anthropic Claude (multi-model: Opus 4.7 / Sonnet 4.6 / Haiku 4.5) · Resend (email) · Render (host).
+
+**Deliberately modular** — separate `config / db / lib / middleware / modules` rather than Forge's single 19.5K-line `server.js` (its main scaling debt).
+
+## Layout
+
+```
+platform/
+├── migrations/0001_init.sql     # full data model (tenant-scoped golden record)
+├── src/
+│   ├── server.ts                # entry
+│   ├── app.ts                   # express wiring + /health
+│   ├── config/env.ts            # zod-validated env
+│   ├── db/                      # Neon pool + migration runner
+│   ├── lib/                     # claude routing, logger, sanitizeJson, errors
+│   ├── middleware/              # auth (Clerk), tenant, rbac, audit, error
+│   ├── modules/                 # the six pillars
+│   └── design/tokens.css        # ported design system
+```
+
+## Run locally
+
+```bash
+cd platform
+cp .env.example .env     # fill in DATABASE_URL, CLERK_*, ANTHROPIC_API_KEY, NANGO_SECRET_KEY
+npm install
+npm run migrate          # apply migrations to Neon
+npm run dev              # http://localhost:8080/health
+```
+
+`GET /health` reports which integrations are configured. Endpoints not yet built return a structured `501` naming the plan phase and the Forge pattern to port.
+
+## Infosec posture (equal pillar)
+
+- Tenant isolation: `organization_id` on every domain row, enforced on every query.
+- Connector secrets live in **Nango's vault**, never in our DB.
+- Day-1: Clerk SSO, RBAC (`requireRole`), `audit_log`, TLS + Neon at-rest encryption.
+- Inherited SOC 2 Type II (Neon + Render + Clerk); own SOC 2 program is the next milestone. Known gap: Clerk lacks SCIM — WorkOS fallback planned for enterprise deals.
+
+## Status
+
+Phase 0 foundation. See the approved MVP plan for the phased roadmap (North-Star → Connector Fabric + Unified Record → Consistency Engine → Sales Readiness & Handoff → Forge/Layer 8).

--- a/platform/migrations/0001_init.sql
+++ b/platform/migrations/0001_init.sql
@@ -1,0 +1,253 @@
+-- Event Intelligence Orchestration Platform — initial schema
+-- Tenant model: organization. Every domain row carries organization_id and is
+-- filtered by it on every query (ported discipline from Forge's brand-scoping).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ── Tenancy & identity ──
+CREATE TABLE IF NOT EXISTS organizations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  slug TEXT UNIQUE,
+  plan TEXT NOT NULL DEFAULT 'trial',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clerk_user_id TEXT UNIQUE NOT NULL,
+  email TEXT,
+  full_name TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS memberships (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'member',  -- 'owner' | 'admin' | 'member' | 'viewer'
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (organization_id, user_id)
+);
+
+-- ── Events & North-Star (Layer 1: pre-event intelligence) ──
+CREATE TABLE IF NOT EXISTS events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  starts_at TIMESTAMPTZ,
+  ends_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'planning',
+  -- The single source of truth: goals, KPIs, target ICP, brand voice, themes.
+  -- Everything downstream is measured against this. Port: Forge voice_profile
+  -- + brand_profiles.settings.factualGround.
+  north_star JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_events_org ON events (organization_id);
+
+CREATE TABLE IF NOT EXISTS event_kpis (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  metric TEXT NOT NULL,           -- 'registrations' | 'pipeline_usd' | 'icp_match_rate' | ...
+  target NUMERIC,
+  current NUMERIC DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_kpis_event ON event_kpis (event_id);
+
+-- ── Connector Fabric (Layers 2/4/5/6: BYO tools) ──
+-- Credentials live in Nango's vault; we persist only the connection reference.
+CREATE TABLE IF NOT EXISTS connections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,         -- registry id, e.g. 'sandbox-gtm','hubspot'
+  nango_connection_id TEXT,       -- reference into Nango (no secrets stored here)
+  direction TEXT NOT NULL DEFAULT 'inbound',
+  status TEXT NOT NULL DEFAULT 'pending',  -- 'pending' | 'active' | 'error' | 'revoked'
+  config JSONB NOT NULL DEFAULT '{}',
+  last_synced_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (organization_id, provider)
+);
+CREATE INDEX IF NOT EXISTS idx_connections_org ON connections (organization_id);
+
+-- ── Unified Event Record / golden record (Layer 3 data) ──
+CREATE TABLE IF NOT EXISTS accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name TEXT,
+  domain TEXT,
+  icp_match NUMERIC,              -- 0..1 fit against North-Star ICP
+  attributes JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_accounts_org ON accounts (organization_id);
+CREATE INDEX IF NOT EXISTS idx_accounts_domain ON accounts (organization_id, domain);
+
+CREATE TABLE IF NOT EXISTS contacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  account_id UUID REFERENCES accounts(id) ON DELETE SET NULL,
+  identity_key TEXT,              -- deterministic resolution key ('email:'/'phone:')
+  email TEXT,
+  phone TEXT,
+  full_name TEXT,
+  title TEXT,
+  -- lead → registered → checked_in → session_attended → lead_scanned → opportunity
+  lifecycle_stage TEXT NOT NULL DEFAULT 'lead',
+  attributes JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_contacts_org ON contacts (organization_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_identity
+  ON contacts (organization_id, identity_key) WHERE identity_key IS NOT NULL;
+
+-- Maps each raw source record to its resolved golden contact (merge audit).
+CREATE TABLE IF NOT EXISTS identity_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  source_provider TEXT NOT NULL,
+  source_record_id TEXT NOT NULL,
+  match_type TEXT NOT NULL DEFAULT 'deterministic',  -- 'deterministic' | 'probabilistic' | 'manual'
+  confidence NUMERIC DEFAULT 1.0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (organization_id, source_provider, source_record_id)
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  track TEXT,
+  starts_at TIMESTAMPTZ,
+  attributes JSONB NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_event ON sessions (event_id);
+
+CREATE TABLE IF NOT EXISTS session_attendance (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  attended BOOLEAN DEFAULT false,
+  dwell_seconds INTEGER DEFAULT 0,
+  UNIQUE (session_id, contact_id)
+);
+
+-- Normalized cross-tool activity stream — the spine of the record.
+CREATE TABLE IF NOT EXISTS engagements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  event_id UUID REFERENCES events(id) ON DELETE CASCADE,
+  contact_id UUID REFERENCES contacts(id) ON DELETE CASCADE,
+  source_provider TEXT NOT NULL,
+  kind TEXT NOT NULL,             -- 'registered'|'checked_in'|'session_attended'|'lead_scanned'|'meeting'|'content_view'
+  weight NUMERIC DEFAULT 1.0,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  payload JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_engagements_contact ON engagements (organization_id, contact_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_engagements_event ON engagements (event_id, kind);
+
+-- ── Consistency Engine (the forensic AI) ──
+CREATE TABLE IF NOT EXISTS consistency_signals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  dimension TEXT NOT NULL,        -- 'kpi'|'voice'|'audience'|'content'|'context'
+  severity TEXT NOT NULL DEFAULT 'info',  -- 'info'|'warn'|'critical'
+  summary TEXT NOT NULL,
+  detail JSONB NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'open',     -- 'open'|'acknowledged'|'resolved'|'dismissed'
+  source_provider TEXT,
+  detected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_signals_event ON consistency_signals (event_id, status, severity);
+
+-- ── Sales Readiness & Handoff (Layer 7) ──
+CREATE TABLE IF NOT EXISTS readiness_scores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  score NUMERIC NOT NULL DEFAULT 0,
+  tier TEXT,                      -- 'hot' | 'warm' | 'cold'
+  rationale JSONB NOT NULL DEFAULT '{}',
+  scored_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (event_id, contact_id)
+);
+CREATE INDEX IF NOT EXISTS idx_readiness_event ON readiness_scores (event_id, score DESC);
+
+CREATE TABLE IF NOT EXISTS handoffs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  contact_id UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  destination TEXT NOT NULL,      -- 'hubspot' | 'salesforce' | 'attio'
+  status TEXT NOT NULL DEFAULT 'pending',  -- 'pending' | 'sent' | 'error'
+  external_id TEXT,
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  sent_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_handoffs_event ON handoffs (event_id, status);
+
+-- ── Cross-event Brain (compounding intelligence) ──
+-- Port: Forge brain_patterns / brain_mistakes + Brain-First Protocol.
+CREATE TABLE IF NOT EXISTS playbook_patterns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  pattern_type TEXT,
+  description TEXT,
+  confidence NUMERIC DEFAULT 0,
+  success_rate NUMERIC DEFAULT 0,
+  tags JSONB DEFAULT '[]',
+  last_validated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS playbook_mistakes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  mistake_type TEXT,
+  description TEXT,
+  human_feedback TEXT,
+  guardrail TEXT,
+  severity TEXT DEFAULT 'low',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ── Infosec & AI audit ──
+CREATE TABLE IF NOT EXISTS audit_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID,
+  actor_user_id TEXT,
+  action TEXT NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_audit_org_created ON audit_log (organization_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS agent_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  event_id UUID REFERENCES events(id) ON DELETE SET NULL,
+  agent TEXT NOT NULL,
+  model TEXT,
+  tokens_used INTEGER,
+  latency_ms INTEGER,
+  status TEXT DEFAULT 'complete',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -1,0 +1,1931 @@
+{
+  "name": "event-intelligence-platform",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "event-intelligence-platform",
+      "version": "0.0.1",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
+        "dotenv": "^16.4.7",
+        "express": "^4.21.2",
+        "jose": "^5.9.6",
+        "pg": "^8.13.1",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^22.10.2",
+        "@types/pg": "^8.11.10",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "event-intelligence-platform",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Vendor-neutral system of intelligence for the event lifecycle — keeps KPIs, voice, audience, content and context consistent from first touchpoint through post-event pipeline.",
+  "license": "UNLICENSED",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "migrate": "tsx src/db/migrate.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "jose": "^5.9.6",
+    "pg": "^8.13.1",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.10.2",
+    "@types/pg": "^8.11.10",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/platform/src/app.ts
+++ b/platform/src/app.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+import { requestAudit } from './middleware/audit';
+import { errorHandler } from './middleware/error';
+import { pingDb } from './db/pool';
+import { hasClerk, hasAnthropic, hasNango } from './config/env';
+import northstar from './modules/northstar';
+import connectors from './modules/connectors';
+import record from './modules/record';
+import consistency from './modules/consistency';
+import readiness from './modules/readiness';
+
+export function createApp() {
+  const app = express();
+  app.use(express.json({ limit: '2mb' }));
+  app.use(requestAudit);
+
+  app.get('/health', async (_req, res) => {
+    res.json({
+      status: 'ok',
+      service: 'event-intelligence-platform',
+      time: new Date().toISOString(),
+      checks: { db: await pingDb(), clerk: hasClerk, anthropic: hasAnthropic, nango: hasNango },
+    });
+  });
+
+  app.use('/api/northstar', northstar);
+  app.use('/api/connectors', connectors);
+  app.use('/api/record', record);
+  app.use('/api/consistency', consistency);
+  app.use('/api/readiness', readiness);
+
+  app.use(errorHandler);
+  return app;
+}

--- a/platform/src/config/env.ts
+++ b/platform/src/config/env.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// All integration vars are optional so the app can boot for review/health
+// without secrets. Helper booleans below gate features that actually need them.
+const schema = z.object({
+  NODE_ENV: z.string().default('development'),
+  PORT: z.coerce.number().default(8080),
+  DATABASE_URL: z.string().optional(),
+  CLERK_JWKS_URL: z.string().url().optional(),
+  CLERK_ISSUER: z.string().optional(),
+  ANTHROPIC_API_KEY: z.string().optional(),
+  NANGO_SECRET_KEY: z.string().optional(),
+  NANGO_HOST: z.string().default('https://api.nango.dev'),
+  PIPEDREAM_API_KEY: z.string().optional(),
+  RESEND_API_KEY: z.string().optional(),
+});
+
+const parsed = schema.safeParse(process.env);
+if (!parsed.success) {
+  console.error('Invalid environment configuration', parsed.error.flatten().fieldErrors);
+  process.exit(1);
+}
+
+export const env = parsed.data;
+export const hasDb = Boolean(env.DATABASE_URL);
+export const hasClerk = Boolean(env.CLERK_JWKS_URL);
+export const hasAnthropic = Boolean(env.ANTHROPIC_API_KEY);
+export const hasNango = Boolean(env.NANGO_SECRET_KEY);

--- a/platform/src/db/migrate.ts
+++ b/platform/src/db/migrate.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getPool } from './pool';
+import { hasDb } from '../config/env';
+import { logger } from '../lib/logger';
+
+// Minimal forward-only migration runner: applies every *.sql in migrations/
+// in lexical order, tracked in a _migrations table. Each file runs in a tx.
+async function migrate() {
+  if (!hasDb) {
+    logger.error('DATABASE_URL not set — cannot migrate');
+    process.exit(1);
+  }
+  const dir = path.join(__dirname, '..', '..', 'migrations');
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.sql')).sort();
+  const pool = getPool();
+  await pool.query('CREATE TABLE IF NOT EXISTS _migrations (id TEXT PRIMARY KEY, applied_at TIMESTAMPTZ DEFAULT NOW())');
+
+  for (const file of files) {
+    const applied = await pool.query('SELECT 1 FROM _migrations WHERE id = $1', [file]);
+    if (applied.rowCount) {
+      logger.info('skip migration', { file });
+      continue;
+    }
+    const sql = fs.readFileSync(path.join(dir, file), 'utf8');
+    logger.info('applying migration', { file });
+    await pool.query('BEGIN');
+    try {
+      await pool.query(sql);
+      await pool.query('INSERT INTO _migrations (id) VALUES ($1)', [file]);
+      await pool.query('COMMIT');
+    } catch (e) {
+      await pool.query('ROLLBACK');
+      logger.error('migration failed', { file, error: String(e) });
+      process.exit(1);
+    }
+  }
+  logger.info('migrations complete');
+  await pool.end();
+}
+
+migrate();

--- a/platform/src/db/pool.ts
+++ b/platform/src/db/pool.ts
@@ -1,0 +1,29 @@
+import { Pool } from 'pg';
+import { env, hasDb } from '../config/env';
+import { logger } from '../lib/logger';
+
+let pool: Pool | null = null;
+
+export function getPool(): Pool {
+  if (!hasDb) throw new Error('DATABASE_URL not configured');
+  if (!pool) {
+    pool = new Pool({ connectionString: env.DATABASE_URL, max: 10 });
+    pool.on('error', (err) => logger.error('pg pool error', { error: String(err) }));
+  }
+  return pool;
+}
+
+export async function query<T = Record<string, unknown>>(text: string, params: unknown[] = []): Promise<T[]> {
+  const res = await getPool().query(text, params as unknown[]);
+  return res.rows as T[];
+}
+
+export async function pingDb(): Promise<boolean> {
+  if (!hasDb) return false;
+  try {
+    await getPool().query('SELECT 1');
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/platform/src/design/tokens.css
+++ b/platform/src/design/tokens.css
@@ -1,0 +1,42 @@
+/*
+ * Design tokens — ported from Forge Intelligence's 12-directive system so the
+ * platform shares one visual language. Dark foundation, Intelligence Blue
+ * accent, Signal Teal for positive states, Proof Amber used sparingly.
+ * Lucide icons (1.5 stroke), calm motion, NO emojis anywhere in the UI.
+ */
+:root {
+  /* Foundation */
+  --color-bg-base: #0F1720;
+  --color-bg-card: #1E293B;
+
+  /* Accents */
+  --color-accent: #3563FF;        /* Intelligence Blue — primary CTA / active */
+  --color-secondary: #14B8A6;     /* Signal Teal — positive / insight signals */
+  --color-highlight: #F5B942;     /* Proof Amber — sparing emphasis only */
+
+  /* Signal severity (consistency engine) */
+  --color-signal-info: #14B8A6;
+  --color-signal-warn: #F5B942;
+  --color-signal-critical: #EF4444;
+
+  /* Text */
+  --color-text: #E2E8F0;
+  --color-text-muted: #94A3B8;
+  --color-text-emphasis: #F8FAFC;
+
+  /* Shape & type */
+  --radius: 12px;                 /* 10–14px range */
+  --font-sans: Inter, Geist, system-ui, sans-serif;
+
+  /* Motion — purposeful only */
+  --transition: 160ms ease;
+}
+
+/* Light mode (blueberry) — parity with Forge's light system. */
+:root[data-theme="light"] {
+  --color-bg-base: #EDF1FF;
+  --color-bg-card: #FFFFFF;
+  --color-text: #0F172A;
+  --color-text-emphasis: #0F172A;
+  --color-text-muted: #475569;
+}

--- a/platform/src/lib/claude.ts
+++ b/platform/src/lib/claude.ts
@@ -1,0 +1,41 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { env, hasAnthropic } from '../config/env';
+
+// Multi-model routing, mirroring Forge's economics:
+//   deep   → Opus    (foundational/forensic reasoning)
+//   reason → Sonnet  (strategic analysis, voice fidelity)
+//   fast   → Haiku   (cheap signal checks, routing)
+export const MODELS = {
+  deep: 'claude-opus-4-7',
+  reason: 'claude-sonnet-4-6',
+  fast: 'claude-haiku-4-5-20251001',
+} as const;
+
+export type ModelTier = keyof typeof MODELS;
+
+let client: Anthropic | null = null;
+function getClient(): Anthropic {
+  if (!hasAnthropic) throw new Error('ANTHROPIC_API_KEY not configured');
+  if (!client) client = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+  return client;
+}
+
+export interface CompleteArgs {
+  tier: ModelTier;
+  prompt: string;
+  system?: string;
+  maxTokens?: number;
+}
+
+export async function complete({ tier, prompt, system, maxTokens = 2048 }: CompleteArgs): Promise<string> {
+  const resp = await getClient().messages.create({
+    model: MODELS[tier],
+    max_tokens: maxTokens,
+    system,
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return resp.content
+    .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}

--- a/platform/src/lib/errors.ts
+++ b/platform/src/lib/errors.ts
@@ -1,0 +1,14 @@
+export class AppError extends Error {
+  status: number;
+  code: string;
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export const badRequest = (msg = 'Bad request') => new AppError(400, 'bad_request', msg);
+export const unauthorized = (msg = 'Unauthorized') => new AppError(401, 'unauthorized', msg);
+export const forbidden = (msg = 'Forbidden') => new AppError(403, 'forbidden', msg);
+export const notFound = (msg = 'Not found') => new AppError(404, 'not_found', msg);

--- a/platform/src/lib/logger.ts
+++ b/platform/src/lib/logger.ts
@@ -1,0 +1,14 @@
+type Level = 'debug' | 'info' | 'warn' | 'error';
+
+function log(level: Level, msg: string, meta?: Record<string, unknown>) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), level, msg, ...(meta ?? {}) });
+  if (level === 'error') console.error(line);
+  else console.log(line);
+}
+
+export const logger = {
+  debug: (m: string, meta?: Record<string, unknown>) => log('debug', m, meta),
+  info: (m: string, meta?: Record<string, unknown>) => log('info', m, meta),
+  warn: (m: string, meta?: Record<string, unknown>) => log('warn', m, meta),
+  error: (m: string, meta?: Record<string, unknown>) => log('error', m, meta),
+};

--- a/platform/src/lib/respond.ts
+++ b/platform/src/lib/respond.ts
@@ -1,0 +1,14 @@
+import { Response } from 'express';
+
+// Uniform placeholder for planned-but-unbuilt capabilities. Names the plan
+// phase and the Forge pattern to port so the scaffold is self-documenting.
+export function notImplemented(
+  res: Response,
+  info: { phase: string; portFrom?: string; note?: string },
+) {
+  res.status(501).json({
+    error: 'not_implemented',
+    message: 'Planned capability — not yet built.',
+    ...info,
+  });
+}

--- a/platform/src/lib/sanitizeJson.ts
+++ b/platform/src/lib/sanitizeJson.ts
@@ -1,0 +1,45 @@
+/*
+ * Ported from Forge Intelligence. Streamed LLM output sometimes leaves bare
+ * control characters (raw newlines/tabs) inside JSON string values, which
+ * breaks JSON.parse. This escapes them in-place without touching structure,
+ * and strips a leading/trailing ```json code fence if present.
+ */
+export function sanitizeJson(raw: string): string {
+  const s = raw.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
+  let out = '';
+  let inString = false;
+  let escaped = false;
+  for (const ch of s) {
+    if (escaped) {
+      out += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      out += ch;
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      out += ch;
+      continue;
+    }
+    if (inString) {
+      const code = ch.charCodeAt(0);
+      if (code < 0x20) {
+        if (ch === '\n') out += '\\n';
+        else if (ch === '\r') out += '\\r';
+        else if (ch === '\t') out += '\\t';
+        else out += '\\u' + code.toString(16).padStart(4, '0');
+        continue;
+      }
+    }
+    out += ch;
+  }
+  return out;
+}
+
+export function parseJsonSafe<T = unknown>(raw: string): T {
+  return JSON.parse(sanitizeJson(raw)) as T;
+}

--- a/platform/src/middleware/audit.ts
+++ b/platform/src/middleware/audit.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../lib/logger';
+import { hasDb } from '../config/env';
+import { query } from '../db/pool';
+
+// Lightweight access log on every request.
+export function requestAudit(req: Request, res: Response, next: NextFunction) {
+  const start = Date.now();
+  res.on('finish', () => {
+    logger.info('request', { method: req.method, path: req.path, status: res.statusCode, ms: Date.now() - start });
+  });
+  next();
+}
+
+// Persist a security-relevant action to audit_log (best-effort; never throws
+// into the request path).
+export async function audit(req: Request, action: string, meta: Record<string, unknown> = {}) {
+  if (!hasDb) return;
+  try {
+    await query(
+      'INSERT INTO audit_log (organization_id, actor_user_id, action, metadata) VALUES ($1, $2, $3, $4)',
+      [req.tenant?.organizationId ?? null, req.auth?.userId ?? null, action, JSON.stringify(meta)],
+    );
+  } catch (e) {
+    logger.error('audit insert failed', { error: String(e), action });
+  }
+}

--- a/platform/src/middleware/auth.ts
+++ b/platform/src/middleware/auth.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction } from 'express';
+import { createRemoteJWKSet, jwtVerify, JWTPayload } from 'jose';
+import { env, hasClerk } from '../config/env';
+import { unauthorized } from '../lib/errors';
+
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+function getJwks() {
+  if (!hasClerk) throw unauthorized('Auth not configured (CLERK_JWKS_URL missing)');
+  if (!jwks) jwks = createRemoteJWKSet(new URL(env.CLERK_JWKS_URL as string));
+  return jwks;
+}
+
+async function verify(token: string): Promise<JWTPayload> {
+  const opts = env.CLERK_ISSUER ? { issuer: env.CLERK_ISSUER } : undefined;
+  const { payload } = await jwtVerify(token, getJwks(), opts);
+  return payload;
+}
+
+function bearer(req: Request): string | null {
+  const h = req.headers.authorization;
+  return h && h.startsWith('Bearer ') ? h.slice(7) : null;
+}
+
+function claims(payload: JWTPayload) {
+  const p = payload as JWTPayload & { org_id?: string; org_role?: string; role?: string };
+  return { userId: String(payload.sub), orgId: p.org_id, role: p.org_role ?? p.role };
+}
+
+export async function requireAuth(req: Request, _res: Response, next: NextFunction) {
+  try {
+    const token = bearer(req);
+    if (!token) throw unauthorized('Missing bearer token');
+    req.auth = claims(await verify(token));
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
+// Optional auth: attaches identity if a valid token is present, never blocks.
+export async function softAuth(req: Request, _res: Response, next: NextFunction) {
+  try {
+    const token = bearer(req);
+    if (token && hasClerk) req.auth = claims(await verify(token));
+  } catch {
+    /* ignore — soft */
+  }
+  next();
+}

--- a/platform/src/middleware/error.ts
+++ b/platform/src/middleware/error.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+import { AppError } from '../lib/errors';
+import { logger } from '../lib/logger';
+
+// Centralized error handler. Known AppErrors map to their status; everything
+// else is a 500 with no internal detail leaked to the client.
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction) {
+  if (err instanceof AppError) {
+    return res.status(err.status).json({ error: err.code, message: err.message });
+  }
+  logger.error('unhandled error', { error: String(err) });
+  return res.status(500).json({ error: 'internal_error', message: 'Something went wrong' });
+}

--- a/platform/src/middleware/rbac.ts
+++ b/platform/src/middleware/rbac.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+import { forbidden } from '../lib/errors';
+
+// Role gate. Roles: 'owner' | 'admin' | 'member' | 'viewer'.
+export function requireRole(...roles: string[]) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const role = req.auth?.role;
+    if (!role || !roles.includes(role)) {
+      return next(forbidden(`Requires role: ${roles.join(' | ')}`));
+    }
+    next();
+  };
+}

--- a/platform/src/middleware/tenant.ts
+++ b/platform/src/middleware/tenant.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+import { badRequest } from '../lib/errors';
+
+// Resolves the active tenant (organization) for the request. MVP trusts the
+// Clerk org claim, falling back to an x-org-id header for service calls.
+// TODO(phase-0): validate the user's membership against the memberships table.
+export function resolveTenant(req: Request, _res: Response, next: NextFunction) {
+  const orgId = req.auth?.orgId ?? (req.headers['x-org-id'] as string | undefined);
+  if (!orgId) return next(badRequest('No organization context'));
+  req.tenant = { organizationId: orgId };
+  next();
+}

--- a/platform/src/modules/connectors/index.ts
+++ b/platform/src/modules/connectors/index.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { requireAuth } from '../../middleware/auth';
+import { resolveTenant } from '../../middleware/tenant';
+import { listProviders } from './registry';
+import { nangoConfigured } from './nango';
+import { notImplemented } from '../../lib/respond';
+
+// Connector Fabric — BYO tools. Nango backbone for durable two-way syncs;
+// Pipedream for long-tail automations.
+const router = Router();
+
+// List available providers (registry metadata only, no tenant data).
+router.get('/', requireAuth, (_req, res) => {
+  res.json({ nangoConfigured: nangoConfigured(), providers: listProviders() });
+});
+
+// Inbound webhook ingest (provider → unified record). Verified by the
+// provider's own signature (HMAC), NOT Clerk auth — so it sits before the
+// auth gate below. Port: Forge /api/webhooks/* + signature verification.
+router.post('/:providerId/webhook', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 2', portFrom: 'Forge /api/webhooks/*', note: 'verified by provider signature, not Clerk auth' }),
+);
+
+router.use(requireAuth, resolveTenant);
+
+// Begin a connect flow (Nango connect session).
+router.post('/:providerId/connect', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 2', portFrom: 'Forge publishing_channels + OAuth setup' }),
+);
+
+export default router;

--- a/platform/src/modules/connectors/nango.ts
+++ b/platform/src/modules/connectors/nango.ts
@@ -1,0 +1,25 @@
+import { env, hasNango } from '../../config/env';
+
+// Thin Nango adapter. Nango holds the OAuth token vault and runs typed syncs;
+// we never store provider credentials in our own DB. This wraps the calls we
+// need (connect sessions, reading synced records). Docs: https://docs.nango.dev
+export function nangoConfigured(): boolean {
+  return hasNango;
+}
+
+type FetchInit = { method?: string; headers?: Record<string, string>; body?: string };
+
+export async function nangoFetch(path: string, init: FetchInit = {}): Promise<unknown> {
+  if (!hasNango) throw new Error('NANGO_SECRET_KEY not configured');
+  const res = await fetch(`${env.NANGO_HOST}${path}`, {
+    method: init.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${env.NANGO_SECRET_KEY}`,
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+    body: init.body,
+  });
+  if (!res.ok) throw new Error(`Nango ${res.status}: ${await res.text()}`);
+  return res.json();
+}

--- a/platform/src/modules/connectors/providers/sandbox-gtm.ts
+++ b/platform/src/modules/connectors/providers/sandbox-gtm.ts
@@ -1,0 +1,14 @@
+import type { ConnectorProvider } from '../registry';
+
+// First connector — owned IP (Sandbox-GTM + Engage). Full API control, the
+// dogfoodable anchor for the MVP consistency thread.
+export const sandboxGtm: ConnectorProvider = {
+  id: 'sandbox-gtm',
+  name: 'Sandbox-GTM + Engage',
+  category: 'event_management',
+  authMode: 'api_key',
+  direction: 'bidirectional',
+  objects: ['contacts', 'accounts', 'sessions', 'session_attendance', 'engagements'],
+  owned: true,
+  status: 'planned',
+};

--- a/platform/src/modules/connectors/registry.ts
+++ b/platform/src/modules/connectors/registry.ts
@@ -1,0 +1,42 @@
+import { sandboxGtm } from './providers/sandbox-gtm';
+
+// The Connector Fabric registry. Each provider declares how it connects
+// (Nango-managed OAuth, API key, or inbound webhook) and which unified-record
+// objects it maps to. Port: Forge `publishing_channels` credential pattern.
+export type AuthMode = 'nango_oauth' | 'api_key' | 'webhook';
+export type SyncDirection = 'inbound' | 'outbound' | 'bidirectional';
+export type ProviderCategory =
+  | 'event_management'
+  | 'crm'
+  | 'networking'
+  | 'mobile'
+  | 'lead_capture'
+  | 'community';
+
+export interface ConnectorProvider {
+  id: string;
+  name: string;
+  category: ProviderCategory;
+  authMode: AuthMode;
+  direction: SyncDirection;
+  objects: string[];
+  owned?: boolean; // true = Sandbox IP
+  status: 'live' | 'planned';
+}
+
+// MVP anchors on owned IP; open-API tools come next (research flagged
+// HubSpot/Salesforce/Attio/Swapcard/Brella as open, RainFocus/Whova gated).
+export const registry: Record<string, ConnectorProvider> = {
+  [sandboxGtm.id]: sandboxGtm,
+  hubspot: { id: 'hubspot', name: 'HubSpot', category: 'crm', authMode: 'nango_oauth', direction: 'bidirectional', objects: ['contacts', 'accounts', 'engagements'], status: 'planned' },
+  swapcard: { id: 'swapcard', name: 'Swapcard', category: 'networking', authMode: 'nango_oauth', direction: 'inbound', objects: ['contacts', 'sessions', 'engagements'], status: 'planned' },
+  cvent: { id: 'cvent', name: 'Cvent', category: 'event_management', authMode: 'nango_oauth', direction: 'inbound', objects: ['contacts', 'sessions', 'session_attendance'], status: 'planned' },
+};
+
+export function listProviders(): ConnectorProvider[] {
+  return Object.values(registry);
+}
+
+export function getProvider(id: string): ConnectorProvider | undefined {
+  return registry[id];
+}

--- a/platform/src/modules/consistency/index.ts
+++ b/platform/src/modules/consistency/index.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { requireAuth } from '../../middleware/auth';
+import { resolveTenant } from '../../middleware/tenant';
+import { notImplemented } from '../../lib/respond';
+
+// The Consistency Engine ("forensic AI"). Compares cross-tool reality against
+// the North-Star and emits drift signals across five dimensions: kpi, voice,
+// audience, content, context. Human-in-the-loop review. Port: Forge Compliance
+// Gate (/api/compliance/critique) + decay_alerts + Brain-First Protocol.
+// Model routing: Opus (deep) / Sonnet (reason) / Haiku (fast) — see lib/claude.
+const router = Router();
+router.use(requireAuth, resolveTenant);
+
+router.get('/events/:eventId/signals', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 3', portFrom: 'Forge decay_alerts + Compliance Gate' }),
+);
+router.post('/events/:eventId/scan', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 3', portFrom: 'Forge /api/compliance/critique', note: 'runs the forensic consistency scan' }),
+);
+
+export default router;

--- a/platform/src/modules/northstar/index.ts
+++ b/platform/src/modules/northstar/index.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { requireAuth } from '../../middleware/auth';
+import { resolveTenant } from '../../middleware/tenant';
+import { notImplemented } from '../../lib/respond';
+
+// Layer 1 — Pre-event intelligence / North-Star. The source of truth (goals,
+// KPIs, target ICP, brand voice, themes) every other layer is measured
+// against. Port: Forge voice_profile + settings.factualGround + Territory
+// injection + Brain-First Protocol.
+const router = Router();
+router.use(requireAuth, resolveTenant);
+
+router.get('/events/:eventId', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 1', portFrom: 'Forge brand_profiles.voice_profile / factualGround' }),
+);
+router.put('/events/:eventId', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 1', portFrom: 'Forge Context Hub Stage 1', note: 'North-Star wizard + light audience/account enrichment' }),
+);
+
+export default router;

--- a/platform/src/modules/readiness/index.ts
+++ b/platform/src/modules/readiness/index.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { requireAuth } from '../../middleware/auth';
+import { resolveTenant } from '../../middleware/tenant';
+import { notImplemented } from '../../lib/respond';
+
+// Layer 7 — Sales Readiness & Handoff (the differentiator). Scores engagement
+// across all connected tools, decides sales-readiness, and hands off enriched
+// records to the CRM (HubSpot first). This is the market's weakest-served,
+// highest-value link. Port: Forge analytics→pattern loop.
+const router = Router();
+router.use(requireAuth, resolveTenant);
+
+router.get('/events/:eventId/scores', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 4', note: 'engagement-weighted readiness scoring (hot/warm/cold)' }),
+);
+router.post('/events/:eventId/handoff', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 4', portFrom: 'Forge CRM sync', note: 'push sales-ready contacts to HubSpot/Salesforce/Attio' }),
+);
+
+export default router;

--- a/platform/src/modules/record/identity.ts
+++ b/platform/src/modules/record/identity.ts
@@ -1,0 +1,23 @@
+// Identity resolution for the golden record. Deterministic matching on a
+// normalized email/phone key; probabilistic (fuzzy name + company) matching is
+// a Phase 2 follow-up. Survivorship rules decide which value wins on merge.
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function normalizePhone(phone: string): string {
+  return phone.replace(/[^\d+]/g, '');
+}
+
+export interface IdentityInput {
+  email?: string;
+  phone?: string;
+}
+
+// A stable key used for deterministic dedupe. Email wins over phone.
+export function deterministicKey(input: IdentityInput): string | null {
+  if (input.email && input.email.trim()) return `email:${normalizeEmail(input.email)}`;
+  if (input.phone && input.phone.trim()) return `phone:${normalizePhone(input.phone)}`;
+  return null;
+}

--- a/platform/src/modules/record/index.ts
+++ b/platform/src/modules/record/index.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { requireAuth } from '../../middleware/auth';
+import { resolveTenant } from '../../middleware/tenant';
+import { notImplemented } from '../../lib/respond';
+
+// Layer 3 (data) — Unified Event Record / golden record. Event → Sessions →
+// Contacts ↔ Accounts with identity resolution and lifecycle stages.
+const router = Router();
+router.use(requireAuth, resolveTenant);
+
+router.get('/contacts', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 2', portFrom: 'CDP golden-record pattern (see record/identity.ts)' }),
+);
+router.get('/accounts', (_req, res) => notImplemented(res, { phase: 'Phase 2' }));
+router.get('/events/:eventId/timeline', (_req, res) =>
+  notImplemented(res, { phase: 'Phase 2', note: 'lifecycle: registered → checked_in → session_attended → lead_scanned → opportunity' }),
+);
+
+export default router;

--- a/platform/src/server.ts
+++ b/platform/src/server.ts
@@ -1,0 +1,8 @@
+import { createApp } from './app';
+import { env } from './config/env';
+import { logger } from './lib/logger';
+
+const app = createApp();
+app.listen(env.PORT, () => {
+  logger.info('server listening', { port: env.PORT, env: env.NODE_ENV });
+});

--- a/platform/src/types.d.ts
+++ b/platform/src/types.d.ts
@@ -1,0 +1,12 @@
+import 'express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      auth?: { userId: string; orgId?: string; role?: string };
+      tenant?: { organizationId: string };
+    }
+  }
+}
+
+export {};

--- a/platform/tsconfig.json
+++ b/platform/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## ⚠️ Review only — do NOT merge into Forge

This is **Phase 0 scaffolding for a new product** (the vendor-neutral event-intelligence orchestration platform), living in a self-contained `platform/` subfolder, **structured to extract cleanly into its own repo**. It should not be merged into Forge's `main`/`development` deploy branches. This draft PR is a review surface only, since this session is scoped to the Forge-Intelligence repo and can't create a separate repo.

> Supersedes #167 (branch renamed `claude/cool-ride-OcvLs` → `claude/event-intelligence-platform`). Same commit, no content change.

## Summary

A vendor-neutral, Bring-Your-Own-Tools "system of intelligence" for the event lifecycle — keeps **KPIs, voice, audience, content and context consistent from first touchpoint through the post-event sales pipeline**, then converts engagement into sales-ready, CRM-handed-off pipeline. Much of the intelligence machinery is ported from Forge's proven patterns (Brain, Compliance Gate, connector layer, multi-model Claude routing); Forge plugs in as **Layer 8 (event journalism)**.

### What's in this scaffold (`platform/`)
- **Modular TS/Express server** (`config / db / lib / middleware / modules`) — deliberately avoids Forge's single-file `server.js` scaling debt.
- **Tenant-scoped golden-record schema** (`migrations/0001_init.sql`): events + North-Star, connector fabric, contacts/accounts/identity resolution, sessions, engagements, consistency signals, readiness scores, handoffs, cross-event brain, audit log.
- **Six pillar modules**: North-Star (L1), Connector Fabric (Nango-backed registry live), Unified Record (identity utils live), Consistency Engine, Sales Readiness & Handoff (L7); Forge as L8. Unbuilt endpoints return a structured `501` naming the plan phase + Forge pattern to port.
- **Infosec baseline**: Clerk JWKS auth, RBAC, tenant scoping, audit logging, central error handler; connector secrets designed to live in Nango's vault (not our DB).
- **Reused from Forge**: multi-model Claude routing (Opus/Sonnet/Haiku), `sanitizeJson`, 12-directive design tokens.

## Verification
- [x] `npm install` clean (0 vulnerabilities)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` emits to `dist/`
- [x] Server boots; `GET /health` returns 200 with integration-config flags

## Test plan
- [ ] Provision Neon + run `npm run migrate`; confirm schema applies
- [ ] Wire Clerk JWKS + verify `requireAuth` on a protected route
- [ ] `GET /api/connectors` lists the provider registry
- [ ] Decide repo-extraction timing (move `platform/` to standalone repo)

https://claude.ai/code/session_01RFehnBE6Acyq4wLKTbRj5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFehnBE6Acyq4wLKTbRj5N)_