### PR TITLE
feat(my-website): structured faqs[] payload field + doc sync + restore test fix

### DIFF
--- a/server.js
+++ b/server.js
@@ -10510,11 +10510,17 @@ app.post('/api/integrations/website/:brandProfileId/test', requireAuth, async (r
       canonical: `${creds.endpointUrl}/articles/forge-test-publish`,
       publishedAt: new Date().toISOString(),
       meta: { description: 'Forge test publish', ogImage: 'https://forgeintelligence.ai/og-default.png' },
+      // Structured Q&A — always present (empty array on real publishes with no FAQs).
+      faqs: [{ question: 'Where do FAQs come from?', answer: 'When an article has FAQs, Forge sends them here as a structured array AND embeds them inside html/markdown.' }],
+      // NOTE: mirrors the REAL publish shape exactly — body-only fragment, no
+      // <article>/<h1> wrapper (the title is the separate `title` field above),
+      // sections start at <h2>/##, and FAQs ride inside as an article-faqs
+      // section. Keep in sync with the channel === 'website' publish handler.
       ...(creds.format !== 'markdown' && {
-        html: '<article><h1>Forge Test Publish</h1><h2>Quick sanity check</h2><p>This is the first section of the test article. If you can read this rendered on your site, your receiver is parsing the <code>html</code> field correctly.</p></article>'
+        html: '<h2>Quick sanity check</h2><p>This is the article body, sent exactly as a real publish: heading/paragraph blocks with no outer wrapper and no title baked in (the title is the separate "title" field above). If you can read this on your site, your receiver is parsing the <code>html</code> field correctly.</p>\n<section class="article-faqs">\n<h2>Frequently asked questions</h2>\n<h3>Where do FAQs come from?</h3>\n<p>When an article has FAQs, Forge appends them to html and markdown as this section.</p>\n</section>'
       }),
       ...(creds.format !== 'html' && {
-        markdown: '# Forge Test Publish\n\n## Quick sanity check\n\nThis is the first section of the test article. If you can read this rendered on your site, your receiver is parsing the `markdown` field correctly.'
+        markdown: '## Quick sanity check\n\nThis is the article body, sent exactly as a real publish: `##` sections with no `#` title (the title is the separate "title" field). If you can read this on your site, your receiver is parsing the `markdown` field correctly.\n\n## Frequently asked questions\n\n### Where do FAQs come from?\n\nWhen an article has FAQs, Forge appends them to html and markdown as this section.'
       }),
     };
 
@@ -12533,6 +12539,10 @@ ${canonicalNote}`,
               ogImage: article.hero_image_url || articleJson.hero_image_url || null,
               utm: utmParams,
             },
+            // Structured Q&A — always present (empty array if none). The same
+            // FAQs are also embedded in html/markdown above; this field is for
+            // receivers that want to render/store them without parsing markup.
+            faqs: faqs.map(f => ({ question: f.question, answer: f.answer })),
             ...(creds.format !== 'markdown' && { html: htmlContent }),
             ...(creds.format !== 'html' && { markdown: markdownContent }),
           };

--- a/src/docs/my-website.md
+++ b/src/docs/my-website.md
@@ -26,13 +26,13 @@ The token follows the format `forge_pub_<64 hex chars>`. Treat it like any other
 
 ## Payload schema
 
-On a successful publish, Forge sends:
+On a successful publish, Forge POSTs this JSON:
 
 ```json
 {
   "slug": "your-article-slug",
   "title": "Your Article Title",
-  "excerpt": "Short description — the article's meta description.",
+  "excerpt": "The article's meta description (falls back to the first ~200 chars of the body if there's no meta description).",
   "heroImageUrl": "https://cdn.example.com/image.png",
   "canonical": "https://forgeintelligence.ai/articles/your-brand/your-article-slug",
   "publishedAt": "2026-05-22T00:11:23.450Z",
@@ -41,12 +41,31 @@ On a successful publish, Forge sends:
     "ogImage": "https://cdn.example.com/image.png",
     "utm": { "utm_source": "website", "utm_medium": "blog", "utm_campaign": "..." }
   },
-  "html": "<article>...</article>",
-  "markdown": "# ...\n\n## ..."
+  "faqs": [{ "question": "A question?", "answer": "The answer." }],
+  "html": "<h2>First section</h2><p>...</p>\n<section class=\"article-faqs\">...</section>",
+  "markdown": "## First section\n\n...\n\n## Frequently asked questions\n\n### A question?\n\nThe answer."
 }
 ```
 
-`html` and `markdown` are included based on your format setting. Test payloads include `"test": true` so your receiver can drop them without polluting your live articles table.
+`html` and `markdown` are included based on your format setting (`html`, `markdown`, or `both`); `faqs`, `meta`, and the other fields are always present. Test payloads add `"test": true` so your receiver can drop them without polluting your live articles table.
+
+### What `html` / `markdown` actually contain (the part that trips people up)
+
+They are the article **body only** — not a full document, and **not the title**:
+
+- **No outer wrapper.** `html` is a flat sequence of `<h2>heading</h2><p>body</p>` blocks — no `<html>`, `<head>`, or `<article>` wrapper, and no JSON-LD/schema. `markdown` is a sequence of `## heading` + paragraphs. Your template owns the `<head>`, canonical tag, OG/meta, and structured data.
+- **The title is NOT embedded in the body.** No `<h1>` in `html`, no `# ` H1 in `markdown`. The title lives only in the top-level `title` field — render it yourself, then render the body beneath it. (Rendering `html`/`markdown` alone correctly shows no title; that's expected.)
+
+> Forge's in-app **Smart Export** is different on purpose: it produces a *full* copy-paste HTML document (with `<head>`, schema, and an `<h1>`) for pasting into a CMS. The **webhook** sends a body fragment for programmatic receivers. Same article, two delivery shapes.
+
+### FAQs (Q&A)
+
+FAQs arrive **two ways** — use whichever fits your receiver:
+
+1. **Structured `faqs` array** (recommended for programmatic use): `[{ "question", "answer" }]`, always present (empty `[]` when the article has none). Render or store it directly — no parsing needed.
+2. **Embedded in the body**: the same FAQs are also appended inside `html`/`markdown` as a "Frequently asked questions" section, so if you just store the body as-is, the Q&A comes with it.
+   - **html:** `<section class="article-faqs"><h2>Frequently asked questions</h2><h3>Question?</h3><p>Answer.</p>...</section>`
+   - **markdown:** `## Frequently asked questions` followed by `### Question?` / answer per item.
 
 ## Authentication
 
@@ -284,3 +303,5 @@ Click **Disconnect** in the Forge UI. Forge stops sending publishes to your endp
 | Publish log shows "Receiver returned HTTP N" | Your endpoint returned a non-2xx status. The response body (first 300 chars) is in the error message. |
 | Forge publishes succeed but the article doesn't appear on your site | Receiver isn't actually persisting (check DB), or your site's article route isn't reading from the right source. |
 | Article renders but the lead paragraph appears twice | Your template is rendering both `excerpt` and the first body paragraph. Either drop one in the template, or skip the body's first paragraph when `excerpt` is present. |
+| The article title is missing on your site | The title is **not** inside `html`/`markdown` — it's the top-level `title` field. Render it yourself (e.g. as your page `<h1>`) above the body. The body intentionally starts at the first `<h2>` / `##` section. |
+| FAQs / Q&A don't show up | Use the structured `faqs` array, or render the **full** `html`/`markdown` body (FAQs are appended as a "Frequently asked questions" section — `<section class="article-faqs">` in html, `## Frequently asked questions` in markdown — not just the first section). |


### PR DESCRIPTION
## What
Small follow-up to #200, per your go-ahead.

1. **Structured `faqs[]` field** — the My Website webhook payload now includes `faqs: [{ question, answer }]` (always present, empty `[]` when none). Programmatic receivers can render/store Q&A without parsing it out of markup. The same FAQs stay embedded in `html`/`markdown` for receivers that just store the body.

2. **Restores the test-payload fix that #200's merge dropped.** Heads-up: the test-payload commit from #200 didn't land on `features` — the merge took the FAQ-in-content commits but not the test-shape commit, so "Send test payload" still sent the old `<article><h1>` shape (which mismatches real publishes). Re-applied it here, now also carrying the sample `faqs[]` + embedded FAQ section, with a NOTE comment tying it to the publish handler.

3. **Syncs the live docs.** `src/docs/my-website.md` (the `/docs/my-website` source) was left stale by #200 — still showed `"html": "<article>...</article>"` and no FAQ docs. Brought it fully current: real body-only shape, title-is-separate, FAQ delivery (structured array **and** embedded), + two troubleshooting rows.

(Your external `MYWEBSITE.md` is updated to match and re-sent in chat.)

## Verification
`node --check` clean. `faqs` derives from the same filtered set already used for the embedded FAQ rendering.

## Validate
Send a test payload → confirm it now arrives as a body fragment (no `<article>`/title) with a `faqs` array and an embedded FAQ section, matching a real publish.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_