### PR TITLE
refactor(server): extract auth → src/server/auth.js (first dependency-heavy cut)

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import Anthropic from '@anthropic-ai/sdk';
 import { randomUUID, randomBytes, createHmac, createHash, timingSafeEqual } from 'crypto';
-import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { jwtVerify } from 'jose';
 import puppeteer from 'puppeteer-core';
 import { Readability } from '@mozilla/readability';
 import { JSDOM } from 'jsdom';
@@ -13,6 +13,7 @@ import { pool } from './src/server/db.js';
 import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
 import { truncateStr, truncateAtSentence, stripSocialMarkdown } from './src/server/text.js';
+import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -88,13 +89,6 @@ function buildXOAuthHeader(method, url, apiKey, apiSecret, accessToken, accessSe
 
 const PORT = process.env.PORT || 3000;
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
-const CLERK_JWKS_URL = process.env.CLERK_JWKS_URL || 'https://clerk.forgeintelligence.ai/.well-known/jwks.json';
-const clerkJWKS = createRemoteJWKSet(new URL(CLERK_JWKS_URL));
-// Super Admin user IDs (Clerk) — full access to all brands
-const SUPER_ADMIN_IDS = [
-  'user_3BtC7nusm7CShN7EdUYaaLZcDwp', // brian@sandbox-xm.com
-  'user_3CJmE0WkOj1RJC5yF99scEuwUpO', // brian — therosethyme
-];
 
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, timeout: 1200000 }); // 20min
@@ -14660,110 +14654,6 @@ app.delete('/api/reviewers/:id', async (req, res) => {
 
 
 
-// ── Clerk Auth Middleware ─────────────────────────────────────────────────────
-
-// Verify Clerk JWT and attach userId to req
-// ── Brand ownership verification ─────────────────────────────────────────────
-// Every authenticated endpoint that takes a brandProfileId MUST call this.
-async function verifyBrandAccess(brandProfileId, userId) {
-  if (!brandProfileId || !userId) return false;
-  if (SUPER_ADMIN_IDS.includes(userId)) return true;
-  const r = await pool.query(
-    'SELECT id FROM brand_profiles WHERE id = $1 AND clerk_user_id = $2',
-    [brandProfileId, userId]
-  );
-  return r.rows.length > 0;
-}
-
-
-// ── Brand ownership verification ─────────────────────────────────────────────
-
-
-// ── API key helpers ────────────────────────────────────────────────────
-// Keys are SHA-256 hashed at rest. Plaintext format: `fik_<env>_<64-hex>`
-// where env is 'live' or 'test'. ~256 bits of entropy — no brute-force risk,
-// no need for bcrypt/argon2 (which exist for low-entropy human passwords).
-function hashApiKey(plaintext) {
-  return createHash('sha256').update(plaintext).digest('hex');
-}
-
-// Look up an api_keys row by the plaintext header value. Returns the row or null.
-// Updates last_used_at/last_used_ip opportunistically (fire-and-forget).
-async function lookupApiKey(rawKey, clientIp) {
-  if (!rawKey || typeof rawKey !== 'string' || rawKey.length < 20) return null;
-  const keyHash = hashApiKey(rawKey.trim());
-  try {
-    const r = await pool.query(
-      `SELECT id, label, brand_profile_ids, scopes, revoked_at FROM api_keys WHERE key_hash = $1 LIMIT 1`,
-      [keyHash]
-    );
-    if (!r.rows.length) return null;
-    const row = r.rows[0];
-    if (row.revoked_at) return null;
-    // Record usage without blocking the request
-    pool.query(`UPDATE api_keys SET last_used_at = NOW(), last_used_ip = $1 WHERE id = $2`, [clientIp || null, row.id]).catch(() => {});
-    return row;
-  } catch(e) {
-    console.error('[API-KEY] lookup error:', e.message);
-    return null;
-  }
-}
-
-async function requireAuth(req, res, next) {
-  try {
-    // ── Path 1: API key via X-Api-Key header ──
-    // Used by machine-to-machine integrations (Frank/ForgeOS, future CI jobs, etc.).
-    // Scoped by brand_profile_ids + scopes; downstream handlers should enforce.
-    const apiKey = req.headers['x-api-key'];
-    if (apiKey) {
-      const keyRow = await lookupApiKey(apiKey, req.ip || req.headers['x-forwarded-for']);
-      if (!keyRow) {
-        return res.status(401).json({ error: 'Invalid API key' });
-      }
-      req.apiKeyAuth = {
-        keyId: keyRow.id,
-        label: keyRow.label,
-        brandIds: keyRow.brand_profile_ids || [],
-        scopes: keyRow.scopes || []
-      };
-      // userId stays unset — handlers check req.apiKeyAuth vs req.userId to distinguish
-      return next();
-    }
-
-    // ── Path 2: Clerk JWT (unchanged) ──
-    const authHeader = req.headers.authorization;
-    const queryToken = req.query?.token;
-    const rawToken = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : queryToken;
-    if (!rawToken) {
-      return res.status(401).json({ error: 'Unauthorized' });
-    }
-    const token = rawToken;
-    if (!clerkJWKS) return res.status(500).json({ error: 'Auth not configured' });
-    const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
-    req.userId = payload.sub;
-    next();
-  } catch(e) {
-    return res.status(401).json({ error: 'Invalid token' });
-  }
-}
-
-// Scope guard for API-key-authenticated requests. If req.apiKeyAuth is set,
-// verify (a) the key has the required scope and (b) the brandProfileId in
-// the request body is in the key's allowed brand list. No-op for JWT auth
-// (JWT auth already goes through verifyBrandAccess downstream).
-function requireApiKeyScope(scope) {
-  return (req, res, next) => {
-    if (!req.apiKeyAuth) return next();  // JWT path — skip, verifyBrandAccess handles it
-    if (!req.apiKeyAuth.scopes.includes(scope)) {
-      return res.status(403).json({ error: `API key missing required scope: ${scope}` });
-    }
-    const bodyBrandId = req.body?.brandProfileId || req.params?.brandProfileId;
-    if (bodyBrandId && !req.apiKeyAuth.brandIds.includes(bodyBrandId)) {
-      return res.status(403).json({ error: 'API key not authorized for this brand' });
-    }
-    next();
-  };
-}
 
 // ── forgeScrape — the one scrape primitive ─────────────────────────────────
 // Every URL Forge fetches for content/intelligence purposes goes through
@@ -15245,20 +15135,6 @@ app.post('/api/forge-scrape', express.json({ limit: '16kb' }), async (req, res) 
   }
 });
 
