### PR TITLE
refactor(server): extract LLM client → src/server/llm.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ import { truncateStr, truncateAtSentence, stripSocialMarkdown } from './src/serv
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
 import { callZernio, zernioPublish, getOrCreateZernioProfile, zernioGuard } from './src/server/zernio.js';
 import { forgeScrape, getBrandPageContent, discoverSubpages, _forgeScrapeRateLimited, FORGE_SCRAPE_RATE_PER_MIN } from './src/server/scrape.js';
+import { anthropic, dateContext } from './src/server/llm.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -89,7 +90,9 @@ const PORT = process.env.PORT || 3000;
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
 
 
-const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, timeout: 1200000 }); // 20min
+// anthropic client + dateContext now live in src/server/llm.js (imported above).
+// The bare `Anthropic` class import is kept for the few handlers that spin up a
+// short-timeout client of their own.
 
 async function initDB() {
   // ── Idempotency check: skip the destructive id-column migration if it's already done ──
@@ -5291,19 +5294,7 @@ function stripScaffoldingArtifacts(article) {
 // Without it the model defaults to its training-data prior (heavily 2024-2025)
 // and will write 'in 2025' / '2024 trends' even when it's actually 2026.
 // Returns a multi-line string to splice into prompts: "TODAY IS Saturday, April 25, 2026..."
-function dateContext() {
-  const now = new Date();
-  const formatted = now.toLocaleDateString('en-US', {
-    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
-    timeZone: 'America/Los_Angeles'
-  });
-  const isoDate = now.toISOString().slice(0, 10);
-  const year = now.getFullYear();
-  return `TODAY IS ${formatted} (ISO: ${isoDate}). The current year is ${year}. ` +
-    `When you reference dates, time periods, or 'recent' events, anchor them to this date — ` +
-    `do not assume an earlier year. If you write phrases like 'in ${year - 1}' or 'this year', ` +
-    `they must be accurate against ${year}, not your training cutoff.`;
-}
+// dateContext moved to src/server/llm.js
 
 app.get('/api/geo-strategist/briefs', requireAuth, async (req, res) => {
   try {

--- a/src/server/llm.js
+++ b/src/server/llm.js
@@ -1,0 +1,21 @@
+// LLM client + prompt helpers, extracted from server.js during the decomposition.
+// `anthropic` is the shared Claude client (20-minute timeout for long-form
+// generations). dateContext anchors prompts to "today" so models don't drift to
+// their training-cutoff year.
+import Anthropic from '@anthropic-ai/sdk';
+
+export const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, timeout: 1200000 }); // 20min
+
+export function dateContext() {
+  const now = new Date();
+  const formatted = now.toLocaleDateString('en-US', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    timeZone: 'America/Los_Angeles'
+  });
+  const isoDate = now.toISOString().slice(0, 10);
+  const year = now.getFullYear();
+  return `TODAY IS ${formatted} (ISO: ${isoDate}). The current year is ${year}. ` +
+    `When you reference dates, time periods, or 'recent' events, anchor them to this date — ` +
+    `do not assume an earlier year. If you write phrases like 'in ${year - 1}' or 'this year', ` +
+    `they must be accurate against ${year}, not your training cutoff.`;
+}


### PR DESCRIPTION
## Why
Continues the `server.js` dismemberment. Isolates the shared LLM client + prompt-date helper so the generation surface stops anchoring on the monolith.

## What
- **New `src/server/llm.js`** exports:
  - `anthropic` — the shared Claude client (`new Anthropic`, 20-minute timeout), moved verbatim.
  - `dateContext()` — the prompt "today" anchor, moved verbatim.
- `server.js` now imports `{ anthropic, dateContext }` from it; the module-level singleton + the function body are replaced with breadcrumb comments.
- **KEPT** the bare `import Anthropic from '@anthropic-ai/sdk'`. Four handlers still construct their own short-timeout `new Anthropic(...)` client locally (lines 6908, 7201, 17329, 17503) — untouched, the class import stays for them.

Pure move, zero behavior change. `anthropic` singleton was used 52×, `dateContext` 5×.

## Test plan
- `node --check server.js` → OK
- `npm run lint` (no-undef gate) → clean
- route-inventory guard → **213 routes PASS**
- `vitest` → **41/41 pass**

## Rollback
Revert this commit — the singleton + `dateContext` were a pure copy, so reverting restores the inline definitions exactly.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_