### PR TITLE
refactor(server): extract pool → src/server/db.js (decomposition POC)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,6 @@ import express from 'express';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import pkg from 'pg';
 import Anthropic from '@anthropic-ai/sdk';
 import { randomUUID, randomBytes, createHmac, createHash, timingSafeEqual } from 'crypto';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
@@ -10,8 +9,8 @@ import puppeteer from 'puppeteer-core';
 import { Readability } from '@mozilla/readability';
 import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
+import { pool } from './src/server/db.js';
 
-const { Pool } = pkg;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -95,7 +94,6 @@ const SUPER_ADMIN_IDS = [
 ];
 
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, timeout: 1200000 }); // 20min
 
 async function initDB() {

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -1,0 +1,12 @@
+// Shared Neon Postgres connection pool — the single source of truth for the DB
+// handle. Imported by server.js today; as the server.js decomposition proceeds,
+// every extracted route module imports `pool` from here instead of receiving it
+// as a parameter.
+//
+// ARCHITECTURE RULE: NEON_DATABASE_URL must stay on the
+// ep-odd-waterfall-akyrdo6x-pooler endpoint — never revert to ep-cool-firefly.
+import pkg from 'pg';
+
+const { Pool } = pkg;
+
+export const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });


### PR DESCRIPTION
## Why
**PR B — the proof-of-concept first cut** of the `server.js` decomposition. Goal: prove the extraction round-trip (module out → import back → CI green → route guard green) on the lowest-risk possible target before touching anything bigger.

## What
Pure move, **zero behavior change**: the Neon `pool` singleton moves to `src/server/db.js`; `server.js` imports it.
- Removed from `server.js`: `import pkg from 'pg'`, `const { Pool } = pkg`, `const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL })`
- Added: `import { pool } from './src/server/db.js'`
- All **731** `pool.query(...)` call sites unchanged.

`db.js` preserves the architecture rule in a comment (NEON_DATABASE_URL stays on `ep-odd-waterfall-akyrdo6x-pooler`).

## Why this one first
`pool` is a single exported singleton with hundreds of *unchanged* references — the smallest, safest possible diff that still exercises the full pattern. It deliberately moves a **helper, not routes**, so the route-inventory guard must stay byte-identical — which confirms the guard behaves on a legitimate non-route change.

## Verification
- `node --check server.js` ✓ · `node --check src/server/db.js` ✓
- No orphaned `pkg`/`Pool` references remain
- Route-inventory guard simulated locally → **213 routes, no diff** ✓
- CI (`Typecheck & Test`) will confirm on this PR

## Rollback
Revert — it's a 4-line move. No schema/behavior change.

## Next (PR C)
`auth.js` — `requireAuth`, `softAuth`, `verifyBrandAccess`, `mcpAuth`, API-key helpers + JWKS. More dependencies, so it gets its own PR right after this lands clean.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_