### PR TITLE
fix(integrations): stop My Website channel from wiping its bearer token

### DIFF
--- a/server.js
+++ b/server.js
@@ -10396,7 +10396,24 @@ app.get('/api/publishing/channels/:brandProfileId', requireAuth, async (req, res
        FROM publishing_channels WHERE brand_profile_id = $1 ORDER BY channel`,
       [brandProfileId]
     );
-    res.json({ success: true, channels: result.rows });
+    // The website channel's bearerToken is a shown-once secret — never echo it
+    // back to the browser. Replace it with a non-secret existence flag + last-4
+    // so the UI can render "configured" / a masked value without the raw token.
+    const channels = result.rows.map(row => {
+      if (row.channel === 'website' && row.credentials && typeof row.credentials === 'object') {
+        const { bearerToken, ...rest } = row.credentials;
+        return {
+          ...row,
+          credentials: {
+            ...rest,
+            bearerTokenSet: !!bearerToken,
+            ...(bearerToken ? { bearerTokenLast4: String(bearerToken).slice(-4) } : {}),
+          },
+        };
+      }
+      return row;
+    });
+    res.json({ success: true, channels });
   } catch (err) {
     res.status(500).json({ success: false, error: err.message });
   }

--- a/src/components/MyWebsiteForm.tsx
+++ b/src/components/MyWebsiteForm.tsx
@@ -5,6 +5,8 @@ interface SavedWebsite {
     endpointUrl?: string;
     format?: 'html' | 'markdown' | 'both';
     bearerToken?: string;
+    bearerTokenSet?: boolean;
+    bearerTokenLast4?: string;
   };
   is_active?: boolean;
   updated_at?: string;
@@ -31,8 +33,12 @@ export default function MyWebsiteForm({ brandProfileId, saved, onChange }: MyWeb
   const [testResult, setTestResult] = useState<{ ok: boolean; status?: number; latencyMs?: number; error?: string; responseBody?: string } | null>(null);
   const [error, setError] = useState('');
 
-  const hasToken = !!saved?.credentials?.bearerToken;
-  const maskedToken = hasToken ? `forge_pub_••••${saved!.credentials!.bearerToken!.slice(-4)}` : '';
+  // "Token exists?" must NOT depend on the raw secret being echoed back — the
+  // read endpoint intentionally masks it. Use the server's non-secret flag,
+  // falling back to the raw token only for older payloads.
+  const hasToken = saved?.credentials?.bearerTokenSet ?? !!saved?.credentials?.bearerToken;
+  const last4 = saved?.credentials?.bearerTokenLast4 ?? saved?.credentials?.bearerToken?.slice(-4);
+  const maskedToken = hasToken ? `forge_pub_••••${last4 ?? '••••'}` : '';
 
   const saveConfig = async () => {
     if (!endpointUrl.match(/^https?:\/\//i)) {

--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -830,7 +830,7 @@ export default function IntegrationsPage() {
                     {ch.id === 'website' && selectedBrand && (
                       <MyWebsiteForm
                         brandProfileId={selectedBrand}
-                        saved={saved as unknown as { credentials?: { endpointUrl?: string; format?: 'html' | 'markdown' | 'both'; bearerToken?: string }; is_active?: boolean; updated_at?: string } | null}
+                        saved={saved as unknown as { credentials?: { endpointUrl?: string; format?: 'html' | 'markdown' | 'both'; bearerToken?: string; bearerTokenSet?: boolean; bearerTokenLast4?: string }; is_active?: boolean; updated_at?: string } | null}
                         onChange={() => loadChannels(selectedBrand)}
                       />
                     )}
@@ -886,7 +886,7 @@ export default function IntegrationsPage() {
 
                     <div className="int-form-footer">
                       <button className="int-cancel-btn" onClick={() => setExpanded(null)}>Close</button>
-                      {!ch.oauthFlow && (
+                      {!ch.oauthFlow && ch.id !== 'website' && (
                         <button
                           className="int-save-btn"
                           onClick={() => handleSave(ch.id)}
@@ -895,7 +895,7 @@ export default function IntegrationsPage() {
                           {saving === ch.id ? 'Saving...' : connected ? 'Update Connection' : `Connect ${ch.label}`}
                         </button>
                       )}
-                      {connected && (
+                      {connected && ch.id !== 'website' && (
                         <button
                           className="int-save-btn"
                           style={{ background: 'var(--color-bg-elevated)', color: 'var(--color-text-secondary)', border: '1px solid var(--color-border)' }}


### PR DESCRIPTION
## The bug
On the **My Website** integration, generating a bearer token, then clicking **"Update Connection"** or **"Save UTM Template"** on the website card, **wiped the stored token** (and `endpointUrl`/`format`). Publishes then failed with `partial` → *"bearerToken not generated"*, and the form showed *"No token yet."*

## Root cause
Both of those footer buttons POST to `/api/publishing/channels`, which **wholesale-overwrites** the credentials blob:
```js
DO UPDATE SET credentials = $3   // server.js — not a merge
```
The website channel uses the custom `MyWebsiteForm`, which keeps its **own** state and never populates the page-level `credentials['website']` — so those buttons sent `credentials: {}` and erased `bearerToken`. (Reddit avoided this exact footgun via a dedicated merge endpoint; the website channel was never excluded.)

A secondary issue: the channels **read** endpoint returned the raw `bearerToken` to the browser, and `MyWebsiteForm` keyed `hasToken` off that raw value — so any read that masked it would also show "No token yet."

## Fix
- **`IntegrationsPage.tsx`** — exclude `channel === 'website'` from both wholesale-overwrite footer buttons (`Update Connection`/`Connect` and `Save UTM Template`). The website card keeps only its own merge-safe **Save config** / **Generate token**.
- **`server.js`** (`GET /api/publishing/channels`) — never return the website `bearerToken` to the browser; surface non-secret `bearerTokenSet` + `bearerTokenLast4` instead (fixes a token-leak-to-client **and** makes the display reflect reality).
- **`MyWebsiteForm.tsx`** — derive `hasToken` from `bearerTokenSet` (raw-token fallback for older payloads); build the masked display from `bearerTokenLast4`.

Scope is confined to the channels read endpoint's response shaping + the My Website UI. **No changes to the publish path or token generation/storage.**

## Verification
- `node --check server.js` — clean
- `npm install` + `tsc --noEmit` (project typecheck) — both exit 0

> Note: the repo's `CLAUDE.md` mandates a `gitnexus_impact` / `gitnexus_detect_changes` pass before edits — that MCP wasn't available in this session, so I verified via typecheck instead. Blast radius is small (one read endpoint's response + the website UI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQszE8jJnD1xGKHyn9Uox6)_