### PR TITLE
ci: add ESLint no-undef gate (decomposition safety net)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: npm install --no-audit --no-fund
       - name: Backend syntax check (server.js monolith)
         run: node --check server.js
+      - name: Lint (no-undef) — catches missed imports from extractions
+        run: npm run lint
       - name: Typecheck (React app)
         run: npm run typecheck
       - name: Unit tests (route-inventory guard + future units)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,29 @@
+import globals from 'globals';
+
+// Minimal lint gate for the server.js decomposition. The point is ONE rule:
+// no-undef catches "X is not defined" — the exact failure mode of an extraction
+// that forgets to import a moved symbol back. CI doesn't boot the app, so this
+// is how that mistake gets caught at the PR gate instead of on deploy.
+//
+// Deliberately NOT the full eslint:recommended set — we don't want to surface
+// pre-existing style/unused-var noise across a 20k-line file. Just no-undef.
+export default [
+  {
+    files: ['server.js', 'src/server/**/*.js', 'test/**/*.{js,mjs}'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        // server.js runs browser code inside Puppeteer page.evaluate /
+        // waitForFunction callbacks (forgeScrape). document/window are legit
+        // there, so whitelist them rather than flag false positives.
+        document: 'readonly',
+        window: 'readonly',
+      },
+    },
+    rules: {
+      'no-undef': 'error',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node server.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "lint": "eslint server.js \"src/server/**/*.js\" \"test/**/*.{js,mjs}\"",
     "routes:snapshot": "node test/gen-snapshot.js"
   },
   "dependencies": {
@@ -37,6 +38,8 @@
     "@types/react-dom": "^18.2.15",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.0.1",
+    "eslint": "^9.0.0",
+    "globals": "^15.0.0",
     "typescript": "^5.2.2",
     "vite": "^8.0.12",
     "vitest": "^2.1.9"


### PR DESCRIPTION
## Why
Lands the ESLint `no-undef` gate — the safety net for the decomposition. It catches the one failure mode CI couldn't before: an extraction that forgets to import a moved symbol back (a `ReferenceError` that passes `node --check`/typecheck and only blows up on deploy).

## What
- `eslint.config.js` — flat config, **single rule: `no-undef`** (deliberately not the full recommended set, to avoid legacy style noise). `document`/`window` whitelisted for the Puppeteer `page.evaluate`/`waitForFunction` browser-context callbacks in `forgeScrape`.
- `npm run lint` added to the **Typecheck & Test** CI job.
- `eslint` + `globals` devDeps + `lint` script.

## Green by construction
This branch merges the synced `development` (which now has the #193/#194 fixes that resolved the 15 pre-existing `no-undef` errors). Verified locally: `npm run lint` exits **0**. The only would-be findings (`document` ×2) are whitelisted as legitimate browser globals.

## Note for future extractions
Keep `eslint.config.js`'s `files` list current: when a route group moves into `src/server/**`, it's already covered by the glob. If a module lands elsewhere, add it. Regenerate nothing — just keep imports honest and the gate stays quiet.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_