### PR TITLE
fix: Zernio LinkedIn disconnect + reconnect picker, creds merge, pre-Zernio analytics backfill

### DIFF
--- a/server.js
+++ b/server.js
@@ -17099,7 +17099,10 @@ app.get('/integrations/zernio/callback', async (req, res) => {
       `SELECT id, credentials FROM publishing_channels WHERE brand_profile_id = $1 AND channel = $2`,
       [brand, platform]
     );
-    const creds = JSON.stringify({ provider: 'zernio', zernioAccountId: newAccount._id, zernioProfileId: zernio_profile_id, platform, accountName: newAccount.name || newAccount.username || platform });
+    const existingCreds = existing.rows.length
+      ? (typeof existing.rows[0].credentials === 'string' ? JSON.parse(existing.rows[0].credentials || '{}') : (existing.rows[0].credentials || {}))
+      : {};
+    const creds = JSON.stringify({ ...existingCreds, provider: 'zernio', zernioAccountId: newAccount._id, zernioProfileId: zernio_profile_id, platform, accountName: newAccount.name || newAccount.username || platform });
     if (existing.rows.length) {
       await pool.query(
         `UPDATE publishing_channels SET credentials = $1::jsonb, is_active = true, updated_at = NOW() WHERE id = $2`,

--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -663,6 +663,22 @@ export default function IntegrationsPage() {
     if (!saved) return;
     setDisconnecting(channelId);
     try {
+      // Zernio-routed channels must be revoked on Zernio's side first. Deleting only
+      // Forge's local row leaves the account authorized on Zernio, so a later reconnect
+      // skips Zernio's account/page selection screen and silently reuses the old account
+      // (no picker). /api/zernio/disconnect calls Zernio's DELETE /accounts/{id}.
+      // Best-effort: if this channel isn't actually Zernio, the endpoint 400s and we
+      // still fall through to the local-row delete below.
+      const zernioPlatforms: Record<string, string> = { linkedin: 'linkedin', facebook: 'facebook', reddit: 'reddit' };
+      if (zernioPlatforms[channelId] && selectedBrand) {
+        try {
+          await fetch('/api/zernio/disconnect', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ brandProfileId: selectedBrand, platform: zernioPlatforms[channelId] })
+          });
+        } catch { /* non-fatal — still remove the local row below */ }
+      }
       await fetch(`/api/publishing/channels/${saved.id}`, { method: 'DELETE' });
       setSavedChannels(prev => ({ ...prev, [channelId]: null }));
       setCredentials(prev => ({ ...prev, [channelId]: {} }));


### PR DESCRIPTION
Omnibus of the Zernio LinkedIn fixes from this session (disconnect/picker, creds, analytics).

## 1. Reconnect page picker (root cause)
**Disconnect never disconnected from Zernio.** UI called `DELETE /api/publishing/channels/:id` (local-row-only); `/api/zernio/disconnect` (→ Zernio `DELETE /accounts/{id}`) was never called from `src/`. The account stayed authorized on Zernio, so reconnect skipped Zernio's account/page selection screen — that screen is the picker. Fixed: `handleDisconnect` best-effort calls `/api/zernio/disconnect` for linkedin/facebook/reddit before the local delete.

## 2. Credential clobber
Zernio OAuth callback's comment said "merge … don't clobber" but the code overwrote the whole `credentials` column, wiping legacy `accessToken`/`availableTargets` on reconnect. Now genuinely merges.

## 3. Pre-Zernio analytics gap ("only tracking 10 of 25")
14 posts hit `"No credentials — skipping"`: a LinkedIn share URN but no `zernioPostId`, and no LinkedIn token for the legacy fallback (its pre-Zernio token was wiped by #2). New **`/api/admin/backfill-linkedin-zernio-ids`** maps URN→Zernio `_id` and backfills `publish_log.response_data` so they sync via Zernio. Gated on `ADMIN_RELAY_PASSWORD`; `dryRun:true` by default (returns mapping + raw Zernio sample, doubles as the API-shape probe).

## 4. "Pending" analytics that never auto-resolve
Zernio's `/analytics` is eventually-consistent (202 for fresh posts). The handler parked those as `pending:true` placeholders that only retried on manual refresh.
- **In-request 202 re-poll (LinkedIn):** retry ~1.5s ×2 before parking → a manual refresh resolves fresh posts on the spot.
- **Clear the lingering `pending` flag:** the 200-path upsert merged `raw_data` with `||` and kept `pending:true` forever; now `(raw_data - 'pending') || EXCLUDED.raw_data` across all 3 Zernio channels.
- **Background `runAnalyticsResync`:** every 30 min, re-sync only brands with pending rows, reusing the real sync endpoint via the adminPassword cron bypass (mirrors `runScheduledPublishes`). Self-limits as posts resolve.

## Test plan
- Disconnect LinkedIn → account gone on Zernio dashboard → reconnect → Zernio re-prompts page selection.
- Backfill dry run on the Forge brand → inspect `matched`/`zernioSampleShape` → re-run `{dryRun:false}` → Refresh → the 14 populate.
- Publish a fresh post → Refresh → resolves within the 202 re-poll instead of parking; otherwise auto-resolves within 30 min.

## Rollback
Revert commits. No schema changes; backfill is additive + dry-run-by-default; the rest is behavioral.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7