### PR TITLE
fix(logging): guard captureLog stringify against throwing args (dev mirror)

### DIFF
--- a/src/server/logging.js
+++ b/src/server/logging.js
@@ -15,7 +15,14 @@ export const logSSEClients = new Set();
 export const errorAggregates = [];
 
 function captureLog(level, args) {
-  const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
+  // Stringify non-string args defensively: JSON.stringify throws on circular
+  // structures (and BigInt), and captureLog runs INSIDE the patched console.*,
+  // so an unguarded throw would propagate to whoever called console.log. Fall
+  // back to String(a) (then a literal marker) rather than break the caller.
+  const msg = args.map(a => {
+    if (typeof a === 'string') return a;
+    try { return JSON.stringify(a); } catch { try { return String(a); } catch { return '[unserializable]'; } }
+  }).join(' ');
   const entry = {
     ts: new Date().toISOString(),
     level,

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -45,6 +45,15 @@ describe('logging ring buffer', () => {
     expect(hits.length).toBe(1);
   });
 
+  it('does not throw when logging a circular object', () => {
+    const circular = { name: 'loop' };
+    circular.self = circular;
+    // Must not propagate JSON.stringify's "circular structure" TypeError to the
+    // caller — captureLog runs inside the patched console.log.
+    expect(() => console.log('circ-marker', circular)).not.toThrow();
+    expect(logBuffer.some(e => e.msg.includes('circ-marker'))).toBe(true);
+  });
+
   it('exposes logSSEClients as a Set', () => {
     expect(logSSEClients).toBeInstanceOf(Set);
   });


### PR DESCRIPTION
## What
Dev-side mirror of the `features` logging hardening (#217). On `development` this code lives in `src/server/logging.js` (extracted in #214, already merged), so this patches the module instead of the inline `server.js`.

## The footgun (same as #217)
`captureLog` stringified non-string args with `JSON.stringify(a)` and no guard. `JSON.stringify` throws on circular structures and BigInt; because `captureLog` runs *inside* the patched `console.log/error/warn`, that throw propagates to the caller — a log line becomes a crash. Never fired in prod (nothing logs circular objects today), but it's the hottest path in the app.

## The fix
Try `JSON.stringify` → fall back to `String(a)` → fall back to `'[unserializable]'`. Identical output for all serializable args, so no behavior change for existing call sites.

## Test plan
- `node --check server.js` → OK
- `npm run lint` → clean
- `vitest` → **47/47 pass**, including a new regression test: logging a circular object no longer throws and still records the buffer entry.

## Rollback
Revert — one expression.

Pairs with #217 (features). Forward-integrates cleanly.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_