### PR TITLE
fix(images): disable fal.ai MagicPrompt + add 60s timeout

### DIFF
--- a/server.js
+++ b/server.js
@@ -930,10 +930,18 @@ async function generateHeroImage(prompt) {
       prompt,
       aspect_ratio: '16:9',
       style: 'realistic',
-      expand_prompt: true,            // Ideogram's MagicPrompt — expands our terse prompt into a richer one before generation
+      // expand_prompt OFF: our prompt is already a carefully brand-voice-tuned
+      // sentence (buildImagePrompt, with explicit anti-AI-stock + don't-take-
+      // brand-name-literally constraints). Ideogram's MagicPrompt rewrites the
+      // prompt and can re-inject the generic/stock aesthetic we deliberately
+      // excluded, so we hand it our prompt verbatim.
+      expand_prompt: false,
       negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
       num_images: 1
-    })
+    }),
+    // Cap a hung fal.ai call. Image gen runs ~10-20s; 60s is generous headroom
+    // while still preventing an indefinite block on the generate/publish path.
+    signal: AbortSignal.timeout(60000)
   });
   if (!falRes.ok) throw new Error(`fal.ai ${falRes.status}: ${await falRes.text()}`);
   const falData = await falRes.json();
@@ -7580,10 +7588,14 @@ async function generateSocialImage(prompt) {
       prompt,
       aspect_ratio: '1:1',
       style: 'realistic',
-      expand_prompt: true,
+      // expand_prompt OFF — see generateHeroImage. Our buildSocialImagePrompt
+      // output is already tuned; MagicPrompt would rewrite it and can undo the
+      // anti-stock / single-focal-subject constraints.
+      expand_prompt: false,
       negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
       num_images: 1
-    })
+    }),
+    signal: AbortSignal.timeout(60000) // cap a hung fal.ai call (see generateHeroImage)
   });
   if (!falRes.ok) throw new Error(`fal.ai social ${falRes.status}: ${await falRes.text()}`);
   const falData = await falRes.json();


### PR DESCRIPTION
## Two fixes to the fal.ai image generators (`generateHeroImage` 16:9, `generateSocialImage` 1:1)

### 1. `expand_prompt: true` → `false` — stop MagicPrompt undoing our prompt
We spend a Claude Haiku call (`buildImagePrompt` / `buildSocialImagePrompt`) building a carefully brand-voice-tuned prompt with explicit constraints — *no photorealistic/professional/polished/corporate/stock language, never interpret the brand name literally, no 3D/cartoon*. Then `expand_prompt: true` handed that prompt to Ideogram's **MagicPrompt**, which **rewrites it before generation** and can re-inject exactly the generic AI-stock aesthetic we told Haiku to avoid.

MagicPrompt helps *terse* prompts; ours are already rich, so we now send them **verbatim**. This is the likely root cause of the "weird / generic image" complaints.

### 2. 60s timeout on both fal.ai fetches
They were bare `fetch()` calls with no ceiling — a hung fal.ai response would block the generate/publish path **indefinitely** (the same failure mode we capped on `callZernio` with `AbortSignal.timeout`). Added `signal: AbortSignal.timeout(60000)`. 60s is generous against the typical ~10–20s gen time.

## Scope
The two fal.ai wrappers only. No API / route / schema change. Prompt builders + shared negative prompt untouched. (Left the hero/social generator duplication alone per Brian — social output has been excellent.)

## Test plan
- `node --check server.js` → OK
- `npm run lint` → clean
- Behavior: fal.ai now receives our exact prompt (no MagicPrompt rewrite); a >60s hang aborts instead of blocking forever.

## Rollback
Revert — two-field change in two functions.

## Note
Production-lane (`features`) patch on the **inline** generators. Same fix mirrored to `development`, where this code lives in `src/server/images.js` (PR #225).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_