### PR TITLE
fix(scrape): close SSRF in discoverSubpages sitemap fetches

### DIFF
--- a/server.js
+++ b/server.js
@@ -15231,18 +15231,22 @@ async function discoverSubpages(baseUrl, max = 8, { seedMarkdown = null, seedHtm
 
   // Step 1: sitemap.xml (handles sitemapindex by following the first child)
   try {
-    const sm = await fetch(new URL('/sitemap.xml', baseUrl).href, { signal: AbortSignal.timeout(8000) });
-    if (sm.ok) {
-      let xml = await sm.text();
+    // SSRF-safe: fetch sitemaps through forgeScrape (Bright Data) like every
+    // other external fetch, rather than hitting the URL directly from this
+    // server. baseUrl and the child <loc> are attacker-controllable, so a direct
+    // fetch could reach internal/metadata endpoints. render:'never' = Unlocker
+    // only (sitemaps are static XML — no browser tier needed); it also gets the
+    // sitemap past Cloudflare/WAF on protected sites. Tight 12s budget — if it's
+    // slow we'd rather fall through to link extraction.
+    const sm = await forgeScrape(new URL('/sitemap.xml', baseUrl).href, { render: 'never', caller: 'context-hub-sitemap', timeout: 12000 });
+    if (sm.success && sm.html) {
+      let xml = sm.html;
       let urls = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
       if (/<sitemapindex/i.test(xml) && urls.length) {
-        try {
-          const child = await fetch(urls[0], { signal: AbortSignal.timeout(8000) });
-          if (child.ok) {
-            const cx = await child.text();
-            urls = [...cx.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
-          }
-        } catch { /* child fetch failed — fall through with index URLs */ }
+        const child = await forgeScrape(urls[0], { render: 'never', caller: 'context-hub-sitemap', timeout: 12000 });
+        if (child.success && child.html) {
+          urls = [...child.html.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
+        }
       }
       const ranked = rankBrandPages(urls.filter(sameOrigin).filter(u => u !== baseUrl && u !== `${baseUrl}/`));
       if (ranked.length) return ranked.slice(0, max);


### PR DESCRIPTION
## Why
`discoverSubpages` Step 1 fetched `<baseUrl>/sitemap.xml` — and, for a `<sitemapindex>`, the first child `<loc>` — **directly from the FI server**, bypassing the Stage-1 invariant that all external page fetches go through Bright Data (whose network can't reach FI infra). Both URLs are attacker-controllable:
- `baseUrl` is the brand URL on the `softAuth` `/api/context-hub/analyze` flow (reachable unauthenticated during onboarding).
- the child `<loc>` comes from the *fetched sitemap body* — fully attacker-controlled content.

So a crafted target (`http://169.254.169.254/…`, or a `<sitemapindex>` pointing `<loc>` at an internal service) could make the server fetch internal / cloud-metadata endpoints. Blind-ish SSRF, but real.

## Fix
Route both sitemap fetches through `forgeScrape` with `render: 'never'` (Unlocker only — sitemaps are static XML, no browser tier needed). The fetch now happens inside Bright Data's network → SSRF closed. Bonus: it also gets the sitemap past Cloudflare/WAF on protected sites, where the old direct fetch would 403.

## Quality: unchanged (the important part)
This only changes **how the subpage URL list is fetched** — not how any content is extracted. `getBrandPageContent`'s Jina + forgeScrape (Unlocker → Scraping Browser) content path is **untouched**, so the ruthless Cloudflare-busting gutting is exactly as before. If anything, sitemap *discovery* gets more robust on hostile sites. 12s budget keeps it bounded (falls through to link extraction on timeout).

**Tradeoff (honest):** the sitemap fetch now costs a Bright Data Unlocker credit (was a free direct fetch) and adds a little latency on non-blocking sites.

## Verification
`node --check` + `no-undef` clean.

## Cross-lane note
This touches `discoverSubpages`, which #209 moved into `development`'s `src/server/scrape.js`. After this ships `features → main`, I'll mirror it into `development`'s `scrape.js` so the next sync is conflict-free (same as the Zernio reconciliation).

## Not in this PR (flagged earlier)
The `format:'markdown'` no-fallback gap (#2) and the `scrape_log` 15 KB-sample bloat (#3) — separate, lower priority. Say the word.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_