-// Soft auth — attaches userId if present, continues either way (for public + authed routes)
-async function softAuth(req, res, next) {
-  try {
-    const authHeader = req.headers.authorization;
-    if (authHeader?.startsWith('Bearer ')) {
-      const token = authHeader.split(' ')[1];
-      if (clerkJWKS) {
-        const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
-        req.userId = payload.sub;
-      }
-    }
-  } catch { /* no-op */ }
-  next();
-}
 
 // ── Onboarding / GTM Flow ─────────────────────────────────────────────────────
 
@@ -16516,31 +16392,6 @@ app.get('/robots.txt', async (req, res) => {
 // Admin endpoints for minting, listing, and revoking API keys. Gated by adminPassword
 // since key management is privileged (a key grants long-lived access without user rotation).
 
-// MCP server at POST /mcp — JSON-RPC 2.0 transport for MCP clients (Viktor, Slack-Claude,
-// future agentic tooling). Read-only by design. Auth: Forge api_keys (Bearer or X-Api-Key).
-// Scopes: mcp:campaigns:read, mcp:emails:read.
-
-async function mcpAuth(req, res, next) {
-  try {
-    let key = null;
-    const authHeader = req.headers.authorization || '';
-    if (authHeader.startsWith('Bearer ')) key = authHeader.slice(7).trim();
-    else if (req.headers['x-api-key']) key = String(req.headers['x-api-key']).trim();
-    if (!key) return res.status(401).json({ error: 'Missing Authorization: Bearer <key> or X-Api-Key header' });
-    const keyRow = await lookupApiKey(key, req.ip || req.headers['x-forwarded-for']);
-    if (!keyRow) return res.status(401).json({ error: 'Invalid or revoked API key' });
-    req.apiKeyAuth = {
-      keyId: keyRow.id,
-      label: keyRow.label,
-      brandIds: keyRow.brand_profile_ids || [],
-      scopes: keyRow.scopes || []
-    };
-    next();
-  } catch(e) {
-    console.error('[MCP auth]', e.message);
-    res.status(500).json({ error: 'auth_internal_error' });
-  }
-}
 
 const MCP_TOOLS = [
   {

--- a/src/server/auth.js
+++ b/src/server/auth.js
@@ -1,0 +1,161 @@
+// Authentication & authorization, extracted from server.js during the
+// decomposition: Clerk JWT + Forge API-key middleware, brand-ownership checks,
+// and the shared auth constants (clerkJWKS, SUPER_ADMIN_IDS) that the rest of
+// server.js also reads.
+import { pool } from './db.js';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { createHash } from 'crypto';
+
+export const CLERK_JWKS_URL = process.env.CLERK_JWKS_URL || 'https://clerk.forgeintelligence.ai/.well-known/jwks.json';
+export const clerkJWKS = createRemoteJWKSet(new URL(CLERK_JWKS_URL));
+// Super Admin user IDs (Clerk) — full access to all brands
+export const SUPER_ADMIN_IDS = [
+  'user_3BtC7nusm7CShN7EdUYaaLZcDwp', // brian@sandbox-xm.com
+  'user_3CJmE0WkOj1RJC5yF99scEuwUpO', // brian — therosethyme
+];
+
+// ── Clerk Auth Middleware ─────────────────────────────────────────────────────
+
+// Verify Clerk JWT and attach userId to req
+// ── Brand ownership verification ─────────────────────────────────────────────
+// Every authenticated endpoint that takes a brandProfileId MUST call this.
+export async function verifyBrandAccess(brandProfileId, userId) {
+  if (!brandProfileId || !userId) return false;
+  if (SUPER_ADMIN_IDS.includes(userId)) return true;
+  const r = await pool.query(
+    'SELECT id FROM brand_profiles WHERE id = $1 AND clerk_user_id = $2',
+    [brandProfileId, userId]
+  );
+  return r.rows.length > 0;
+}
+
+
+// ── Brand ownership verification ─────────────────────────────────────────────
+
+
+// ── API key helpers ────────────────────────────────────────────────────
+// Keys are SHA-256 hashed at rest. Plaintext format: `fik_<env>_<64-hex>`
+// where env is 'live' or 'test'. ~256 bits of entropy — no brute-force risk,
+// no need for bcrypt/argon2 (which exist for low-entropy human passwords).
+export function hashApiKey(plaintext) {
+  return createHash('sha256').update(plaintext).digest('hex');
+}
+
+// Look up an api_keys row by the plaintext header value. Returns the row or null.
+// Updates last_used_at/last_used_ip opportunistically (fire-and-forget).
+export async function lookupApiKey(rawKey, clientIp) {
+  if (!rawKey || typeof rawKey !== 'string' || rawKey.length < 20) return null;
+  const keyHash = hashApiKey(rawKey.trim());
+  try {
+    const r = await pool.query(
+      `SELECT id, label, brand_profile_ids, scopes, revoked_at FROM api_keys WHERE key_hash = $1 LIMIT 1`,
+      [keyHash]
+    );
+    if (!r.rows.length) return null;
+    const row = r.rows[0];
+    if (row.revoked_at) return null;
+    // Record usage without blocking the request
+    pool.query(`UPDATE api_keys SET last_used_at = NOW(), last_used_ip = $1 WHERE id = $2`, [clientIp || null, row.id]).catch(() => {});
+    return row;
+  } catch(e) {
+    console.error('[API-KEY] lookup error:', e.message);
+    return null;
+  }
+}
+
+export async function requireAuth(req, res, next) {
+  try {
+    // ── Path 1: API key via X-Api-Key header ──
+    // Used by machine-to-machine integrations (Frank/ForgeOS, future CI jobs, etc.).
+    // Scoped by brand_profile_ids + scopes; downstream handlers should enforce.
+    const apiKey = req.headers['x-api-key'];
+    if (apiKey) {
+      const keyRow = await lookupApiKey(apiKey, req.ip || req.headers['x-forwarded-for']);
+      if (!keyRow) {
+        return res.status(401).json({ error: 'Invalid API key' });
+      }
+      req.apiKeyAuth = {
+        keyId: keyRow.id,
+        label: keyRow.label,
+        brandIds: keyRow.brand_profile_ids || [],
+        scopes: keyRow.scopes || []
+      };
+      // userId stays unset — handlers check req.apiKeyAuth vs req.userId to distinguish
+      return next();
+    }
+
+    // ── Path 2: Clerk JWT (unchanged) ──
+    const authHeader = req.headers.authorization;
+    const queryToken = req.query?.token;
+    const rawToken = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : queryToken;
+    if (!rawToken) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const token = rawToken;
+    if (!clerkJWKS) return res.status(500).json({ error: 'Auth not configured' });
+    const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
+    req.userId = payload.sub;
+    next();
+  } catch(e) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+// Scope guard for API-key-authenticated requests. If req.apiKeyAuth is set,
+// verify (a) the key has the required scope and (b) the brandProfileId in
+// the request body is in the key's allowed brand list. No-op for JWT auth
+// (JWT auth already goes through verifyBrandAccess downstream).
+export function requireApiKeyScope(scope) {
+  return (req, res, next) => {
+    if (!req.apiKeyAuth) return next();  // JWT path — skip, verifyBrandAccess handles it
+    if (!req.apiKeyAuth.scopes.includes(scope)) {
+      return res.status(403).json({ error: `API key missing required scope: ${scope}` });
+    }
+    const bodyBrandId = req.body?.brandProfileId || req.params?.brandProfileId;
+    if (bodyBrandId && !req.apiKeyAuth.brandIds.includes(bodyBrandId)) {
+      return res.status(403).json({ error: 'API key not authorized for this brand' });
+    }
+    next();
+  };
+}
+
+// Soft auth — attaches userId if present, continues either way (for public + authed routes)
+export async function softAuth(req, res, next) {
+  try {
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.split(' ')[1];
+      if (clerkJWKS) {
+        const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
+        req.userId = payload.sub;
+      }
+    }
+  } catch { /* no-op */ }
+  next();
+}
+
+// MCP server at POST /mcp — JSON-RPC 2.0 transport for MCP clients (Viktor, Slack-Claude,
+// future agentic tooling). Read-only by design. Auth: Forge api_keys (Bearer or X-Api-Key).
+// Scopes: mcp:campaigns:read, mcp:emails:read.
+
+export async function mcpAuth(req, res, next) {
+  try {
+    let key = null;
+    const authHeader = req.headers.authorization || '';
+    if (authHeader.startsWith('Bearer ')) key = authHeader.slice(7).trim();
+    else if (req.headers['x-api-key']) key = String(req.headers['x-api-key']).trim();
+    if (!key) return res.status(401).json({ error: 'Missing Authorization: Bearer <key> or X-Api-Key header' });
+    const keyRow = await lookupApiKey(key, req.ip || req.headers['x-forwarded-for']);
+    if (!keyRow) return res.status(401).json({ error: 'Invalid or revoked API key' });
+    req.apiKeyAuth = {
+      keyId: keyRow.id,
+      label: keyRow.label,
+      brandIds: keyRow.brand_profile_ids || [],
+      scopes: keyRow.scopes || []
+    };
+    next();
+  } catch(e) {
+    console.error('[MCP auth]', e.message);
+    res.status(500).json({ error: 'auth_internal_error' });
+  }
+}

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { hashApiKey, requireApiKeyScope } from '../src/server/auth.js';
+
+describe('hashApiKey', () => {
+  it('sha256-hex hashes its input (known vector for "abc")', () => {
+    expect(hashApiKey('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+  it('is deterministic and 64 hex chars', () => {
+    const h = hashApiKey('fik_live_deadbeef');
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashApiKey('fik_live_deadbeef')).toBe(h);
+  });
+});
+
+describe('requireApiKeyScope', () => {
+  const run = (apiKeyAuth, body = {}) => {
+    const req = { apiKeyAuth, body, params: {} };
+    let status = null;
+    const res = { status(c) { status = c; return this; }, json() { return this; } };
+    let nexted = false;
+    requireApiKeyScope('emails:read')(req, res, () => { nexted = true; });
+    return { status, nexted };
+  };
+
+  it('skips (JWT path) when there is no apiKeyAuth', () => {
+    expect(run(undefined)).toEqual({ status: null, nexted: true });
+  });
+  it('403s when the key lacks the required scope', () => {
+    expect(run({ scopes: ['campaigns:read'], brandIds: [] })).toEqual({ status: 403, nexted: false });
+  });
+  it('403s when the brand is not in the key allowlist', () => {
+    expect(run({ scopes: ['emails:read'], brandIds: ['brand-a'] }, { brandProfileId: 'brand-b' }))
+      .toEqual({ status: 403, nexted: false });
+  });
+  it('passes when both scope and brand are allowed', () => {
+    expect(run({ scopes: ['emails:read'], brandIds: ['brand-a'] }, { brandProfileId: 'brand-a' }))
+      .toEqual({ status: null, nexted: true });
+  });
+});


### PR DESCRIPTION
## What
The first **dependency-heavy** extraction. Moves the auth layer to `src/server/auth.js`:
- **Constants** (auth.js owns + exports): `clerkJWKS`, `CLERK_JWKS_URL`, `SUPER_ADMIN_IDS`
- **Middleware/helpers**: `verifyBrandAccess`, `hashApiKey`, `lookupApiKey`, `requireAuth`, `requireApiKeyScope`, `softAuth`, `mcpAuth`

Pure move, no behavior change. `requireAuth`'s **125 call sites are untouched** (still `app.get('/x', requireAuth, …)`).

## The wiring (why this one needed the gate)
`clerkJWKS` and `SUPER_ADMIN_IDS` are used *both* inside the auth fns and directly in server.js (4 inline `jwtVerify` handlers + ~8 `SUPER_ADMIN_IDS` checks). So `auth.js` owns and exports them; `server.js` re-imports. A missed re-import here is invisible to `node --check` — so:

## Verification (the gate earning its keep)
- **`npm run lint` (no-undef) clean** — proves every moved symbol resolves in both `server.js` and `auth.js`. This is precisely the failure mode the gate was built to catch.
- `node --check` clean (both files); 0 leftover defs; jose import trimmed to `jwtVerify` (dropped `createRemoteJWKSet`); `createHash` kept (still used by a PKCE handler).
- Route inventory unchanged (**213**).
- **`test/auth.test.js`** added; full suite **32 tests green** (hashApiKey known-vector + determinism; requireApiKeyScope scope/brand-allowlist logic).

## Note
Independent of other refactor PRs. Now that the gate is merged, this PR's CI runs `no-undef` too — so the green you see locally is enforced in CI.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_