### PR TITLE
fix(logging): guard captureLog stringify against throwing args

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,14 @@ const logSSEClients = new Set();
 const errorAggregates = [];
 
 function captureLog(level, args) {
-  const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
+  // Stringify non-string args defensively: JSON.stringify throws on circular
+  // structures (and BigInt), and captureLog runs INSIDE the patched console.*,
+  // so an unguarded throw would propagate to whoever called console.log. Fall
+  // back to String(a) (then a literal marker) rather than break the caller.
+  const msg = args.map(a => {
+    if (typeof a === 'string') return a;
+    try { return JSON.stringify(a); } catch { try { return String(a); } catch { return '[unserializable]'; } }
+  }).join(' ');
   const entry = {
     ts: new Date().toISOString(),
     level,


### PR DESCRIPTION
## The footgun
`captureLog` mirrors every `console.*` call into the live-log ring buffer and stringified non-string args with no guard:

```js
const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
```

`JSON.stringify` throws on **circular structures** (`TypeError: Converting circular structure to JSON`) and on **BigInt**. Because `captureLog` runs *inside* the patched `console.log/error/warn`, that throw propagates to whatever code called `console.log` — turning a log line into a crash.

No current call site logs a circular object, so this has never fired in prod. But it's a sharp edge sitting in the single hottest path in the app (every log line), and a future `console.log(someObjectWithBackRefs)` would trip it.

## The fix
Guard the stringify: try `JSON.stringify`, fall back to `String(a)`, then to a literal `'[unserializable]'` marker.

```js
const msg = args.map(a => {
  if (typeof a === 'string') return a;
  try { return JSON.stringify(a); } catch { try { return String(a); } catch { return '[unserializable]'; } }
}).join(' ');
```

Pure hardening — identical output for all serializable args, so no behavior change for any existing call site.

## Test plan
- `node --check server.js` → OK
- Trace: `console.log(circularObj)` now logs `[unserializable]` / `String(a)` instead of throwing into the caller.

## Rollback
Revert — one expression.

## Note
Production-lane (`features`) patch on the **inline** `captureLog`. Same fix will be mirrored to `development`, where this lives in `src/server/logging.js` (PR #214, already merged).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_