### PR TITLE
fix(lovable): drop empty whitespace/third-party sections from directive prompt

### DIFF
--- a/server.js
+++ b/server.js
@@ -19677,12 +19677,12 @@ function lovableBuildWithDirective(ctx, buildIntent) {
   if (fgWhatWeDoNot) biLines.push(`What it does NOT do (strategic moats — do not contradict): ${fgWhatWeDoNot}`);
   biLines.push(`Voice profile:\n${voiceBlock}`);
   biLines.push(`Target personas:\n${personasBlock}`);
-  if (whitespaceBlock && whitespaceBlock !== 'No data available') biLines.push(`Competitive whitespace:\n${whitespaceBlock}`);
+  if (lovableHasData(whitespace)) biLines.push(`Competitive whitespace:\n${whitespaceBlock}`);
   if (fgCompetitors) biLines.push(`Competitors: ${fgCompetitors}`);
   if (fgFoundingStory) biLines.push(`Founding story: ${fgFoundingStory}`);
   if (fgQuotablePositions) biLines.push(`Brand positions: ${fgQuotablePositions}`);
   if (fgNamedAuthors) biLines.push(`Attributed authors: ${fgNamedAuthors}`);
-  if (thirdPartyBlock && thirdPartyBlock !== 'No data available') biLines.push(`Third-party voice themes:\n${thirdPartyBlock}`);
+  if (lovableHasData(thirdParty)) biLines.push(`Third-party voice themes:\n${thirdPartyBlock}`);
   const brandIntelligence = biLines.join('\n\n');
 
   return `You are building ${productLabel} for ${brandName}.


### PR DESCRIPTION
## The bug
`lovableBuildWithDirective` (the directive-led Lovable prompt builder, used for Quick Start brains) guards its two optional sections like this:

```js
if (whitespaceBlock && whitespaceBlock !== 'No data available') biLines.push(...);
if (thirdPartyBlock && thirdPartyBlock !== 'No data available') biLines.push(...);
```

But `lovableSection()`'s actual empty-state fallback string is **`"No competitive whitespace data available yet. Design this section to be populated later."`** — it is never the literal `'No data available'`. So both guards are **always true**.

**Effect:** when a brand has no competitive-whitespace or third-party-voice data, the directive prompt injects the placeholder scaffolding text *"Design this section to be populated later"* straight into the `## BRAND INTELLIGENCE` block. Lovable reads design instructions as if they were brand intelligence — quietly degrading every directive-built prompt for data-thin brands.

## The fix
Gate each optional section on the **raw source** via `lovableHasData()` (`whitespace` / `thirdParty` are the formatter outputs — `null` when empty, a non-empty string otherwise). Empty sections are now omitted entirely, matching the function's own stated intent (*"only emit fields that actually have content"*).

- Scope: `lovableBuildWithDirective` **only**.
- The `lovableBuildContentCommandCenter` builder is untouched — it uses those placeholders by design (fixed-structure prompt).
- No API / route / schema change.

## Test plan
- `node --check server.js` → OK
- Trace: empty whitespace/thirdParty → lines dropped; populated → lines emitted verbatim as before.

## Rollback
Revert — single-function logic change.

## Note
This is the production-lane (`features`) patch on the **inline** `server.js` code. The same fix will be mirrored to `development`, where this code now lives in `src/server/lovable.js` (PR #215).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_