### PR TITLE
docs: record server.js decomposition Stage 2 + two bug fixes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,147 @@
+## 2026-06-05 — server.js decomposition (Stage 2): the dismemberment + two latent bug fixes
+
+The "doctor work." `server.js` had grown to ~19.8K lines and 214 routes — a
+single module holding the entire backend. This arc began breaking it into
+`src/server/*.js` modules, one cohesive unit at a time, with a hard rule:
+**every cut is a pure move with zero behavior change.** No logic edits ride
+along with a move; bug fixes go in their own separate, clearly-scoped PRs.
+
+### The safety net came first (and earned its keep)
+
+There is no integration test suite. The #1 risk of pulling code out of a
+monolith is a **missed re-import** — a function moves to a module, the old
+inline definition is deleted, and a caller that still references the bare
+name now throws `ReferenceError`... but only at runtime, on the code path
+that calls it, which means it sails through `node --check` and only crashes
+on deploy. So before moving a single line, we stood up a CI safety net:
+
+1. **ESLint flat config, `no-undef` only.** This is the belt. Every missed
+   re-import surfaces as a lint error at PR time instead of a 2am prod crash.
+   `document`/`window` are whitelisted because Puppeteer `page.evaluate()`
+   callbacks reference browser globals that ESLint can't see are
+   browser-scoped. Across the earlier cuts this gate caught **3 separate
+   real missed-symbol cases** (auth's `clerkJWKS`/`SUPER_ADMIN_IDS`, and
+   scrape's `SPA_SHELL_RE`/`_forgeScrapeHits`/`FORGE_SCRAPE_RATE_PER_MIN`).
+2. **Route-inventory guard.** A static scan (`test/route-inventory.mjs`) of
+   every `app`/`router.METHOD(...)` registration, producing a sorted
+   `"METHOD /path"` set compared against `test/routes.snapshot.json` (213
+   routes). A pure move must never add, drop, or rename a route — if the set
+   shifts, the test fails. This catches the failure mode lint can't:
+   accidentally dropping or duplicating a handler during a move.
+3. **vitest** per-module unit tests, added with each extraction (~56 tests
+   by end of this session).
+4. CI job "Typecheck & Test" runs `node --check → lint → typecheck → vitest`
+   on PRs to `[main, development, features]`.
+
+**Caveat logged:** `features`/`main` CI currently runs only `node --check` +
+`typecheck`. The full lint/vitest/route-guard gate is `development`-only so
+far — promote it to `features` so the production lane gets the same belt.
+
+### This session's cuts
+
+- **`llm.js` (#213)** — the shared `anthropic` Claude client (20-minute
+  timeout, used 52×) + `dateContext()` prompt-date helper (used 5×). The
+  bare `import Anthropic from '@anthropic-ai/sdk'` was deliberately KEPT in
+  `server.js`: 4 handlers construct their own short-timeout
+  `new Anthropic(...)` clients locally, so they still need the class.
+- **`logging.js` (#214)** — the live-log ring buffer, error aggregation, and
+  console capture. Exports `logBuffer` / `logSSEClients` / `errorAggregates`
+  as stable references (mutated in place, never reassigned, so the log-admin
+  routes observe the same live containers) + `installLogCapture()`, which
+  patches `console.{log,error,warn}` and is idempotent (a guard against
+  double-wrapping — the only intentional deviation from verbatim).
+  `captureLog` / `LOG_BUFFER_SIZE` stay module-private.
+- **`lovable.js` (#215)** — the entire Lovable prompt-pack integration
+  (Brand Intelligence Profile → deterministic URL-encoded Build-with-URL
+  prompt). ~324 lines, 17 helpers + 4 consts. The cleanest leaf yet: pure
+  templating, **zero external symbol references** (no `pool`, no `anthropic`,
+  no `fetch`). Internal-only helpers (`lovableTruncate`, `lovableSection`,
+  `lovableProductTypeLabel`) kept unexported.
+
+This brings the module count to **10**: `db`, `llm-json`, `utm`, `text`,
+`auth`, `zernio`, `scrape`, `llm`, `logging`, `lovable`.
+
+### Two latent bugs found during review — fixed on BOTH lanes
+
+Brian's standing "anything stupid in there?" review on each extracted module
+paid off twice this session. Both bugs predated the refactor (moved
+verbatim), so the fixes were split into their own PRs — never folded into a
+pure-move extraction.
+
+**1. Lovable directive prompt leaked scaffolding as brand intel.**
+`lovableBuildWithDirective` gated its two optional sections like:
+```js
+if (whitespaceBlock && whitespaceBlock !== 'No data available') biLines.push(...);
+if (thirdPartyBlock && thirdPartyBlock !== 'No data available') biLines.push(...);
+```
+But `lovableSection()`'s real empty-state fallback is *"No competitive
+whitespace data available yet. Design this section to be populated later."*
+— it is **never** the literal `'No data available'`. So both guards were
+always true. When a brand had no competitive-whitespace or third-party-voice
+data, the directive prompt injected the placeholder scaffolding text into the
+`## BRAND INTELLIGENCE` block, and Lovable read "Design this section to be
+populated later" as if it were brand intelligence. Quietly degraded every
+directive-built prompt for data-thin brands. **Fix:** gate each section on
+the raw source via `lovableHasData()` (`whitespace`/`thirdParty` are the
+formatter outputs — `null` when empty), so empty sections drop entirely,
+matching the function's own stated intent. The content-command-center
+builder was left untouched — its placeholders are by design.
+(#216 → `features`, #219 → `development`.)
+
+**2. `captureLog` could crash the caller via unguarded `JSON.stringify`.**
+`captureLog` mirrors every `console.*` call into the ring buffer and
+stringified non-string args with no guard. `JSON.stringify` throws on
+circular structures and BigInt — and because `captureLog` runs *inside* the
+patched `console.log/error/warn`, that throw would propagate to whatever code
+called `console.log`, turning a log line into a crash. No current call site
+logs a circular object, so it never fired — but it's a sharp edge in the
+single hottest path in the app. **Fix:** try `JSON.stringify` → fall back to
+`String(a)` → fall back to `'[unserializable]'`. Identical output for all
+serializable args. (#217 → `features`, #218 → `development`.)
+
+### Recurring patterns logged
+
+- **Build the verification harness before the risky change, not after.** The
+  `no-undef` gate caught 3 missed re-imports that would each have been a
+  deploy-time crash. A refactor with no test suite is only as safe as the
+  cheap static checks you put in front of it.
+- **Pure move ≠ pure code.** Moving a module verbatim is the moment you read
+  it most carefully — which is exactly when latent bugs surface. Keep the
+  move pure (so the diff is reviewable and revertable) and spin the fixes
+  into their own scoped PRs. Never mix a behavior change into an extraction.
+- **A string-equality guard against a fallback you don't control is a
+  time bomb.** The Lovable bug was a guard checking `!== 'No data available'`
+  against a fallback string that had since been reworded. Gate on the
+  *source* state (`lovableHasData(...)`), not on a magic rendered string.
+- **Stacked PRs need a manual base flip.** #219 was opened against the #215
+  branch (so its diff showed only the fix). GitHub did NOT auto-retarget it
+  to `development` on #215's merge (the branch wasn't deleted) — had to flip
+  the base manually via `update_pull_request`. Don't assume auto-retarget.
+
+### Net state
+
+All five PRs merged. `features` merged through to production (`main`) — both
+bug fixes are live in prod. `development` holds the full refactor (10
+modules) + both fixes, ready for the `development → main` rollup.
+
+**Endpoint count:** 213 routes (snapshot-locked in `test/routes.snapshot.json`).
+**Modules extracted:** 10. **server.js:** still the bulk of the backend, but
+~1,000+ lines lighter and shedding cohesive units cleanly.
+
+#### What's next
+
+- More clean leaves before route-group surgery: X OAuth/crypto cluster
+  (`buildXOAuthHeader`, `refreshXOAuth2Token`, `buildGhostJWT`,
+  `uploadXMedia`), then image helpers (`generateHeroImage`,
+  `buildImagePrompt`, `generateSocialImage`, `buildSocialImagePrompt`).
+- **Route GROUPS** — the big line-count win, and the first non-leaf step.
+  Requires teaching the route-inventory guard mount-prefix resolution
+  (`app.use('/prefix', router)`) BEFORE moving handlers behind a router, so
+  the guard still verifies full paths. Guard change first, then the move.
+- Promote the full CI gate (lint + vitest + route guard) to `features`/`main`.
+
+---
+
 ## 2026-05-13 (late PT) — Social Generator regenerate-arcs + X v2 media upload fix
 
 Two unrelated items shipped in one long session. Both are worth logging

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,6 +10,41 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-05 — server.js decomposition (Stage 2) begins + two latent bug fixes
+
+The monolith dismemberment is underway. `server.js` (~19.8K lines, 214 routes) is being broken into `src/server/*.js` modules, one cohesive unit at a time. **Every cut is a pure move with zero behavior change**, verified by a CI safety net built *before* the refactor started.
+
+**Modules extracted to date (10):** `db`, `llm-json`, `utm`, `text`, `auth`, `zernio`, `scrape`, `llm`, `logging`, `lovable`. All on `development`.
+
+This session's cuts:
+- **`llm.js`** (#213) — `anthropic` client (20-min timeout, used 52×) + `dateContext()`. Kept the bare `Anthropic` class import for 4 handlers that build their own short-timeout client.
+- **`logging.js`** (#214) — live-log ring buffer + console capture + error aggregation. Exports `logBuffer`/`logSSEClients`/`errorAggregates` + `installLogCapture()` (idempotent); `captureLog`/`LOG_BUFFER_SIZE` private.
+- **`lovable.js`** (#215) — the whole Lovable prompt-pack integration (~324 lines, 17 helpers + 4 consts). Fully self-contained leaf: pure templating, zero external deps.
+
+**Two latent bugs found during review, fixed on BOTH lanes:**
+- **Lovable directive placeholder leak.** `lovableBuildWithDirective` guarded optional sections with `block !== 'No data available'` — a string that never matches `lovableSection()`'s real fallback, so the guard was always true. Brands with no whitespace/third-party data got scaffolding text ("Design this section to be populated later") injected into the `## BRAND INTELLIGENCE` block, which Lovable read as brand intel. Fixed: gate on the raw source via `lovableHasData()`. (#216 features, #219 development)
+- **`captureLog` unguarded stringify.** Ran `JSON.stringify` on console args with no try/catch; a circular object or BigInt would throw *inside* the patched `console.log` and crash the caller. Never fired in prod, but it's the hottest path in the app. Fixed: try `JSON.stringify` → `String(a)` → `'[unserializable]'`. (#217 features, #218 development)
+
+All five PRs merged. **`features` merged to production (`main`)** — both bug fixes are live. `development` holds the full refactor + both fixes, ready for the `development → main` rollup.
+
+#### CI safety net (built before the refactor)
+- **`npm run lint`** — ESLint flat config, `no-undef` only. Catches a missed re-import (the #1 risk of moving code out of a monolith — otherwise only crashes on deploy). `document`/`window` whitelisted for Puppeteer page-eval callbacks.
+- **route-inventory guard** — static scan of `app`/`router.METHOD` registrations → sorted `"METHOD /path"` set vs `test/routes.snapshot.json` (213 routes). A pure move must not add/drop/rename a route.
+- **vitest** — per-module unit tests added with each extraction (~56 tests now).
+- CI job "Typecheck & Test" on PRs to `[main, development, features]`: `node --check` → lint → typecheck → vitest.
+- **NOTE:** `features`/`main` CI currently runs only `node --check` + `typecheck` — the lint/vitest/route-guard gate is `development`-only so far. Promote the full gate to `features` when convenient.
+
+#### Extraction pattern
+Pure move: module imports its own deps (`pool` from `db.js`, etc.), `server.js` re-imports the public surface, internal-only helpers stay unexported. Verify `node --check` + lint + route guard + vitest before commit. The `no-undef` gate is the safety belt — it has caught 3 missed-symbol cases across earlier cuts.
+
+#### What's next
+- **More clean leaves** before route-group surgery: X OAuth/crypto cluster (`buildXOAuthHeader`, `refreshXOAuth2Token`, `buildGhostJWT`, `uploadXMedia`), then image helpers (`generateHeroImage`, `buildImagePrompt`, `generateSocialImage`, `buildSocialImagePrompt`).
+- **Route GROUPS** — the big line-count win. Requires teaching the route-inventory guard mount-prefix resolution (`app.use('/prefix', router)`) *before* moving handlers behind a router, so full paths still verify. Guard change first, then the move.
+- **Promote the full CI gate** (lint + vitest + route guard) to `features`/`main`.
+- Tracked but not approved: scrape `format:'markdown'` no-fallback gap; `scrape_log` 15KB `body_sample` bloat.
+
+---
+
 ### 2026-05-10 → 2026-05-23 — Stage 1 rebuild + My Website + /docs + X OAuth migration
 
 ~14 days, ~222 commits across 30+ PRs. Multi-session arc; Brian + Claude (full-stack).
@@ -38,89 +73,15 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 **Other notable**: Lovable integration + Build button (5/12); Quick Start no-website onramp (5/12); X v2 media upload fix (5/13); Regenerate Arcs (5/13); Vite 5→8 + Clerk/postcss security patches (5/13); GFM table rendering (5/15); `/api/admin/mark-unpublished` (5/17); GitNexus context files committed — aspirational without live MCP runtime in cloud sessions (5/21); `SESSION-PROTOCOL.md` refreshed + moved to repo root (5/22); topbar alerts bell + Get Help form (5/23).
 
-#### Recurring patterns logged
-
-- **Build the primitive once, share it everywhere.** `forgeScrape` replaced 3+ ad-hoc fetchers. The 6 channels that ignored `forgeArticleUrl` accumulated because each new channel re-derived from scratch instead of using the shared helper.
-- **Stdio MCP doesn't reach cloud sessions.** GitNexus is useful but its MCP transport is stdio-only — FleetView/cloud Claude Code can't connect to a remote install. Committed the context files as aspirational; the live graph tools are unavailable until either GitNexus ships HTTP/SSE MCP or FleetView gains custom-MCP support.
-- **Controlled test cases prevent wrong-direction guesses.** sandbox-gtm.com diagnostic loop (PRs #103–#110) was driven by one URL where Brian knew ground truth — saved several wrong-direction fixes.
-- **Error UIs must match the action that actually fixes the error.** "Reset & Retry" for auth-expired is dishonest; users need a Reconnect path with a real link.
-
 #### State of key surfaces (end of period)
 
 - **Stage 1 (Context Hub crawl):** Jina-first, forgeScrape fallback, parallel discovery. Reads full sites including SPAs.
 - **Site Template:** Same `forgeScrape` primitive, same Tier 2 fallback. Grades by content + structural selectors.
 - **Publishing channels live:** LinkedIn (Zernio), X (OAuth2, x.com migrated), Facebook (Zernio + Pipedream), Reddit (Zernio), Medium, Ghost, WordPress, Webflow, **My Website (new)**. HubSpot stripped per 5/9.
 - **`/docs` surface:** Live at `forgeintelligence.ai/docs/my-website`. Share With AI on every entry.
-- **Bootstrap files at repo root:** `CLAUDE.md`, `AGENTS.md`, `SESSION-PROTOCOL.md`, `WORKING-STATE.md`, `WHITEBOARD.md`, `.claude/skills/gitnexus/`. Skills aspirational without MCP runtime.
 - **GitNexus index:** 2,818 nodes / 3,968 edges / 61 clusters / 129 flows.
 
-#### What's next
+#### What's next (from that period — superseded items pruned)
 
-- **Nurture email** framing the Stage 1 upgrade as a free product enhancement. Two before/after proof points ready: sandbox-gtm.com v8→v9 and forgeintelligence.ai v11→v12.
 - **Watch X OAuth in the wild** — if runtime API calls start failing the same way, apply the domain swap to those endpoints too.
 - **My Website rollout copy** — landing page, email blast, in-app announcement. Feature exists + documented; awareness is the remaining gap.
-- **GitNexus runtime** — register `gitnexus mcp` if FleetView adds custom MCP support, or if upstream ships HTTP/SSE MCP transport.
-
-**Endpoint count:** ~205 HTTP endpoints in server.js (up from ~191 baseline; added forgeScrape primitive + My Website's 4 admin endpoints + Facebook backfill + various smaller).
-
----
-
-### 2026-05-09 — Email Campaign Generator polish, MCP for Viktor, HubSpot strip
-
-**Ended:** 2026-05-09 ~04:15 PT (~13h continuous, single-session arc)
-**Operator:** Brian + Claude (full-stack)
-
-#### Major shipments
-
-**MCP server live for Viktor (Slack assistant integration).** `POST /mcp` endpoint, JSON-RPC 2.0, dual-auth (Bearer + X-Api-Key). Three read-only tools exposed: `list_email_campaigns`, `list_emails_in_campaign`, `get_email_copy`. New scope namespace: `mcp:campaigns:read`, `mcp:emails:read`. Brian's API key minted: `fik_live_c2310c2c…b12f` scoped to the Forge brand only.
-
-**Attio CSV export shipped on the Email Campaign Generator.** Per-email CSV download with subject-variant picker (benefit / curiosity / pattern_interrupt, default benefit). Two columns matching Attio's "Generated Emails" Object attributes exactly so the importer auto-maps. Filename: `attio-import-{campaignId8}-{variant}.csv`. RFC-compliant escaping + UTF-8 BOM. Brian's manual Attio Object setup made this a 30-line FE feature instead of a multi-day OAuth integration.
-
-**Landing page polish.** "Read your brand to filth" subline replaced with strategist-framed brand voice. Footer split to two rows with **Published by Forge** linking to `/articles/forgeintelligence-ai` (brand-specific public article hub).
-
-**HubSpot integration full strip + replace with clipboard copy.** Four rebuild rounds across ~6 hours ended in the right answer: HubSpot's public API gates email-template creation behind Marketing Hub Pro+ at every endpoint accessible to Sales Hub Starter (Brian's tier). Replaced with **"Copy for HubSpot" button** on each email card — formats email body as paste-ready HTML, writes to clipboard, user pastes into HubSpot Sales > Templates > New > Source view manually. Same UX shape as Attio CSV export. All `/api/hubspot/*` endpoints, the IntegrationsPage HubSpot card, and the `publishing_channels` row for hubspot are deleted.
-
-**Email Campaign Generator polish (Phase 1 + 2 + 3):**
-
-1. **Render bugs fixed** — P.S. duplication, inline `{{cta_url}}`, `[NEEDS_PROOF]` token leakage. System prompt rewritten with explicit field-separation rules; render-side `sanitizeBody()` helper as defense in depth so existing campaigns clean up retroactively.
-2. **Inline edit + flag actions.** New endpoints: `PATCH /api/email-campaign/email/:id`, `POST /api/email-campaign/email/:id/resolve-flag`, `POST /api/email-campaign/email/:id/dismiss-flag-as-false-positive`. Edit mode on every EmailCard makes subject_lines + body + ps + cta_text + cta_url_placeholder all editable. Per-flag actions: Mark resolved / Add citation / Dismiss as false positive. Dismissals write to `brain_mistakes` so the Compliance Gate's brain learns to suppress false-positive patterns on future runs.
-3. **Sequence Assessment readability.** System prompt now asks LLM for three short paragraphs (arc / tone / brand-voice shaping) in plain English with no `[bracket_identifiers]`. Render-side cleanup strips legacy bracket tokens + orphan commas + tightens punctuation.
-
-**DB migration applied via SQL relay:**
-```sql
-ALTER TABLE email_campaign_emails ADD COLUMN flag_resolutions JSONB DEFAULT '{}'::jsonb;
-```
-
-**HubSpot OAuth app rotated:** Old app's scope state was unrecoverable in the dev portal. New app: App ID `39088507`, Client ID `78a09da5-3d3f-4c4b-b00e-74310739be3e`. Render `HUBSPOT_CLIENT_ID` updated via single-var PATCH. Brian rotated `HUBSPOT_CLIENT_SECRET` directly. Both prod + dev redeployed to refresh `process.env`. App is now obsolete since HubSpot integration was stripped, but the new credentials are in place if it ever comes back.
-
-#### Recurring patterns logged
-
-- **Half-applied state from intermediate-assertion crashes:** for multi-step edits to a single file, do everything in memory first, sanity-check before any commit, then ONE atomic PUT. Two scripts crashed mid-edit today, requiring fix-up commits.
-- **Propose simplest workable path FIRST before architecting OAuth flows.** Brian's CSV-via-Attio-Object outpaced my OAuth dive.
-- **When same paywall appears twice in different shapes = stop pivoting, call it.** I burned ~90 minutes on HubSpot endpoint pivots when the answer was visible after the second 403.
-- **Render-side defense-in-depth is only valuable where the default is broken.** Sentence-boundary split on sequence_notes was over-engineering that fragmented good content.
-
-#### State of key surfaces (end of session)
-
-- **Email Campaign Generator:** clean, editable, brain-feedback-loop wired. Most polished it has ever been.
-- **Integrations page:** HubSpot card removed. LinkedIn / Facebook / Reddit / Ghost / Medium / WordPress / Webflow / X all live.
-- **MCP server:** live at `/mcp`, 3 tools, ready for Viktor.
-- **Brain Memory:** Forge brain has 9 OWNED + 8 CONTESTED positioning patterns. `brain_mistakes` is now actively written to by user dismissals (closes the feedback loop on Compliance Gate flags).
-
-#### What's next
-
-**Validation pass on the new prompts:**
-- Generate a fresh test campaign to confirm sequence_notes produces 3 paragraphs (arc / tone / brand-voice) as designed
-- Generate a fresh test campaign to confirm body has no inline P.S. / `{{cta_url}}` / `[NEEDS_PROOF]` after the prompt rewrite
-
-**Zernio cleanup (deferred from May 8):**
-- Sandbox-XM, Sandbox-GTM, Attio LinkedIn migrations through Zernio (Forge done; others still on direct OAuth)
-- Cancel Pipedream Connect ($150/mo savings)
-- Remove `FACEBOOK_PIPEDREAM_WORKFLOW_URL` env var from Render (stale)
-- LinkedIn OAuth callback to MERGE credentials instead of overwriting (server.js ~L9262)
-
-**Reddit Phase 4:** per-publish subreddit picker in queue UI + flair selection.
-
-**Strategy branch update:** WHITEBOARD on main captures session technical detail, but `STRATEGY.md` on the `strategy` branch should get the Email Campaign Generator improvements + HubSpot-paywall lesson woven into the broader Voice of Market positioning thread.
-
-**Endpoint count:** ~191 HTTP endpoints in server.js + 3 logical MCP tools (down from 194 net after HubSpot strip + 3 email-campaign edit/flag endpoints added).


### PR DESCRIPTION
## Why
End-of-session doc hygiene for the 2026-06-05 `server.js` decomposition arc, per CLAUDE.md (touch both `WORKING-STATE.md` and `PLAN.md` or the next session loses context).

## What
**`WORKING-STATE.md`**
- New top session block: the dismemberment status (10 modules extracted), this session's cuts (`llm`/`logging`/`lovable`, #213–#215), the two latent bug fixes (#216–#219), the CI safety net, the extraction pattern, and what's next (clean leaves → route groups).
- Archived the 2026-05-09 block — already preserved in `PLAN.md` (§"What shipped (chronological)" / "HubSpot demolition" / "Email Campaign Generator polish") — to bring the file back under the ~100-line cap (**now 87**).

**`PLAN.md`**
- New long-form retrospective at top (newest-first): why the safety net came first and the 3 missed-imports it caught, the three cuts, both bugs in detail (Lovable dead-guard placeholder leak; `captureLog` unguarded-stringify crash), recurring patterns, and net state.

Docs only — **no code change**.

## Note
Records that all five code PRs merged, and that `features` is merged through to production (`main`) — both bug fixes are live. `development` holds the full refactor + both fixes, ready for the `development → main` rollup.

## Test plan
N/A (Markdown only). Line counts: WORKING-STATE 87, PLAN +144.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_