### PR TITLE
fix(scrape): close discoverSubpages SSRF (dev-side mirror of #210)

### DIFF
--- a/src/server/scrape.js
+++ b/src/server/scrape.js
@@ -335,18 +335,22 @@ export async function discoverSubpages(baseUrl, max = 8, { seedMarkdown = null, 
 
   // Step 1: sitemap.xml (handles sitemapindex by following the first child)
   try {
-    const sm = await fetch(new URL('/sitemap.xml', baseUrl).href, { signal: AbortSignal.timeout(8000) });
-    if (sm.ok) {
-      let xml = await sm.text();
+    // SSRF-safe: fetch sitemaps through forgeScrape (Bright Data) like every
+    // other external fetch, rather than hitting the URL directly from this
+    // server. baseUrl and the child <loc> are attacker-controllable, so a direct
+    // fetch could reach internal/metadata endpoints. render:'never' = Unlocker
+    // only (sitemaps are static XML — no browser tier needed); it also gets the
+    // sitemap past Cloudflare/WAF on protected sites. Tight 12s budget — if it's
+    // slow we'd rather fall through to link extraction.
+    const sm = await forgeScrape(new URL('/sitemap.xml', baseUrl).href, { render: 'never', caller: 'context-hub-sitemap', timeout: 12000 });
+    if (sm.success && sm.html) {
+      let xml = sm.html;
       let urls = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
       if (/<sitemapindex/i.test(xml) && urls.length) {
-        try {
-          const child = await fetch(urls[0], { signal: AbortSignal.timeout(8000) });
-          if (child.ok) {
-            const cx = await child.text();
-            urls = [...cx.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
-          }
-        } catch { /* child fetch failed — fall through with index URLs */ }
+        const child = await forgeScrape(urls[0], { render: 'never', caller: 'context-hub-sitemap', timeout: 12000 });
+        if (child.success && child.html) {
+          urls = [...child.html.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1].trim());
+        }
       }
       const ranked = rankBrandPages(urls.filter(sameOrigin).filter(u => u !== baseUrl && u !== `${baseUrl}/`));
       if (ranked.length) return ranked.slice(0, max);


### PR DESCRIPTION
## What
Dev-side mirror of the SSRF fix. #210 applied it to `server.js` on `features` → `main`; this applies the identical fix to the extracted `src/server/scrape.js` on the refactor lane, so `development` carries the same hardening.

`discoverSubpages` Step 1 fetched the sitemap (and the first child `<loc>` of a `<sitemapindex>`) **directly from this server** — both URLs attacker-controllable (brand URL on the softAuth analyze flow; child `<loc>` from fetched content) → blind SSRF to internal/metadata endpoints. Now routed through `forgeScrape` with `render:'never'` (Unlocker only — static XML, no browser tier), which fetches via Bright Data's network (SSRF-safe) and also gets sitemaps past Cloudflare.

Content-extraction quality unchanged — only the sitemap **list** fetch moved (`forgeScrape` is same-module here).

## Verification
`node --check` + **no-undef gate clean**, **41 tests green**, route inventory **213**.

## Why a separate dev PR (not a sync)
#210 isn't on `main` yet (you're still promoting it), so a `main → development` merge wouldn't carry it. This protects `development` now. When #210 reaches `main` and the next `main → development` sync runs, both sides will already have the fix — a trivial resolve.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_