### PR TITLE
refactor(server): extract image helpers → src/server/images.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ import {
   lovableStubPrompt, lovableRecommendedAppName, lovableAppTypeDescription,
 } from './src/server/lovable.js';
 import { buildXOAuthHeader, uploadXMedia, refreshXOAuth2Token } from './src/server/x.js';
+import { generateHeroImage, buildImagePrompt, buildSocialImagePrompt, generateSocialImage } from './src/server/images.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -864,93 +865,9 @@ app.use(express.json());
 // Swapped from Flux Schnell (4-step distilled, plastic skin, "Kim K" vibe on humans)
 // to Ideogram v2 (realistic style, built-in MagicPrompt expansion, reliable faces/hands).
 // Cost: ~$0.08/image vs $0.003 prior. Quality difference is enormous for B2B marketing imagery.
-const HERO_IMAGE_NEGATIVE_PROMPT = "airbrushed skin, smooth skin, plastic skin, waxy skin, overproduced, HDR, oversaturated, hyperreal, AI art, digital painting, 3D render, cartoon, illustration, distorted hands, extra fingers, malformed fingers, mutated anatomy, stock photo, generic corporate stock image, blurry faces in background blobbing together, text artifacts";
-
-async function generateHeroImage(prompt) {
-  const falRes = await fetch('https://fal.run/fal-ai/ideogram/v2', {
-    method: 'POST',
-    headers: { 'Authorization': `Key ${process.env.FAL_API_KEY}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      prompt,
-      aspect_ratio: '16:9',
-      style: 'realistic',
-      expand_prompt: true,            // Ideogram's MagicPrompt — expands our terse prompt into a richer one before generation
-      negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
-      num_images: 1
-    })
-  });
-  if (!falRes.ok) throw new Error(`fal.ai ${falRes.status}: ${await falRes.text()}`);
-  const falData = await falRes.json();
-  const imageUrl = falData?.images?.[0]?.url;
-  if (!imageUrl) throw new Error('No image URL returned from fal.ai');
-  return imageUrl;
-}
-
-
-// ── Shared: Build brand-voice-aware image prompt ─────────────────────────────
-async function buildImagePrompt(title, voiceProfile = {}, firstBody = '') {
-  const brandName = voiceProfile.brand_name || '';
-  // tone: handle both snake_case (legacy) and camelCase (Context Agent output)
-  const toneAttrStr = Array.isArray(voiceProfile.toneAttributes)
-    ? voiceProfile.toneAttributes.map(a => a.attribute).join(', ')
-    : '';
-  const toneSummary = voiceProfile.tone_summary || voiceProfile.summary || voiceProfile.writingStyle || toneAttrStr || '';
-  const industry = voiceProfile.industry || voiceProfile.target_industry || voiceProfile.marketCategory || '';
-  const positioning = voiceProfile.positioning || voiceProfile.brand_positioning || '';
-  const targetPersona = voiceProfile.targetPersona || voiceProfile.target_persona || voiceProfile.primary_persona || '';
-  const visualStyle = voiceProfile.visualStyle || voiceProfile.visual_style || voiceProfile.brand_aesthetic || '';
-  const accentColor = voiceProfile.accentColor || voiceProfile.accent_color || voiceProfile.brand_color || '';
-
-  const brandContext = [
-    brandName && `Brand: ${brandName}`,
-    industry && `Industry: ${industry}`,
-    toneSummary && `Tone: ${toneSummary}`,
-    positioning && `Positioning: ${positioning}`,
-    targetPersona && `Audience: ${targetPersona}`,
-    visualStyle && `Visual style: ${visualStyle}`,
-    accentColor && `Brand accent color: ${accentColor}`,
-  ].filter(Boolean).join('\n');
-
-  const bodySnippet = (firstBody || '').slice(0, 250);
-
-  const hasBrandVisual = !!(visualStyle || accentColor);
-
-  const imagePromptInstruction = hasBrandVisual
-    ? `Write a single-sentence image generation prompt for an article hero image that reflects this brand's visual identity and the article topic.
-
-Article title: "${title}"
-${brandContext ? brandContext + '\n' : ''}${bodySnippet ? 'Article context: ' + bodySnippet : ''}
-
-Rules:
-- One sentence. Describe the concrete scene — what's happening, who is in it (if anyone), where, what the mood is.
-- Editorial/documentary photography feel: natural available light, real moment, candid — not posed. If humans are present, describe what they are doing, not how they look.
-- Let the brand's visual style, tone, and color palette shape the aesthetic.
-- Avoid words that signal AI-generated stock imagery: "photorealistic", "professional", "polished", "corporate", "stock", "perfect", "high-quality". Use concrete sensory details instead.
-- No illustrations, 3D renders, cartoons, or surrealism.
-- NEVER interpret the brand name literally (e.g. 'Forge' is software, not a blacksmith).
-- Output only the prompt. No quotes, no preamble, no explanation.`
-    : `Write a single-sentence image generation prompt for an article hero image.
-
-Article title: "${title}"
-${bodySnippet ? 'Article context: ' + bodySnippet : ''}
-
-Rules:
-- One sentence. Describe the concrete scene — what's happening, who is in it (if anyone), where, what the mood is.
-- Editorial/documentary photography feel: natural available light, real moment, candid — not posed. If humans are present, describe what they are doing, not how they look.
-- Avoid words that signal AI-generated stock imagery: "photorealistic", "professional", "polished", "corporate", "stock", "perfect", "high-quality". Use concrete sensory details instead.
-- No illustrations, 3D renders, cartoons, or surrealism.
-- Output only the prompt. No quotes, no preamble, no explanation.`;
-
-  const res = await anthropic.messages.create({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 200,
-    messages: [{ role: 'user', content: imagePromptInstruction }]
-  });
-
-  return res.content[0]?.type === 'text'
-    ? res.content[0].text.trim()
-    : `A candid documentary moment capturing the world of ${title}, natural available light, shallow depth of field`;
-}
+// Image helpers (generateHeroImage / buildImagePrompt / buildSocialImagePrompt
+// / generateSocialImage + HERO_IMAGE_NEGATIVE_PROMPT) moved to
+// src/server/images.js (imported at top).
 
 
 // ── Public Article Viewer ─────────────────────────────────────────────────────
@@ -7352,71 +7269,7 @@ const activeStreams = (typeof globalThis.__activeStreams === 'object' && globalT
 // brand color palette, type-friendly negative space). Different shape than buildImagePrompt()
 // which is editorial 16:9. Takes the writer's per-post imagePromptHint as the seed concept
 // so each post gets imagery matched to its angle, not generic brand stock.
-async function buildSocialImagePrompt(post, voiceProfile = {}, brandName = '') {
-  const visualStyle = voiceProfile.visualStyle || voiceProfile.visual_style || voiceProfile.brand_aesthetic || '';
-  const accentColor = voiceProfile.accentColor || voiceProfile.accent_color || voiceProfile.brand_color || '';
-  const tone = voiceProfile.summary || voiceProfile.writingStyle || '';
-
-  const hint = post?.imagePromptHint || post?.hook || post?.body?.slice(0, 200) || '';
-  const angle = post?.angle || 'general';
-
-  const brandContext = [
-    brandName && `Brand: ${brandName}`,
-    visualStyle && `Visual style: ${visualStyle}`,
-    accentColor && `Brand accent: ${accentColor}`,
-    tone && `Tone: ${tone}`,
-  ].filter(Boolean).join('\n');
-
-  const instruction = `Write a one-sentence Flux Schnell image prompt for a SQUARE (1:1) social media post. The image must work scrolling on phones — single focal subject, strong silhouette, type-friendly negative space, NOT a busy editorial scene.
-
-Post concept: ${hint}
-Post angle: ${angle}
-${brandContext ? brandContext + '\n' : ''}
-Rules:
-- One sentence describing a clear, graphic, scroll-stopping visual.
-- Single dominant subject. Strong composition. Centered or rule-of-thirds.
-- 1:1 square aspect ratio in mind. Avoid wide cinematic compositions.
-- Reflect the brand's accent color in the lighting or palette if specified.
-- Concrete sensory details — no "professional", "polished", "corporate", "stock photo".
-- No illustrations, 3D renders, cartoons. No text, no logos, no UI elements.
-- NEVER interpret the brand name literally.
-- Output only the prompt. No quotes, no preamble.`;
-
-  try {
-    const res = await anthropic.messages.create({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 200,
-      messages: [{ role: 'user', content: instruction }]
-    });
-    return res.content[0]?.type === 'text'
-      ? res.content[0].text.trim()
-      : `A clean square composition with a single focal subject illuminated by natural light, related to ${hint}, scroll-stopping social composition`;
-  } catch (e) {
-    console.error('[SOCIAL-IMG-PROMPT]', e.message);
-    return `A clean square composition with a single focal subject illuminated by natural light, related to ${hint}, scroll-stopping social composition`;
-  }
-}
-
-// fal.ai Ideogram v2 wrapper for square social images. Mirrors generateHeroImage but with 1:1.
-async function generateSocialImage(prompt) {
-  const falRes = await fetch('https://fal.run/fal-ai/ideogram/v2', {
-    method: 'POST',
-    headers: { 'Authorization': `Key ${process.env.FAL_API_KEY}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      prompt,
-      aspect_ratio: '1:1',
-      style: 'realistic',
-      expand_prompt: true,
-      negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
-      num_images: 1
-    })
-  });
-  if (!falRes.ok) throw new Error(`fal.ai social ${falRes.status}: ${await falRes.text()}`);
-  const falData = await falRes.json();
-  const imageUrl = falData?.images?.[0]?.url;
-  if (!imageUrl) throw new Error('No image URL returned from fal.ai');
-  return imageUrl;
-}
+// buildSocialImagePrompt + generateSocialImage moved to src/server/images.js (imported at top).
 
 app.get('/api/social-generator/generate', requireAuth, async (req, res) => {
   const { brandProfileId, platform, topicPrompt, briefId, mandatories, constraints, audience, ctaTarget, desiredAction, arcId } = req.query;

--- a/src/server/images.js
+++ b/src/server/images.js
@@ -1,0 +1,161 @@
+// Image generation helpers, extracted from server.js during the decomposition.
+// Two pairs: a prompt builder (brand-voice-aware, via Claude Haiku) and a
+// fal.ai Ideogram v2 generator, for hero (16:9) and social (1:1) images.
+//   - buildImagePrompt / generateHeroImage   — article hero, 16:9
+//   - buildSocialImagePrompt / generateSocialImage — social post, 1:1
+// Deps: the shared `anthropic` client (llm.js) + fetch/process.env (FAL_API_KEY).
+// HERO_IMAGE_NEGATIVE_PROMPT is shared by both generators and stays private.
+import { anthropic } from './llm.js';
+
+const HERO_IMAGE_NEGATIVE_PROMPT = "airbrushed skin, smooth skin, plastic skin, waxy skin, overproduced, HDR, oversaturated, hyperreal, AI art, digital painting, 3D render, cartoon, illustration, distorted hands, extra fingers, malformed fingers, mutated anatomy, stock photo, generic corporate stock image, blurry faces in background blobbing together, text artifacts";
+
+export async function generateHeroImage(prompt) {
+  const falRes = await fetch('https://fal.run/fal-ai/ideogram/v2', {
+    method: 'POST',
+    headers: { 'Authorization': `Key ${process.env.FAL_API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      prompt,
+      aspect_ratio: '16:9',
+      style: 'realistic',
+      expand_prompt: true,            // Ideogram's MagicPrompt — expands our terse prompt into a richer one before generation
+      negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
+      num_images: 1
+    })
+  });
+  if (!falRes.ok) throw new Error(`fal.ai ${falRes.status}: ${await falRes.text()}`);
+  const falData = await falRes.json();
+  const imageUrl = falData?.images?.[0]?.url;
+  if (!imageUrl) throw new Error('No image URL returned from fal.ai');
+  return imageUrl;
+}
+
+// ── Shared: Build brand-voice-aware image prompt ─────────────────────────────
+export async function buildImagePrompt(title, voiceProfile = {}, firstBody = '') {
+  const brandName = voiceProfile.brand_name || '';
+  // tone: handle both snake_case (legacy) and camelCase (Context Agent output)
+  const toneAttrStr = Array.isArray(voiceProfile.toneAttributes)
+    ? voiceProfile.toneAttributes.map(a => a.attribute).join(', ')
+    : '';
+  const toneSummary = voiceProfile.tone_summary || voiceProfile.summary || voiceProfile.writingStyle || toneAttrStr || '';
+  const industry = voiceProfile.industry || voiceProfile.target_industry || voiceProfile.marketCategory || '';
+  const positioning = voiceProfile.positioning || voiceProfile.brand_positioning || '';
+  const targetPersona = voiceProfile.targetPersona || voiceProfile.target_persona || voiceProfile.primary_persona || '';
+  const visualStyle = voiceProfile.visualStyle || voiceProfile.visual_style || voiceProfile.brand_aesthetic || '';
+  const accentColor = voiceProfile.accentColor || voiceProfile.accent_color || voiceProfile.brand_color || '';
+
+  const brandContext = [
+    brandName && `Brand: ${brandName}`,
+    industry && `Industry: ${industry}`,
+    toneSummary && `Tone: ${toneSummary}`,
+    positioning && `Positioning: ${positioning}`,
+    targetPersona && `Audience: ${targetPersona}`,
+    visualStyle && `Visual style: ${visualStyle}`,
+    accentColor && `Brand accent color: ${accentColor}`,
+  ].filter(Boolean).join('\n');
+
+  const bodySnippet = (firstBody || '').slice(0, 250);
+
+  const hasBrandVisual = !!(visualStyle || accentColor);
+
+  const imagePromptInstruction = hasBrandVisual
+    ? `Write a single-sentence image generation prompt for an article hero image that reflects this brand's visual identity and the article topic.
+
+Article title: "${title}"
+${brandContext ? brandContext + '\n' : ''}${bodySnippet ? 'Article context: ' + bodySnippet : ''}
+
+Rules:
+- One sentence. Describe the concrete scene — what's happening, who is in it (if anyone), where, what the mood is.
+- Editorial/documentary photography feel: natural available light, real moment, candid — not posed. If humans are present, describe what they are doing, not how they look.
+- Let the brand's visual style, tone, and color palette shape the aesthetic.
+- Avoid words that signal AI-generated stock imagery: "photorealistic", "professional", "polished", "corporate", "stock", "perfect", "high-quality". Use concrete sensory details instead.
+- No illustrations, 3D renders, cartoons, or surrealism.
+- NEVER interpret the brand name literally (e.g. 'Forge' is software, not a blacksmith).
+- Output only the prompt. No quotes, no preamble, no explanation.`
+    : `Write a single-sentence image generation prompt for an article hero image.
+
+Article title: "${title}"
+${bodySnippet ? 'Article context: ' + bodySnippet : ''}
+
+Rules:
+- One sentence. Describe the concrete scene — what's happening, who is in it (if anyone), where, what the mood is.
+- Editorial/documentary photography feel: natural available light, real moment, candid — not posed. If humans are present, describe what they are doing, not how they look.
+- Avoid words that signal AI-generated stock imagery: "photorealistic", "professional", "polished", "corporate", "stock", "perfect", "high-quality". Use concrete sensory details instead.
+- No illustrations, 3D renders, cartoons, or surrealism.
+- Output only the prompt. No quotes, no preamble, no explanation.`;
+
+  const res = await anthropic.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 200,
+    messages: [{ role: 'user', content: imagePromptInstruction }]
+  });
+
+  return res.content[0]?.type === 'text'
+    ? res.content[0].text.trim()
+    : `A candid documentary moment capturing the world of ${title}, natural available light, shallow depth of field`;
+}
+
+export async function buildSocialImagePrompt(post, voiceProfile = {}, brandName = '') {
+  const visualStyle = voiceProfile.visualStyle || voiceProfile.visual_style || voiceProfile.brand_aesthetic || '';
+  const accentColor = voiceProfile.accentColor || voiceProfile.accent_color || voiceProfile.brand_color || '';
+  const tone = voiceProfile.summary || voiceProfile.writingStyle || '';
+
+  const hint = post?.imagePromptHint || post?.hook || post?.body?.slice(0, 200) || '';
+  const angle = post?.angle || 'general';
+
+  const brandContext = [
+    brandName && `Brand: ${brandName}`,
+    visualStyle && `Visual style: ${visualStyle}`,
+    accentColor && `Brand accent: ${accentColor}`,
+    tone && `Tone: ${tone}`,
+  ].filter(Boolean).join('\n');
+
+  const instruction = `Write a one-sentence Flux Schnell image prompt for a SQUARE (1:1) social media post. The image must work scrolling on phones — single focal subject, strong silhouette, type-friendly negative space, NOT a busy editorial scene.
+
+Post concept: ${hint}
+Post angle: ${angle}
+${brandContext ? brandContext + '\n' : ''}
+Rules:
+- One sentence describing a clear, graphic, scroll-stopping visual.
+- Single dominant subject. Strong composition. Centered or rule-of-thirds.
+- 1:1 square aspect ratio in mind. Avoid wide cinematic compositions.
+- Reflect the brand's accent color in the lighting or palette if specified.
+- Concrete sensory details — no "professional", "polished", "corporate", "stock photo".
+- No illustrations, 3D renders, cartoons. No text, no logos, no UI elements.
+- NEVER interpret the brand name literally.
+- Output only the prompt. No quotes, no preamble.`;
+
+  try {
+    const res = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 200,
+      messages: [{ role: 'user', content: instruction }]
+    });
+    return res.content[0]?.type === 'text'
+      ? res.content[0].text.trim()
+      : `A clean square composition with a single focal subject illuminated by natural light, related to ${hint}, scroll-stopping social composition`;
+  } catch (e) {
+    console.error('[SOCIAL-IMG-PROMPT]', e.message);
+    return `A clean square composition with a single focal subject illuminated by natural light, related to ${hint}, scroll-stopping social composition`;
+  }
+}
+
+// fal.ai Ideogram v2 wrapper for square social images. Mirrors generateHeroImage but with 1:1.
+export async function generateSocialImage(prompt) {
+  const falRes = await fetch('https://fal.run/fal-ai/ideogram/v2', {
+    method: 'POST',
+    headers: { 'Authorization': `Key ${process.env.FAL_API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      prompt,
+      aspect_ratio: '1:1',
+      style: 'realistic',
+      expand_prompt: true,
+      negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
+      num_images: 1
+    })
+  });
+  if (!falRes.ok) throw new Error(`fal.ai social ${falRes.status}: ${await falRes.text()}`);
+  const falData = await falRes.json();
+  const imageUrl = falData?.images?.[0]?.url;
+  if (!imageUrl) throw new Error('No image URL returned from fal.ai');
+  return imageUrl;
+}

--- a/test/images.test.js
+++ b/test/images.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the shared anthropic client (llm.js) so the prompt builders run without
+// network. generateHeroImage / generateSocialImage are pure fal.ai fetch
+// wrappers — exercised via the live publish path, not here.
+const create = vi.fn();
+vi.mock('../src/server/llm.js', () => ({
+  anthropic: { messages: { create: (...a) => create(...a) } },
+}));
+
+const { buildImagePrompt, buildSocialImagePrompt } = await import('../src/server/images.js');
+
+beforeEach(() => create.mockReset());
+
+describe('buildImagePrompt', () => {
+  it('returns the model text when the response is a text block', async () => {
+    create.mockResolvedValue({ content: [{ type: 'text', text: '  a quiet workshop at dawn  ' }] });
+    const out = await buildImagePrompt('My Title', { brand_name: 'Acme' }, 'body');
+    expect(out).toBe('a quiet workshop at dawn');
+  });
+
+  it('falls back to a deterministic prompt when the response is not text', async () => {
+    create.mockResolvedValue({ content: [{ type: 'tool_use' }] });
+    const out = await buildImagePrompt('Widgets 101', {}, '');
+    expect(out).toContain('Widgets 101');
+    expect(out).toContain('natural available light');
+  });
+
+  it('passes brand visual context into the instruction when present', async () => {
+    create.mockResolvedValue({ content: [{ type: 'text', text: 'x' }] });
+    await buildImagePrompt('T', { visualStyle: 'brutalist', accentColor: '#f00' }, '');
+    const sentInstruction = create.mock.calls[0][0].messages[0].content;
+    expect(sentInstruction).toContain('visual identity'); // hasBrandVisual branch
+    expect(sentInstruction).toContain('brutalist');
+  });
+});
+
+describe('buildSocialImagePrompt', () => {
+  it('returns model text on success', async () => {
+    create.mockResolvedValue({ content: [{ type: 'text', text: 'bold square shot' }] });
+    expect(await buildSocialImagePrompt({ hook: 'launch day' }, {}, 'Acme')).toBe('bold square shot');
+  });
+
+  it('returns the deterministic fallback when the response is not a text block', async () => {
+    // Same fallback string the catch path returns, so this covers the
+    // "unusable model response" branch without a thrown-mock unhandled-rejection.
+    create.mockResolvedValue({ content: [{ type: 'tool_use' }] });
+    const out = await buildSocialImagePrompt({ hook: 'launch day' }, {}, 'Acme');
+    expect(out).toContain('scroll-stopping social composition');
+  });
+});


### PR DESCRIPTION
## Why
Continues the `server.js` dismemberment. The four image-generation helpers are a cohesive media cluster. Their only non-global dependency is the shared `anthropic` client — which already lives in `src/server/llm.js`, so the new module imports it from there. Otherwise just `fetch` + `process.env.FAL_API_KEY`.

## What
- **New `src/server/images.js`** exports (moved verbatim):
  - `buildImagePrompt` / `generateHeroImage` — article hero, 16:9 (5/7 refs)
  - `buildSocialImagePrompt` / `generateSocialImage` — social post, 1:1 (2/2 refs)
  - `HERO_IMAGE_NEGATIVE_PROMPT` kept **module-private** (only the two fal.ai generators use it).
  - imports `anthropic` from `./llm.js`.
- `server.js` imports the four; the inline defs (two separate blocks — hero pair ~L867, social pair ~L7355) → breadcrumb comments.

Pure move, no logic touched.

## Test plan
- `node --check server.js` → OK
- `npm run lint` (no-undef gate) → clean — confirms all four imported and no orphaned `HERO_IMAGE_NEGATIVE_PROMPT` reference left behind
- route-inventory guard → **PASS** (snapshot unchanged)
- `vitest` → **65/65 pass** (+5 new tests: `buildImagePrompt` text / fallback / brand-visual-branch via a mocked `anthropic`; `buildSocialImagePrompt` text + fallback). The two fal.ai generators are pure network wrappers — exercised via the live publish path, not unit-tested.

## Rollback
Revert — pure copy, restores the inline defs exactly.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_