### PR TITLE
refactor(server): extract Zernio client → src/server/zernio.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
 import { truncateStr, truncateAtSentence, stripSocialMarkdown } from './src/server/text.js';
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
+import { callZernio, zernioPublish, getOrCreateZernioProfile, ensureZernioProfile, zernioGuard } from './src/server/zernio.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10786,26 +10787,6 @@ app.post('/api/linkedin/select-target', requireAuth, async (req, res) => {
 // on brand_profiles.zernio_profile_id). Profile groups all of that brand's
 // connected accounts together inside Zernio.
 
-// Helper: ensure the brand has a Zernio profile, creating one if needed.
-async function ensureZernioProfile(brandProfileId) {
-  const r = await pool.query('SELECT zernio_profile_id, brand_name, brand_url FROM brand_profiles WHERE id = $1', [brandProfileId]);
-  if (!r.rows.length) throw new Error('Brand not found');
-  const brand = r.rows[0];
-  if (brand.zernio_profile_id) return brand.zernio_profile_id;
-
-  // Create a new Zernio profile named after the brand
-  const name = brand.brand_name || brand.brand_url || `Forge brand ${brandProfileId.slice(0, 8)}`;
-  const createRes = await callZernio('POST', '/profiles', {
-    name: name.slice(0, 100),
-    description: `Forge Intelligence — ${brand.brand_url || brandProfileId}`
-  });
-  if (!createRes.ok) throw new Error(`Zernio profile create failed (${createRes.status}): ${createRes.raw?.slice(0, 200)}`);
-  const newProfileId = createRes.parsed?.profile?._id;
-  if (!newProfileId) throw new Error('Zernio profile create returned no _id');
-
-  await pool.query('UPDATE brand_profiles SET zernio_profile_id = $1, updated_at = NOW() WHERE id = $2', [newProfileId, brandProfileId]);
-  return newProfileId;
-}
 
 // 1) Kickoff: customer clicks Connect, we get an authUrl from Zernio + redirect.
 app.get('/api/zernio/connect/:platform', async (req, res) => {
@@ -16710,105 +16691,8 @@ app.post('/api/admin/relay', express.json({ limit: '500kb' }), async (req, res) 
 // Once Zernio is validated as the Pipedream replacement, these come out and the
 // real integration ships into the publishing pipeline as a normal vendor.
 
-const zernioGuard = (req, res) => {
-  // Reject on production
-  const host = req.headers.host || '';
-  if (host.includes('forgeintelligence.ai') && !host.startsWith('dev.') && !host.startsWith('strategy.')) {
-    res.status(403).json({ success: false, error: 'Zernio test endpoints are dev/strategy only' });
-    return false;
-  }
-  // Admin password gate
-  if (req.body?.adminPassword !== process.env.ADMIN_RELAY_PASSWORD) {
-    res.status(403).json({ success: false, error: 'Unauthorized' });
-    return false;
-  }
-  // Env var check
-  if (!process.env.ZERNIO_API_KEY) {
-    res.status(500).json({ success: false, error: 'ZERNIO_API_KEY not set on this service' });
-    return false;
-  }
-  return true;
-};
 
-// stripSocialMarkdown — Claude defaults to producing markdown structure
-// (# headings, **bold**) because it's been trained to. Social platforms
-// like Facebook, LinkedIn, X, and Reddit don't render markdown — they
-// show the raw characters. Result: posts that open with a literal '#'
-// and have '**word**' embedded inline.
-//
-// Apply this to any Haiku-generated post copy before sending to a
-// platform that renders plain text. Conservative by design — only
-// strips the two patterns that demonstrably leak (leading H1-H6 and
-// double-asterisk/underscore bold). Single asterisks, backticks, list
-// markers, and link syntax are left intact: they appear naturally in
-// URLs and prose, and stripping them risks corrupting real content.
-//
-// NOT applied to user-supplied postCopy overrides — if a human typed
-// asterisks they wanted them literal.
-const callZernio = async (method, path, body) => {
-  const url = `https://zernio.com/api/v1${path}`;
-  const opts = {
-    method,
-    headers: {
-      'Authorization': `Bearer ${process.env.ZERNIO_API_KEY}`,
-      'Content-Type': 'application/json'
-    }
-  };
-  if (body) opts.body = JSON.stringify(body);
-  const r = await fetch(url, opts);
-  let parsed = null;
-  const raw = await r.text();
-  try { parsed = JSON.parse(raw); } catch { /* keep raw */ }
-  return { status: r.status, ok: r.ok, raw, parsed };
-};
 
-// Production helper for publishing through Zernio's social media API. Used by the
-// /api/publishing/publish handler when a channel's credentials include
-// zernioAccountId. Returns a normalized { status, postId, postUrl, raw } object
-// regardless of which platform was published to.
-//
-// Throws on failure — caller wraps in try/catch and reports to results[channel].
-const zernioPublish = async ({ platform, accountId, content }) => {
-  if (!process.env.ZERNIO_API_KEY) throw new Error('ZERNIO_API_KEY not configured on this service');
-  if (!platform) throw new Error('zernioPublish: platform required');
-  if (!accountId) throw new Error('zernioPublish: accountId required');
-  if (!content) throw new Error('zernioPublish: content required');
-
-  const result = await callZernio('POST', '/posts', {
-    content,
-    publishNow: true,
-    platforms: [{ platform, accountId }]
-  });
-
-  if (!result.ok) {
-    throw new Error(`Zernio ${platform} publish failed (${result.status}): ${result.raw?.slice(0, 300) || 'no response body'}`);
-  }
-
-  const post = result.parsed?.post;
-  const platformResult = (post?.platforms || []).find(p => p.platform === platform);
-  if (!platformResult) {
-    throw new Error(`Zernio response missing platform result for ${platform}: ${result.raw?.slice(0, 300)}`);
-  }
-  if (platformResult.status !== 'published') {
-    const errorMsg = platformResult.error || platformResult.platformSpecificData?.lastError || 'Zernio did not publish (status: ' + platformResult.status + ')';
-    throw new Error(`Zernio ${platform}: ${errorMsg}`);
-  }
-
-  return {
-    status: 'published',
-    // platformPostId is the platform-native ID (LinkedIn URN, X tweetId, etc).
-    // This is what platform-direct APIs use and what appears in user-visible URLs.
-    postId: platformResult.platformPostId,
-    // Zernio's internal _id. REQUIRED for Zernio's /analytics endpoint — it
-    // does NOT accept platformPostId. Saving both means the analytics sync
-    // can use zernioPostId for Zernio lookups while preserving platform ID
-    // for everything else.
-    zernioPostId: post._id,
-    postUrl: platformResult.platformPostUrl,
-    publishedAt: platformResult.publishedAt,
-    raw: post
-  };
-};
 
 // GET-style — list profiles. Lightest possible test: validates key + reachability.
 app.post('/api/admin/zernio/profiles', async (req, res) => {
@@ -16905,37 +16789,6 @@ app.post('/api/admin/zernio/create-profile', async (req, res) => {
 //   2. LinkedIn → Zernio's callback (out of band)
 //   3. GET /integrations/zernio/callback → Zernio bounces back, we save zernioAccountId
 
-const getOrCreateZernioProfile = async (brandProfileId) => {
-  const brandRes = await pool.query(
-    `SELECT id, brand_name, brand_url, zernio_profile_id FROM brand_profiles WHERE id = $1`,
-    [brandProfileId]
-  );
-  if (!brandRes.rows.length) throw new Error('Brand not found');
-  const brand = brandRes.rows[0];
-  if (brand.zernio_profile_id) return brand.zernio_profile_id;
-
-  const slug = (brand.brand_url || brand.brand_name || brand.id)
-    .replace(/^https?:\/\//, '')
-    .replace(/[^a-z0-9]/gi, '-')
-    .toLowerCase()
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 50);
-  const profileName = `forge-${slug}`;
-
-  const createRes = await callZernio('POST', '/profiles', {
-    name: profileName,
-    description: `Forge Intelligence brand: ${brand.brand_name || brand.brand_url || brand.id}`
-  });
-  if (!createRes.ok) throw new Error(`Zernio profile creation failed (${createRes.status}): ${createRes.raw?.slice(0, 200)}`);
-  const profileId = createRes.parsed?.profile?._id;
-  if (!profileId) throw new Error('Zernio create-profile response missing _id');
-
-  await pool.query(
-    `UPDATE brand_profiles SET zernio_profile_id = $1, updated_at = NOW() WHERE id = $2`,
-    [profileId, brandProfileId]
-  );
-  return profileId;
-};
 
 
 // POST /api/admin/zernio/raw — Generic Zernio API probe for admin debugging.

--- a/src/server/zernio.js
+++ b/src/server/zernio.js
@@ -1,0 +1,158 @@
+// Zernio social-publishing client + helpers, extracted from server.js during
+// the decomposition. callZernio is the single HTTP primitive; the rest layer on
+// top (publish, profile create/ensure) plus the dev-only test guard.
+import { pool } from './db.js';
+import { verifyBrandAccess } from './auth.js';
+
+// Helper: ensure the brand has a Zernio profile, creating one if needed.
+export async function ensureZernioProfile(brandProfileId) {
+  const r = await pool.query('SELECT zernio_profile_id, brand_name, brand_url FROM brand_profiles WHERE id = $1', [brandProfileId]);
+  if (!r.rows.length) throw new Error('Brand not found');
+  const brand = r.rows[0];
+  if (brand.zernio_profile_id) return brand.zernio_profile_id;
+
+  // Create a new Zernio profile named after the brand
+  const name = brand.brand_name || brand.brand_url || `Forge brand ${brandProfileId.slice(0, 8)}`;
+  const createRes = await callZernio('POST', '/profiles', {
+    name: name.slice(0, 100),
+    description: `Forge Intelligence — ${brand.brand_url || brandProfileId}`
+  });
+  if (!createRes.ok) throw new Error(`Zernio profile create failed (${createRes.status}): ${createRes.raw?.slice(0, 200)}`);
+  const newProfileId = createRes.parsed?.profile?._id;
+  if (!newProfileId) throw new Error('Zernio profile create returned no _id');
+
+  await pool.query('UPDATE brand_profiles SET zernio_profile_id = $1, updated_at = NOW() WHERE id = $2', [newProfileId, brandProfileId]);
+  return newProfileId;
+}
+
+export const zernioGuard = (req, res) => {
+  // Reject on production
+  const host = req.headers.host || '';
+  if (host.includes('forgeintelligence.ai') && !host.startsWith('dev.') && !host.startsWith('strategy.')) {
+    res.status(403).json({ success: false, error: 'Zernio test endpoints are dev/strategy only' });
+    return false;
+  }
+  // Admin password gate
+  if (req.body?.adminPassword !== process.env.ADMIN_RELAY_PASSWORD) {
+    res.status(403).json({ success: false, error: 'Unauthorized' });
+    return false;
+  }
+  // Env var check
+  if (!process.env.ZERNIO_API_KEY) {
+    res.status(500).json({ success: false, error: 'ZERNIO_API_KEY not set on this service' });
+    return false;
+  }
+  return true;
+};
+
+// stripSocialMarkdown — Claude defaults to producing markdown structure
+// (# headings, **bold**) because it's been trained to. Social platforms
+// like Facebook, LinkedIn, X, and Reddit don't render markdown — they
+// show the raw characters. Result: posts that open with a literal '#'
+// and have '**word**' embedded inline.
+//
+// Apply this to any Haiku-generated post copy before sending to a
+// platform that renders plain text. Conservative by design — only
+// strips the two patterns that demonstrably leak (leading H1-H6 and
+// double-asterisk/underscore bold). Single asterisks, backticks, list
+// markers, and link syntax are left intact: they appear naturally in
+// URLs and prose, and stripping them risks corrupting real content.
+//
+// NOT applied to user-supplied postCopy overrides — if a human typed
+// asterisks they wanted them literal.
+export const callZernio = async (method, path, body) => {
+  const url = `https://zernio.com/api/v1${path}`;
+  const opts = {
+    method,
+    headers: {
+      'Authorization': `Bearer ${process.env.ZERNIO_API_KEY}`,
+      'Content-Type': 'application/json'
+    }
+  };
+  if (body) opts.body = JSON.stringify(body);
+  const r = await fetch(url, opts);
+  let parsed = null;
+  const raw = await r.text();
+  try { parsed = JSON.parse(raw); } catch { /* keep raw */ }
+  return { status: r.status, ok: r.ok, raw, parsed };
+};
+
+// Production helper for publishing through Zernio's social media API. Used by the
+// /api/publishing/publish handler when a channel's credentials include
+// zernioAccountId. Returns a normalized { status, postId, postUrl, raw } object
+// regardless of which platform was published to.
+//
+// Throws on failure — caller wraps in try/catch and reports to results[channel].
+export const zernioPublish = async ({ platform, accountId, content }) => {
+  if (!process.env.ZERNIO_API_KEY) throw new Error('ZERNIO_API_KEY not configured on this service');
+  if (!platform) throw new Error('zernioPublish: platform required');
+  if (!accountId) throw new Error('zernioPublish: accountId required');
+  if (!content) throw new Error('zernioPublish: content required');
+
+  const result = await callZernio('POST', '/posts', {
+    content,
+    publishNow: true,
+    platforms: [{ platform, accountId }]
+  });
+
+  if (!result.ok) {
+    throw new Error(`Zernio ${platform} publish failed (${result.status}): ${result.raw?.slice(0, 300) || 'no response body'}`);
+  }
+
+  const post = result.parsed?.post;
+  const platformResult = (post?.platforms || []).find(p => p.platform === platform);
+  if (!platformResult) {
+    throw new Error(`Zernio response missing platform result for ${platform}: ${result.raw?.slice(0, 300)}`);
+  }
+  if (platformResult.status !== 'published') {
+    const errorMsg = platformResult.error || platformResult.platformSpecificData?.lastError || 'Zernio did not publish (status: ' + platformResult.status + ')';
+    throw new Error(`Zernio ${platform}: ${errorMsg}`);
+  }
+
+  return {
+    status: 'published',
+    // platformPostId is the platform-native ID (LinkedIn URN, X tweetId, etc).
+    // This is what platform-direct APIs use and what appears in user-visible URLs.
+    postId: platformResult.platformPostId,
+    // Zernio's internal _id. REQUIRED for Zernio's /analytics endpoint — it
+    // does NOT accept platformPostId. Saving both means the analytics sync
+    // can use zernioPostId for Zernio lookups while preserving platform ID
+    // for everything else.
+    zernioPostId: post._id,
+    postUrl: platformResult.platformPostUrl,
+    publishedAt: platformResult.publishedAt,
+    raw: post
+  };
+};
+
+export const getOrCreateZernioProfile = async (brandProfileId) => {
+  const brandRes = await pool.query(
+    `SELECT id, brand_name, brand_url, zernio_profile_id FROM brand_profiles WHERE id = $1`,
+    [brandProfileId]
+  );
+  if (!brandRes.rows.length) throw new Error('Brand not found');
+  const brand = brandRes.rows[0];
+  if (brand.zernio_profile_id) return brand.zernio_profile_id;
+
+  const slug = (brand.brand_url || brand.brand_name || brand.id)
+    .replace(/^https?:\/\//, '')
+    .replace(/[^a-z0-9]/gi, '-')
+    .toLowerCase()
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+  const profileName = `forge-${slug}`;
+
+  const createRes = await callZernio('POST', '/profiles', {
+    name: profileName,
+    description: `Forge Intelligence brand: ${brand.brand_name || brand.brand_url || brand.id}`
+  });
+  if (!createRes.ok) throw new Error(`Zernio profile creation failed (${createRes.status}): ${createRes.raw?.slice(0, 200)}`);
+  const profileId = createRes.parsed?.profile?._id;
+  if (!profileId) throw new Error('Zernio create-profile response missing _id');
+
+  await pool.query(
+    `UPDATE brand_profiles SET zernio_profile_id = $1, updated_at = NOW() WHERE id = $2`,
+    [profileId, brandProfileId]
+  );
+  return profileId;
+};

--- a/src/server/zernio.js
+++ b/src/server/zernio.js
@@ -45,21 +45,9 @@ export const zernioGuard = (req, res) => {
   return true;
 };
 
-// stripSocialMarkdown — Claude defaults to producing markdown structure
-// (# headings, **bold**) because it's been trained to. Social platforms
-// like Facebook, LinkedIn, X, and Reddit don't render markdown — they
-// show the raw characters. Result: posts that open with a literal '#'
-// and have '**word**' embedded inline.
-//
-// Apply this to any Haiku-generated post copy before sending to a
-// platform that renders plain text. Conservative by design — only
-// strips the two patterns that demonstrably leak (leading H1-H6 and
-// double-asterisk/underscore bold). Single asterisks, backticks, list
-// markers, and link syntax are left intact: they appear naturally in
-// URLs and prose, and stripping them risks corrupting real content.
-//
-// NOT applied to user-supplied postCopy overrides — if a human typed
-// asterisks they wanted them literal.
+// callZernio — the single Zernio HTTP primitive; every Zernio call routes
+// through here. Auth via the ZERNIO_API_KEY bearer. Returns
+// { status, ok, raw, parsed }, where `parsed` is null if the body isn't JSON.
 export const callZernio = async (method, path, body) => {
   const url = `https://zernio.com/api/v1${path}`;
   const opts = {

--- a/test/zernio.test.js
+++ b/test/zernio.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { zernioGuard } from '../src/server/zernio.js';
+
+// Temporarily set env (restoring afterward) so the guard's process.env reads are controlled.
+function withEnv(env, fn) {
+  const saved = {};
+  for (const k of Object.keys(env)) {
+    saved[k] = process.env[k];
+    if (env[k] === undefined) delete process.env[k]; else process.env[k] = env[k];
+  }
+  try { return fn(); } finally {
+    for (const k of Object.keys(env)) {
+      if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k];
+    }
+  }
+}
+
+const callGuard = (host, body, env) => withEnv(env, () => {
+  let status = null;
+  const res = { status(c) { status = c; return this; }, json() { return this; } };
+  const out = zernioGuard({ headers: { host }, body }, res);
+  return { out, status };
+});
+
+const OK_ENV = { ADMIN_RELAY_PASSWORD: 'secret', ZERNIO_API_KEY: 'zk_live_test' };
+
+describe('zernioGuard', () => {
+  it('rejects on the production host (403)', () => {
+    expect(callGuard('forgeintelligence.ai', { adminPassword: 'secret' }, OK_ENV))
+      .toEqual({ out: false, status: 403 });
+  });
+
+  it('allows the dev host through the host check', () => {
+    expect(callGuard('dev.forgeintelligence.ai', { adminPassword: 'secret' }, OK_ENV))
+      .toEqual({ out: true, status: null });
+  });
+
+  it('rejects a wrong admin password (403)', () => {
+    expect(callGuard('dev.forgeintelligence.ai', { adminPassword: 'nope' }, OK_ENV))
+      .toEqual({ out: false, status: 403 });
+  });
+
+  it('500s when ZERNIO_API_KEY is unset', () => {
+    expect(callGuard('dev.forgeintelligence.ai', { adminPassword: 'secret' }, { ADMIN_RELAY_PASSWORD: 'secret', ZERNIO_API_KEY: undefined }))
+      .toEqual({ out: false, status: 500 });
+  });
+
+  it('passes a non-Forge host with the right password + key', () => {
+    expect(callGuard('localhost:3000', { adminPassword: 'secret' }, OK_ENV))
+      .toEqual({ out: true, status: null });
+  });
+});


### PR DESCRIPTION
## What
Next shared-core extraction. Moves the Zernio social-publishing cluster to `src/server/zernio.js`:
- `callZernio` — the single HTTP primitive (**24 call sites**)
- `zernioPublish`, `getOrCreateZernioProfile`, `ensureZernioProfile`
- `zernioGuard` — dev-only test-endpoint guard

Pure move, no behavior change.

## Layering
`zernio.js` imports `pool` (db.js) and `verifyBrandAccess` (auth.js) — cleanly builds on the already-extracted modules. No cycle: `server.js → zernio.js → auth.js → db.js`. `server.js` re-imports all five.

## Verification
- **`npm run lint` (no-undef) clean** — every call site + the cross-module `verifyBrandAccess`/`pool` imports resolve across `server.js` and `zernio.js`.
- `node --check` clean (both); 0 leftover defs; 5 exports.
- Route inventory unchanged (**213**).
- **`test/zernio.test.js`** added — `zernioGuard` prod-host block, admin-password gate, missing-`ZERNIO_API_KEY` 500, happy path. Full suite **37 green**.

## Scorecard
`db.js` · `llm-json.js` · `utm.js` · `text.js` · `auth.js` · **`zernio.js`** — shared core continues peeling off, each a tested pure move.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_