### PR TITLE
refactor(server): extract text utils → src/server/text.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ import TurndownService from 'turndown';
 import { pool } from './src/server/db.js';
 import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
+import { truncateStr, truncateAtSentence, stripSocialMarkdown } from './src/server/text.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -5752,21 +5753,6 @@ app.get('/api/authenticity-enricher/briefs', requireAuth, async (req, res) => {
 // ── Truncate long text at last sentence boundary within budget ──
 // Prefers ending on a full sentence (. ! ?) rather than mid-word.
 // Falls back to word boundary if no sentence break found in window.
-function truncateAtSentence(text, maxChars) {
-  if (!text || typeof text !== 'string') return '';
-  if (text.length <= maxChars) return text.trim();
-  const window = text.slice(0, maxChars);
-  // Look for last sentence-ending punctuation followed by space/newline or at end
-  const sentenceMatch = window.match(/^.*[.!?](?=\s|$)/s);
-  if (sentenceMatch && sentenceMatch[0].length >= maxChars * 0.5) {
-    return sentenceMatch[0].trim();
-  }
-  // Fallback: last complete word
-  const lastSpace = window.lastIndexOf(' ');
-  if (lastSpace > maxChars * 0.5) return window.slice(0, lastSpace).trim() + '…';
-  return window.trim() + '…';
-}
-
 app.post('/api/authenticity-enricher/analyze', requireAuth, async (req, res) => {
   const { brandProfileId, geoBriefId, topicBriefId, manualInputs = {}, force = false } = req.body;
   if (!brandProfileId) return res.status(400).json({ success: false, error: 'brandProfileId is required' });
@@ -15459,12 +15445,6 @@ app.get('/api/admin/logs/errors', requireAuth, async (req, res) => {
 // ── User-facing Alerts (topbar bell) ─────────────────────────────────────────
 // Scoped to clerk_user_id from the JWT. Never returns rows from other users.
 // short_message is the only field shown to end users; raw_message is admin-only.
-function truncateStr(s, max) {
-  if (s == null) return null;
-  const str = String(s);
-  return str.length > max ? str.slice(0, max) : str;
-}
-
 async function getActiveBrandIdForUser(userId) {
   if (!userId) return null;
   try {
@@ -16899,17 +16879,6 @@ const zernioGuard = (req, res) => {
 //
 // NOT applied to user-supplied postCopy overrides — if a human typed
 // asterisks they wanted them literal.
-function stripSocialMarkdown(text) {
-  if (!text || typeof text !== 'string') return text;
-  return text
-    // Leading H1-H6 markers on any line: "# Heading" → "Heading"
-    .replace(/^[ \t]*#{1,6}[ \t]+/gm, '')
-    // **bold** → bold (non-greedy, single line)
-    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
-    // __bold__ → bold (less common; Claude uses it occasionally)
-    .replace(/__([^_\n]+?)__/g, '$1');
-}
-
 const callZernio = async (method, path, body) => {
   const url = `https://zernio.com/api/v1${path}`;
   const opts = {

--- a/src/server/text.js
+++ b/src/server/text.js
@@ -1,0 +1,38 @@
+// Text / string utilities, extracted from server.js during the decomposition.
+// Pure functions, no external dependencies.
+
+// Hard-truncate to a max length (null-safe). No ellipsis.
+export function truncateStr(s, max) {
+  if (s == null) return null;
+  const str = String(s);
+  return str.length > max ? str.slice(0, max) : str;
+}
+
+// Truncate to maxChars, preferring a sentence boundary, then a word boundary,
+// appending an ellipsis on the soft fallbacks.
+export function truncateAtSentence(text, maxChars) {
+  if (!text || typeof text !== 'string') return '';
+  if (text.length <= maxChars) return text.trim();
+  const window = text.slice(0, maxChars);
+  // Look for last sentence-ending punctuation followed by space/newline or at end
+  const sentenceMatch = window.match(/^.*[.!?](?=\s|$)/s);
+  if (sentenceMatch && sentenceMatch[0].length >= maxChars * 0.5) {
+    return sentenceMatch[0].trim();
+  }
+  // Fallback: last complete word
+  const lastSpace = window.lastIndexOf(' ');
+  if (lastSpace > maxChars * 0.5) return window.slice(0, lastSpace).trim() + '…';
+  return window.trim() + '…';
+}
+
+// Strip markdown that social platforms render literally (headings, bold).
+export function stripSocialMarkdown(text) {
+  if (!text || typeof text !== 'string') return text;
+  return text
+    // Leading H1-H6 markers on any line: "# Heading" -> "Heading"
+    .replace(/^[ \t]*#{1,6}[ \t]+/gm, '')
+    // **bold** -> bold (non-greedy, single line)
+    .replace(/\*\*([^*\n]+?)\*\*/g, '$1')
+    // __bold__ -> bold (less common; Claude uses it occasionally)
+    .replace(/__([^_\n]+?)__/g, '$1');
+}

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { truncateStr, truncateAtSentence, stripSocialMarkdown } from '../src/server/text.js';
+
+describe('truncateStr', () => {
+  it('returns null for null/undefined', () => {
+    expect(truncateStr(null, 5)).toBeNull();
+    expect(truncateStr(undefined, 5)).toBeNull();
+  });
+  it('leaves short strings unchanged', () => {
+    expect(truncateStr('hi', 5)).toBe('hi');
+  });
+  it('hard-truncates longer strings with no ellipsis', () => {
+    expect(truncateStr('hello world', 5)).toBe('hello');
+  });
+  it('coerces non-strings', () => {
+    expect(truncateStr(12345, 3)).toBe('123');
+  });
+});
+
+describe('truncateAtSentence', () => {
+  it('returns empty string for non-string input', () => {
+    expect(truncateAtSentence(null, 10)).toBe('');
+  });
+  it('returns trimmed text when under the limit', () => {
+    expect(truncateAtSentence('  short.  ', 100)).toBe('short.');
+  });
+  it('prefers a sentence boundary', () => {
+    expect(truncateAtSentence('First sentence. Second sentence that overflows the window.', 20)).toBe('First sentence.');
+  });
+  it('falls back to a word boundary with an ellipsis', () => {
+    const out = truncateAtSentence('one two three four five six seven', 18);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.startsWith('one two')).toBe(true);
+  });
+});
+
+describe('stripSocialMarkdown', () => {
+  it('removes heading markers', () => {
+    expect(stripSocialMarkdown('# Title\n## Sub')).toBe('Title\nSub');
+  });
+  it('unwraps **bold** and __bold__', () => {
+    expect(stripSocialMarkdown('a **bold** and __also__ here')).toBe('a bold and also here');
+  });
+  it('passes non-strings through unchanged', () => {
+    expect(stripSocialMarkdown(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What
Next decomposition step. `truncateStr` + `truncateAtSentence` + `stripSocialMarkdown` (all pure, zero external deps) → `src/server/text.js`; `server.js` imports them. Call sites unchanged.

## Safety
- `node --check` clean (server.js + text.js); 0 leftover defs; import resolves; call counts consistent (9 / 1 / 6).
- **ESLint `no-undef` exit 0** against this branch (ran with the gate config) — confirms the moved symbols all still resolve. This is the failure mode the gate exists to catch, and it's clean.
- Route inventory unchanged (213).
- **Adds `test/text.test.js`** — null-safety + coercion, sentence-vs-word-boundary truncation + ellipsis, heading/bold stripping.

## Note
Independent of the gate PR (#197) — that touches `ci.yml`/`package.json`/`eslint.config.js`, this touches `server.js` + new files. Merge in any order. Once #197 lands, this PR's CI will run the `no-undef` gate too.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_