### PR TITLE
fix(images): disable fal.ai MagicPrompt + add 60s timeout (dev mirror)

### DIFF
--- a/src/server/images.js
+++ b/src/server/images.js
@@ -17,10 +17,18 @@ export async function generateHeroImage(prompt) {
       prompt,
       aspect_ratio: '16:9',
       style: 'realistic',
-      expand_prompt: true,            // Ideogram's MagicPrompt — expands our terse prompt into a richer one before generation
+      // expand_prompt OFF: our prompt is already a carefully brand-voice-tuned
+      // sentence (buildImagePrompt, with explicit anti-AI-stock + don't-take-
+      // brand-name-literally constraints). Ideogram's MagicPrompt rewrites the
+      // prompt and can re-inject the generic/stock aesthetic we deliberately
+      // excluded, so we hand it our prompt verbatim.
+      expand_prompt: false,
       negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
       num_images: 1
-    })
+    }),
+    // Cap a hung fal.ai call. Image gen runs ~10-20s; 60s is generous headroom
+    // while still preventing an indefinite block on the generate/publish path.
+    signal: AbortSignal.timeout(60000)
   });
   if (!falRes.ok) throw new Error(`fal.ai ${falRes.status}: ${await falRes.text()}`);
   const falData = await falRes.json();
@@ -148,10 +156,14 @@ export async function generateSocialImage(prompt) {
       prompt,
       aspect_ratio: '1:1',
       style: 'realistic',
-      expand_prompt: true,
+      // expand_prompt OFF — see generateHeroImage. Our buildSocialImagePrompt
+      // output is already tuned; MagicPrompt would rewrite it and can undo the
+      // anti-stock / single-focal-subject constraints.
+      expand_prompt: false,
       negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
       num_images: 1
-    })
+    }),
+    signal: AbortSignal.timeout(60000) // cap a hung fal.ai call (see generateHeroImage)
   });
   if (!falRes.ok) throw new Error(`fal.ai social ${falRes.status}: ${await falRes.text()}`);
   const falData = await falRes.json();


### PR DESCRIPTION
## What
Dev-side mirror of #226 (`features`). On `development` this code lives in `src/server/images.js` (extracted in #225), so this **stacks on the #225 branch** and patches the module.

> **Base note:** targets `refactor/extract-images` so the diff is just the fix. When #225 merges to `development`, retarget this PR's base to `development` (GitHub may not auto-flip if the branch isn't deleted). **Merge #225 first, then this.**

## The two fixes (same as #226)
1. **`expand_prompt: true` → `false`** — stop Ideogram's MagicPrompt rewriting our carefully brand-voice-tuned prompt and re-injecting the generic AI-stock aesthetic we explicitly excluded. Likely root cause of the "weird image" complaints.
2. **`signal: AbortSignal.timeout(60000)`** on both fal.ai fetches — they were bare `fetch()` with no ceiling; a hung response blocked the publish path indefinitely (same shape as the `callZernio` cap). 60s vs the typical ~10–20s gen time.

Scope: the two fal.ai generators only.

## Test plan
- `node --check server.js` → OK
- `npm run lint` → clean
- `vitest` → **65/65 pass** (prompt-builder tests unaffected; the generators are network wrappers, verified by inspection)

## Rollback
Revert — two-field change in two functions.

Pairs with #226 (features).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_