### PR TITLE
fix(my-website): FAQs in markdown/payload + test payload matches real shape

### DIFF
--- a/server.js
+++ b/server.js
@@ -12501,12 +12501,17 @@ ${canonicalNote}`,
 
           const articleJson = article.article_json || {};
           const sections = articleJson.sections || [];
+          const faqs = Array.isArray(articleJson.faqs) ? articleJson.faqs.filter(f => f?.question && f?.answer) : [];
           const htmlContent = sections.map(s =>
             `${s.heading ? `<h2>${s.heading}</h2>` : ''}<p>${s.body || s.content || ''}</p>`
-          ).join('\n');
+          ).join('\n') + (faqs.length
+            ? `\n<section class="article-faqs">\n<h2>Frequently asked questions</h2>\n${faqs.map(f => `<h3>${f.question}</h3>\n<p>${f.answer}</p>`).join('\n')}\n</section>`
+            : '');
           const markdownContent = sections.map(s =>
             `${s.heading ? `## ${s.heading}\n\n` : ''}${s.body || s.content || ''}`
-          ).join('\n\n');
+          ).join('\n\n') + (faqs.length
+            ? `\n\n## Frequently asked questions\n\n${faqs.map(f => `### ${f.question}\n\n${f.answer}`).join('\n\n')}`
+            : '');
           // Prefer the article's own meta description for excerpt — it's the
           // hand-curated short summary. Falls back to a slice of the first
           // section body only when the description is missing. Without this

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -727,6 +727,17 @@ export default function PublishingQueuePage() {
       if (s.heading) lines.push(`## ${s.heading}`, '');
       if (s.body || s.content) lines.push(s.body || s.content, '');
     }
+    // FAQs — mirror the HTML export's "Frequently asked questions" block so the
+    // Q&A (and its GEO value) travels with the markdown too, not just the HTML.
+    const faqs = Array.isArray(article?.article_json?.faqs)
+      ? article.article_json.faqs.filter((f: any) => f?.question && f?.answer)
+      : [];
+    if (faqs.length) {
+      lines.push('## Frequently asked questions', '');
+      for (const f of faqs) {
+        lines.push(`### ${String(f.question).trim()}`, '', String(f.answer).trim(), '');
+      }
+    }
     return lines.join('\n');
   };
 


### PR DESCRIPTION
## Why
You spotted Q&A missing from Markdown but present in HTML, and the My Website payload not sending Q&A. Investigating turned up a **bigger inconsistency**: the test payload didn't match real publishes, which is what's been confusing receiver builders.

## Fixes
1. **Smart Export markdown** (`buildMarkdown`) — appended FAQs as `## Frequently asked questions` (matches the HTML export which already had them).
2. **My Website webhook** (`channel='website'`) — `htmlContent` + `markdownContent` were sections-only; both now append the FAQ block (html `<section class="article-faqs">`, markdown `## Frequently asked questions`).
3. **My Website test payload** — it sent a *different shape* than real publishes: `<article><h1>title</h1>…</article>` / `# title` (wrapped, title baked in, no FAQs) vs. real publishes which are bare `<h2>`/`##` body fragments with the title only in the `title` field. Rewrote the test payload to mirror the real publish handler exactly (body-only, h2/`##`-first, no embedded title, sample FAQ section) + a NOTE comment to keep them in sync. **This is the root cause of "the receiver doesn't make sense."**

## Verification
`node --check` clean; `tsc --noEmit` exit 0.

## Note
Separately updated the external `MYWEBSITE.md` integration doc (the one used to build receivers) to describe the **real** payload shape: html/markdown are body-only fragments (no wrapper, no embedded title — render `title` yourself), and FAQs ride inside the content. Also flagged the optional structured `faqs[]` payload field.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7