### PR TITLE
refactor(server): extract UTM helpers → src/server/utm.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ import { Readability } from '@mozilla/readability';
 import { JSDOM } from 'jsdom';
 import TurndownService from 'turndown';
 import { pool } from './src/server/db.js';
+import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9842,23 +9843,6 @@ app.post('/api/compliance/approve', requireAuth, async (req, res) => {
 // ── Stage 6: Publishing & Distribution ───────────────────────────────────────
 
 // Resolve UTM tokens against article + brand context
-function resolveUtmParams(template, ctx) {
-  const resolved = {};
-  for (const [k, v] of Object.entries(template)) {
-    resolved[k] = v
-      .replace('{campaign_slug}', ctx.campaignSlug || 'forge')
-      .replace('{article_slug}', ctx.articleSlug || 'article')
-      .replace('{brand_slug}', ctx.brandSlug || 'brand')
-      .replace('{channel}', ctx.channel || k);
-  }
-  return resolved;
-}
-
-function buildUtmString(params) {
-  return Object.entries(params).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
-}
-
-
 // GET /api/public/articles — list published articles (for public library)
 app.get('/api/public/articles', async (req, res) => {
   const { brandSlug } = req.query;

--- a/src/server/utm.js
+++ b/src/server/utm.js
@@ -1,0 +1,21 @@
+// UTM helpers, extracted from server.js during the decomposition.
+// Pure functions, no external dependencies.
+
+// Resolve {campaign_slug}/{article_slug}/{brand_slug}/{channel} placeholders in
+// a UTM template against a context object.
+export function resolveUtmParams(template, ctx) {
+  const resolved = {};
+  for (const [k, v] of Object.entries(template)) {
+    resolved[k] = v
+      .replace('{campaign_slug}', ctx.campaignSlug || 'forge')
+      .replace('{article_slug}', ctx.articleSlug || 'article')
+      .replace('{brand_slug}', ctx.brandSlug || 'brand')
+      .replace('{channel}', ctx.channel || k);
+  }
+  return resolved;
+}
+
+// Serialize a params object into a URL-encoded query string.
+export function buildUtmString(params) {
+  return Object.entries(params).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
+}

--- a/test/utm.test.js
+++ b/test/utm.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { resolveUtmParams, buildUtmString } from '../src/server/utm.js';
+
+describe('resolveUtmParams', () => {
+  it('substitutes all placeholders from context', () => {
+    const out = resolveUtmParams(
+      { utm_campaign: '{campaign_slug}', utm_content: '{article_slug}', utm_source: '{brand_slug}', utm_medium: '{channel}' },
+      { campaignSlug: 'q1', articleSlug: 'how-to', brandSlug: 'acme', channel: 'linkedin' }
+    );
+    expect(out).toEqual({ utm_campaign: 'q1', utm_content: 'how-to', utm_source: 'acme', utm_medium: 'linkedin' });
+  });
+
+  it('falls back to defaults when context fields are missing (channel falls back to the key)', () => {
+    const out = resolveUtmParams({ utm_campaign: '{campaign_slug}', utm_medium: '{channel}' }, {});
+    expect(out).toEqual({ utm_campaign: 'forge', utm_medium: 'utm_medium' });
+  });
+
+  it('passes literals through unchanged', () => {
+    expect(resolveUtmParams({ utm_source: 'newsletter' }, {})).toEqual({ utm_source: 'newsletter' });
+  });
+});
+
+describe('buildUtmString', () => {
+  it('serializes params into a url-encoded query string', () => {
+    expect(buildUtmString({ utm_source: 'acme', utm_campaign: 'spring sale' }))
+      .toBe('utm_source=acme&utm_campaign=spring%20sale');
+  });
+
+  it('returns an empty string for empty params', () => {
+    expect(buildUtmString({})).toBe('');
+  });
+});


### PR DESCRIPTION
## Why
Decomposition step 2 (after the `db.js` POC). Pure-helper extraction, safe to do unattended.

## What
`resolveUtmParams` + `buildUtmString` (both pure, zero external deps) → `src/server/utm.js`; `server.js` imports them. All three call sites unchanged.

## Safety
- `node --check` clean on `server.js` + `utm.js`; no leftover local defs; import + 3 call sites resolve.
- Route inventory unchanged (213) — guard green.
- **Adds `test/utm.test.js`** (first real unit coverage). Since CI doesn't boot the app, the unit test is what proves the extracted module actually loads and behaves — catching the one failure mode `node --check` can't.

## Merge note
Independent of the other queued refactor PRs, but its import sits next to the `db.js` import line; if you merge another import-adding refactor PR first, GitHub may ask for a one-click **Update branch** here. No logic conflicts.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_