### PR TITLE
fix(lovable): drop empty whitespace/third-party sections from directive prompt (dev mirror)

### DIFF
--- a/src/server/lovable.js
+++ b/src/server/lovable.js
@@ -273,12 +273,12 @@ export function lovableBuildWithDirective(ctx, buildIntent) {
   if (fgWhatWeDoNot) biLines.push(`What it does NOT do (strategic moats — do not contradict): ${fgWhatWeDoNot}`);
   biLines.push(`Voice profile:\n${voiceBlock}`);
   biLines.push(`Target personas:\n${personasBlock}`);
-  if (whitespaceBlock && whitespaceBlock !== 'No data available') biLines.push(`Competitive whitespace:\n${whitespaceBlock}`);
+  if (lovableHasData(whitespace)) biLines.push(`Competitive whitespace:\n${whitespaceBlock}`);
   if (fgCompetitors) biLines.push(`Competitors: ${fgCompetitors}`);
   if (fgFoundingStory) biLines.push(`Founding story: ${fgFoundingStory}`);
   if (fgQuotablePositions) biLines.push(`Brand positions: ${fgQuotablePositions}`);
   if (fgNamedAuthors) biLines.push(`Attributed authors: ${fgNamedAuthors}`);
-  if (thirdPartyBlock && thirdPartyBlock !== 'No data available') biLines.push(`Third-party voice themes:\n${thirdPartyBlock}`);
+  if (lovableHasData(thirdParty)) biLines.push(`Third-party voice themes:\n${thirdPartyBlock}`);
   const brandIntelligence = biLines.join('\n\n');
 
   return `You are building ${productLabel} for ${brandName}.

--- a/test/lovable.test.js
+++ b/test/lovable.test.js
@@ -72,6 +72,28 @@ describe('lovable helpers', () => {
     expect(directive).toContain('waitlist');
   });
 
+  it('directive omits empty whitespace/third-party sections (no placeholder leak)', () => {
+    // whitespace/thirdParty are formatter outputs: null when the brand has no
+    // data. The directive prompt must drop those sections entirely, not inject
+    // the "Design this section to be populated later" scaffolding placeholder.
+    const directive = lovableBuildWithDirective(
+      { brandName: 'Acme', brandColors: '#000', brandProfileId: 'abc', whitespace: null, thirdParty: null },
+      { description: 'a landing page', productType: 'landing-page' },
+    );
+    expect(directive).not.toContain('Competitive whitespace:');
+    expect(directive).not.toContain('Third-party voice themes:');
+
+    // Populated sections still render.
+    const withData = lovableBuildWithDirective(
+      { brandName: 'Acme', brandColors: '#000', brandProfileId: 'abc',
+        whitespace: '- unclaimed topic X', thirdParty: '- [G2] review: loved it' },
+      { description: 'a landing page', productType: 'landing-page' },
+    );
+    expect(withData).toContain('Competitive whitespace:');
+    expect(withData).toContain('unclaimed topic X');
+    expect(withData).toContain('Third-party voice themes:');
+  });
+
   it('stub + naming helpers map app types', () => {
     expect(lovableStubPrompt('geo-monitor', 'Acme', 'abc')).toContain('not yet shipped');
     expect(lovableRecommendedAppName('campaign-planner', 'Acme')).toBe('Acme Campaign Planner');


### PR DESCRIPTION
## What
Dev-side mirror of the Lovable directive fix (#216, `features`). On `development` this code lives in `src/server/lovable.js` (extracted in #215, **now merged**), so this patches the module.

> **Status:** #215 has merged and this PR is now retargeted to `development` — base is clean, diff is just the fix (+24/−2: module + regression test). Ready to merge.

## The bug (same as #216)
`lovableBuildWithDirective` guarded its optional sections with `block !== 'No data available'`, but `lovableSection()`'s real empty-state fallback is `"No <label> data available yet. Design this section to be populated later."` — the strings never match, so the guard was always true. Brands with no whitespace / third-party data got placeholder scaffolding injected into the `## BRAND INTELLIGENCE` block, which Lovable read as brand intel.

## The fix
Gate each optional section on the raw source via `lovableHasData()` (`whitespace` / `thirdParty` are formatter outputs — `null` when empty). Empty sections are omitted, matching the function's stated intent. The content-command-center builder is untouched (its placeholders are by design).

## Test plan
- `node --check server.js` → OK
- `npm run lint` → clean
- `vitest` → **56/56 pass**, +1 regression test: empty whitespace/third-party sections are omitted; populated ones still render.

## Rollback
Revert — one-function logic change.

Pairs with #216 (features). Completes "both patches in dev" alongside #218 (logging).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7