### PR TITLE
chore: sync main → development (reconcile #206 Zernio fixes into zernio.js)

### DIFF
--- a/server.js
+++ b/server.js
@@ -10914,26 +10914,9 @@ app.post('/api/linkedin/select-target', requireAuth, async (req, res) => {
 // on brand_profiles.zernio_profile_id). Profile groups all of that brand's
 // connected accounts together inside Zernio.
 
-// Helper: ensure the brand has a Zernio profile, creating one if needed.
-async function ensureZernioProfile(brandProfileId) {
-  const r = await pool.query('SELECT zernio_profile_id, brand_name, brand_url FROM brand_profiles WHERE id = $1', [brandProfileId]);
-  if (!r.rows.length) throw new Error('Brand not found');
-  const brand = r.rows[0];
-  if (brand.zernio_profile_id) return brand.zernio_profile_id;
+// Zernio profile create-or-get lives in getOrCreateZernioProfile (below). The
+// former ensureZernioProfile duplicate was consolidated into it.
 
-  // Create a new Zernio profile named after the brand
-  const name = brand.brand_name || brand.brand_url || `Forge brand ${brandProfileId.slice(0, 8)}`;
-  const createRes = await callZernio('POST', '/profiles', {
-    name: name.slice(0, 100),
-    description: `Forge Intelligence — ${brand.brand_url || brandProfileId}`
-  });
-  if (!createRes.ok) throw new Error(`Zernio profile create failed (${createRes.status}): ${createRes.raw?.slice(0, 200)}`);
-  const newProfileId = createRes.parsed?.profile?._id;
-  if (!newProfileId) throw new Error('Zernio profile create returned no _id');
-
-  await pool.query('UPDATE brand_profiles SET zernio_profile_id = $1, updated_at = NOW() WHERE id = $2', [newProfileId, brandProfileId]);
-  return newProfileId;
-}
 
 // 1) Kickoff: customer clicks Connect, we get an authUrl from Zernio + redirect.
 app.get('/api/zernio/connect/:platform', async (req, res) => {
@@ -10947,7 +10930,7 @@ app.get('/api/zernio/connect/:platform', async (req, res) => {
     const brandRes = await pool.query('SELECT id FROM brand_profiles WHERE id = $1', [brandProfileId]);
     if (!brandRes.rows.length) return res.status(404).send('Brand not found');
 
-    const profileId = await ensureZernioProfile(brandProfileId);
+    const profileId = await getOrCreateZernioProfile(brandProfileId);
 
     // Where Zernio sends the user after they finish OAuth. Same host as the kickoff
     // request so dev/prod each return to themselves. Pass brandProfileId + platform
@@ -17040,7 +17023,10 @@ const callZernio = async (method, path, body) => {
     headers: {
       'Authorization': `Bearer ${process.env.ZERNIO_API_KEY}`,
       'Content-Type': 'application/json'
-    }
+    },
+    // Cap every Zernio call so a hung connection can't block the publish /
+    // analytics path indefinitely (all 20+ Zernio calls route through here).
+    signal: AbortSignal.timeout(15000),
   };
   if (body) opts.body = JSON.stringify(body);
   const r = await fetch(url, opts);

--- a/server.js
+++ b/server.js
@@ -10806,26 +10806,9 @@ app.post('/api/linkedin/select-target', requireAuth, async (req, res) => {
 // on brand_profiles.zernio_profile_id). Profile groups all of that brand's
 // connected accounts together inside Zernio.
 
-// Helper: ensure the brand has a Zernio profile, creating one if needed.
-async function ensureZernioProfile(brandProfileId) {
-  const r = await pool.query('SELECT zernio_profile_id, brand_name, brand_url FROM brand_profiles WHERE id = $1', [brandProfileId]);
-  if (!r.rows.length) throw new Error('Brand not found');
-  const brand = r.rows[0];
-  if (brand.zernio_profile_id) return brand.zernio_profile_id;
+// Zernio profile create-or-get lives in getOrCreateZernioProfile (below). The
+// former ensureZernioProfile duplicate was consolidated into it.
 
-  // Create a new Zernio profile named after the brand
-  const name = brand.brand_name || brand.brand_url || `Forge brand ${brandProfileId.slice(0, 8)}`;
-  const createRes = await callZernio('POST', '/profiles', {
-    name: name.slice(0, 100),
-    description: `Forge Intelligence — ${brand.brand_url || brandProfileId}`
-  });
-  if (!createRes.ok) throw new Error(`Zernio profile create failed (${createRes.status}): ${createRes.raw?.slice(0, 200)}`);
-  const newProfileId = createRes.parsed?.profile?._id;
-  if (!newProfileId) throw new Error('Zernio profile create returned no _id');
-
-  await pool.query('UPDATE brand_profiles SET zernio_profile_id = $1, updated_at = NOW() WHERE id = $2', [newProfileId, brandProfileId]);
-  return newProfileId;
-}
 
 // 1) Kickoff: customer clicks Connect, we get an authUrl from Zernio + redirect.
 app.get('/api/zernio/connect/:platform', async (req, res) => {
@@ -10839,7 +10822,7 @@ app.get('/api/zernio/connect/:platform', async (req, res) => {
     const brandRes = await pool.query('SELECT id FROM brand_profiles WHERE id = $1', [brandProfileId]);
     if (!brandRes.rows.length) return res.status(404).send('Brand not found');
 
-    const profileId = await ensureZernioProfile(brandProfileId);
+    const profileId = await getOrCreateZernioProfile(brandProfileId);
 
     // Where Zernio sends the user after they finish OAuth. Same host as the kickoff
     // request so dev/prod each return to themselves. Pass brandProfileId + platform
@@ -16932,7 +16915,10 @@ const callZernio = async (method, path, body) => {
     headers: {
       'Authorization': `Bearer ${process.env.ZERNIO_API_KEY}`,
       'Content-Type': 'application/json'
-    }
+    },
+    // Cap every Zernio call so a hung connection can't block the publish /
+    // analytics path indefinitely (all 20+ Zernio calls route through here).
+    signal: AbortSignal.timeout(15000),
   };
   if (body) opts.body = JSON.stringify(body);
   const r = await fetch(url, opts);

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
 import { truncateStr, truncateAtSentence, stripSocialMarkdown } from './src/server/text.js';
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
-import { callZernio, zernioPublish, getOrCreateZernioProfile, ensureZernioProfile, zernioGuard } from './src/server/zernio.js';
+import { callZernio, zernioPublish, getOrCreateZernioProfile, zernioGuard } from './src/server/zernio.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10800,7 +10800,7 @@ app.get('/api/zernio/connect/:platform', async (req, res) => {
     const brandRes = await pool.query('SELECT id FROM brand_profiles WHERE id = $1', [brandProfileId]);
     if (!brandRes.rows.length) return res.status(404).send('Brand not found');
 
-    const profileId = await ensureZernioProfile(brandProfileId);
+    const profileId = await getOrCreateZernioProfile(brandProfileId);
 
     // Where Zernio sends the user after they finish OAuth. Same host as the kickoff
     // request so dev/prod each return to themselves. Pass brandProfileId + platform

--- a/src/server/zernio.js
+++ b/src/server/zernio.js
@@ -4,27 +4,6 @@
 import { pool } from './db.js';
 import { verifyBrandAccess } from './auth.js';
 
-// Helper: ensure the brand has a Zernio profile, creating one if needed.
-export async function ensureZernioProfile(brandProfileId) {
-  const r = await pool.query('SELECT zernio_profile_id, brand_name, brand_url FROM brand_profiles WHERE id = $1', [brandProfileId]);
-  if (!r.rows.length) throw new Error('Brand not found');
-  const brand = r.rows[0];
-  if (brand.zernio_profile_id) return brand.zernio_profile_id;
-
-  // Create a new Zernio profile named after the brand
-  const name = brand.brand_name || brand.brand_url || `Forge brand ${brandProfileId.slice(0, 8)}`;
-  const createRes = await callZernio('POST', '/profiles', {
-    name: name.slice(0, 100),
-    description: `Forge Intelligence — ${brand.brand_url || brandProfileId}`
-  });
-  if (!createRes.ok) throw new Error(`Zernio profile create failed (${createRes.status}): ${createRes.raw?.slice(0, 200)}`);
-  const newProfileId = createRes.parsed?.profile?._id;
-  if (!newProfileId) throw new Error('Zernio profile create returned no _id');
-
-  await pool.query('UPDATE brand_profiles SET zernio_profile_id = $1, updated_at = NOW() WHERE id = $2', [newProfileId, brandProfileId]);
-  return newProfileId;
-}
-
 export const zernioGuard = (req, res) => {
   // Reject on production
   const host = req.headers.host || '';
@@ -55,7 +34,10 @@ export const callZernio = async (method, path, body) => {
     headers: {
       'Authorization': `Bearer ${process.env.ZERNIO_API_KEY}`,
       'Content-Type': 'application/json'
-    }
+    },
+    // Cap every Zernio call so a hung connection can't block the publish /
+    // analytics path indefinitely (all 20+ Zernio calls route through here).
+    signal: AbortSignal.timeout(15000),
   };
   if (body) opts.body = JSON.stringify(body);
   const r = await fetch(url, opts);


### PR DESCRIPTION
## What
Forward-integrate `main → development`, **with the Zernio conflict hand-resolved**. This is the cross-lane reconciliation I flagged: #206's Zernio hardening landed on `main` in `server.js`, but `development` had already moved those functions into `src/server/zernio.js` (#205). So the merge hit modify/delete conflicts.

## How it was resolved
Kept development's extracted structure (functions stay in `zernio.js`) and re-applied #206's *intent* to `zernio.js`:
- **`callZernio` timeout** — added the 15s `AbortSignal.timeout` in `zernio.js`
- **Dedupe** — removed the `ensureZernioProfile` duplicate from `zernio.js`
- Dropped `ensureZernioProfile` from `server.js`'s `zernio.js` import (the legacy call site auto-merged onto `getOrCreateZernioProfile`)

Also brings the rest of `main` (#207) onto `development`.

## Why a real merge (not a re-apply)
Doing the actual `main → development` merge records that `development` incorporated #206, so future `main → development` syncs won't re-surface the same conflict. Pays the divergence tax once, cleanly.

## Verified on the result
- `node --check` clean (both files); **no-undef gate clean**; **37 tests green**; route inventory **213**
- `ensureZernioProfile` gone everywhere; `callZernio` timeout present in `zernio.js`; both call sites on `getOrCreateZernioProfile`

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_