### PR TITLE
ci(features): add ESLint no-undef gate to the production lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: npm install --no-audit --no-fund
       - name: Backend syntax check (server.js monolith)
         run: node --check server.js
+      - name: Lint (no-undef) — catches missed imports from extractions
+        run: npm run lint
       - name: Typecheck (React app)
         run: npm run typecheck
       - name: Unit tests (route-inventory guard + future units)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,29 @@
+import globals from 'globals';
+
+// Minimal lint gate for the server.js decomposition. The point is ONE rule:
+// no-undef catches "X is not defined" — the exact failure mode of an extraction
+// that forgets to import a moved symbol back. CI doesn't boot the app, so this
+// is how that mistake gets caught at the PR gate instead of on deploy.
+//
+// Deliberately NOT the full eslint:recommended set — we don't want to surface
+// pre-existing style/unused-var noise across a 20k-line file. Just no-undef.
+export default [
+  {
+    files: ['server.js', 'src/server/**/*.js', 'test/**/*.{js,mjs}'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        // server.js runs browser code inside Puppeteer page.evaluate /
+        // waitForFunction callbacks (forgeScrape). document/window are legit
+        // there, so whitelist them rather than flag false positives.
+        document: 'readonly',
+        window: 'readonly',
+      },
+    },
+    rules: {
+      'no-undef': 'error',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node server.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "lint": "eslint server.js \"test/**/*.{js,mjs}\"",
     "routes:snapshot": "node test/gen-snapshot.js"
   },
   "dependencies": {
@@ -37,6 +38,8 @@
     "@types/react-dom": "^18.2.15",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.0.1",
+    "eslint": "^9.0.0",
+    "globals": "^15.0.0",
     "typescript": "^5.2.2",
     "vite": "^8.0.12",
     "vitest": "^2.1.9"


### PR DESCRIPTION
## Why
Bring the production-maintenance lane (`features`) up to parity with `development`'s CI safety net. `features` already ran `node --check` + `typecheck` + the route-inventory guard (`npm test`). The one missing piece was the **ESLint `no-undef` gate** — the belt that catches a reference to an undefined symbol (e.g. a hotfix that uses a helper without importing/defining it) at PR time instead of on deploy.

## What
- **`eslint.config.js`** — flat config, `no-undef` only (from `development`). `document`/`window` whitelisted for Puppeteer `page.evaluate` callbacks. Deliberately *not* `eslint:recommended` — no style/unused-var noise across the 20k-line monolith.
- **`package.json`** — `lint` script + `eslint ^9` / `globals ^15` devDeps.
  - ⚠️ The features script lints `server.js` + `test/**` only and **omits the `src/server/**` glob** that development's script carries — those modules don't exist on `features` (inline monolith), and ESLint v9 errors on a glob that matches zero files. (When the decomposition eventually reaches `main`/`features`, restore the glob.)
- **`ci.yml`** — adds the `Lint (no-undef)` step before typecheck, matching development's step order.

No app code touched — CI config + devDeps only.

## Test plan (run locally on the features tree)
- `node --check server.js` → OK
- `npm run lint` → **exit 0** (the inline monolith passes `no-undef` clean)
- `npm test` (route-inventory guard) → pass (213 routes)

## Rollback
Revert — CI-config + devDeps only.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_