### PR TITLE
fix(auth): tolerate clock skew on JWT verify + force-fresh token on retry

### DIFF
--- a/server.js
+++ b/server.js
@@ -3205,7 +3205,7 @@ app.post('/api/brain/distill/:brandProfileId', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
     if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
@@ -3332,7 +3332,7 @@ app.post('/api/analytics/extract-patterns/:brandProfileId', async (req, res) => 
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }
@@ -11559,7 +11559,7 @@ app.post('/api/publishing/publish', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }
@@ -12707,7 +12707,7 @@ app.post('/api/analytics/sync/:brandProfileId', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }
@@ -14878,7 +14878,7 @@ async function requireAuth(req, res, next) {
     }
     const token = rawToken;
     if (!clerkJWKS) return res.status(500).json({ error: 'Auth not configured' });
-    const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
+    const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
     req.userId = payload.sub;
     next();
   } catch(e) {
@@ -15395,7 +15395,7 @@ async function softAuth(req, res, next) {
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.split(' ')[1];
       if (clerkJWKS) {
-        const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
+        const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
         req.userId = payload.sub;
       }
     }
@@ -18605,7 +18605,7 @@ app.post('/api/geo/track/:brandProfileId', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }

--- a/src/pages/ComplianceGatePage.tsx
+++ b/src/pages/ComplianceGatePage.tsx
@@ -198,9 +198,11 @@ function ComplianceGateContent() {
     const headers = { ...options.headers as Record<string,string>, 'Authorization': `Bearer ${token}` };
     const res = await fetch(url, { ...options, headers });
     if (res.status === 401) {
-      // Token was stale — wait 500ms for Clerk to refresh then retry once
+      // First token was rejected (typically already-expired at verify time).
+      // Force Clerk to mint a brand-new token — skipCache bypasses the cached
+      // (possibly near-expired) token the plain getToken would hand back.
       await new Promise(r => setTimeout(r, 500));
-      const retryToken = await getToken({ template: 'jwt-template-600' }) || '';
+      const retryToken = await getToken({ template: 'jwt-template-600', skipCache: true }) || '';
       const retryHeaders = { ...options.headers as Record<string,string>, 'Authorization': `Bearer ${retryToken}` };
       return fetch(url, { ...options, headers: retryHeaders });
     }
@@ -398,6 +400,7 @@ function ComplianceGateContent() {
 
   const submitApproval = async (article: Article) => {
     setSubmitLoading(true);
+    setError(''); // clear any stale 401 banner from a prior attempt — the retry may now succeed
     try {
       const edits = Object.entries(editedSections).map(([idx, content]) => ({
         sectionIndex: parseInt(idx),


### PR DESCRIPTION
## Symptom
The Compliance Gate intermittently showed **"Invalid token"** on Approve, then **approved the article anyway after a wait** — and the red error banner lingered next to the green "Article Approved" state.

## Root cause: token **expiry**, not a signing/JWKS problem
The decisive evidence: the **same request path succeeds on retry** with a refreshed token. A wrong signing key or wrong JWKS URL would fail *every* time and could never self-heal. So the Clerk token was occasionally **already-expired at the moment the server verified it**. Two things made it bite:

1. **Backend `jwtVerify` ran with jose's default ZERO clock tolerance.** Any small skew between Clerk's mint time and Render's verify time — or a token Clerk handed back from cache near its expiry boundary — reads as expired → `401 "Invalid token"`.
2. **The frontend 401-retry re-requested `getToken({ template })` without `skipCache`**, so Clerk returned the **same near-expired cached token**. The retry's own comment claimed "forced fresh token" but it wasn't — it only succeeded when Clerk's background timer happened to refresh, hence "approved after waiting."

## Fixes
- **`server.js`** — add `clockTolerance: '30s'` to **all 7** `jwtVerify` call sites (`requireAuth` + the 6 inline verifies). Absorbs skew / boundary expiry. Standard practice; 30s is well within Clerk's token lifetime.
- **`ComplianceGatePage.tsx`** — retry now calls `getToken({ template: 'jwt-template-600', skipCache: true })` to force a brand-new full-life token, so the retry reliably succeeds.
- **`ComplianceGatePage.tsx`** — clear the error banner at submit start so a stale 401 message can't linger next to the success state.

(Aside, unrelated: the decoded "error" you first pasted was a **LinkedIn Insight Tag** click beacon failing — not this bug. Flagged separately; that tag is loaded inside the authed app and capturing click + hashed-email data, worth a look sometime.)

## Test plan
- `node --check server.js` → OK
- `npm run lint` → clean
- `npm run typecheck` → clean (`skipCache` + `setError('')` type-valid)
- Behavior: a slightly-skewed/near-boundary token now verifies; on a hard 401 the retry mints a fresh token instead of replaying the stale one; no lingering error banner on success.

## Rollback
Revert — options-only backend change + two FE lines.

## Note
Production-lane (`features`) fix. The backend half mirrors to `development` as `src/server/auth.js` (`requireAuth`) + the inline verifies; the `ComplianceGatePage.tsx` change is identical on both lanes. I'll open the dev mirror after this.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_