### PR TITLE
fix(auth): tolerate clock skew on JWT verify + force-fresh token on retry (dev mirror)

### DIFF
--- a/server.js
+++ b/server.js
@@ -3058,7 +3058,7 @@ app.post('/api/brain/distill/:brandProfileId', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
     if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
@@ -3185,7 +3185,7 @@ app.post('/api/analytics/extract-patterns/:brandProfileId', async (req, res) => 
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }
@@ -11101,7 +11101,7 @@ app.post('/api/publishing/publish', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }
@@ -12249,7 +12249,7 @@ app.post('/api/analytics/sync/:brandProfileId', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }
@@ -17483,7 +17483,7 @@ app.post('/api/geo/track/:brandProfileId', async (req, res) => {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ error: 'Unauthorized' });
     try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'] });
+      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
       req.userId = payload.sub;
     } catch { return res.status(401).json({ error: 'Invalid token' }); }
   }

--- a/src/pages/ComplianceGatePage.tsx
+++ b/src/pages/ComplianceGatePage.tsx
@@ -198,9 +198,11 @@ function ComplianceGateContent() {
     const headers = { ...options.headers as Record<string,string>, 'Authorization': `Bearer ${token}` };
     const res = await fetch(url, { ...options, headers });
     if (res.status === 401) {
-      // Token was stale — wait 500ms for Clerk to refresh then retry once
+      // First token was rejected (typically already-expired at verify time).
+      // Force Clerk to mint a brand-new token — skipCache bypasses the cached
+      // (possibly near-expired) token the plain getToken would hand back.
       await new Promise(r => setTimeout(r, 500));
-      const retryToken = await getToken({ template: 'jwt-template-600' }) || '';
+      const retryToken = await getToken({ template: 'jwt-template-600', skipCache: true }) || '';
       const retryHeaders = { ...options.headers as Record<string,string>, 'Authorization': `Bearer ${retryToken}` };
       return fetch(url, { ...options, headers: retryHeaders });
     }
@@ -398,6 +400,7 @@ function ComplianceGateContent() {
 
   const submitApproval = async (article: Article) => {
     setSubmitLoading(true);
+    setError(''); // clear any stale 401 banner from a prior attempt — the retry may now succeed
     try {
       const edits = Object.entries(editedSections).map(([idx, content]) => ({
         sectionIndex: parseInt(idx),

--- a/src/server/auth.js
+++ b/src/server/auth.js
@@ -93,7 +93,7 @@ export async function requireAuth(req, res, next) {
     }
     const token = rawToken;
     if (!clerkJWKS) return res.status(500).json({ error: 'Auth not configured' });
-    const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
+    const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
     req.userId = payload.sub;
     next();
   } catch(e) {
@@ -126,7 +126,7 @@ export async function softAuth(req, res, next) {
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.split(' ')[1];
       if (clerkJWKS) {
-        const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'] });
+        const { payload } = await jwtVerify(token, clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
         req.userId = payload.sub;
       }
     }


### PR DESCRIPTION
## What
Dev-side mirror of **#229** (`features`). On `development` the JWT verify sites are split — `requireAuth` (+ `softAuth`/`mcpAuth`) live in `src/server/auth.js` (2), the rest are inline in `server.js` (5) — **7 total**, same as features.

## Root cause (full writeup in #229)
The Compliance Gate intermittently `401`'d **"Invalid token"** then approved the article after a wait. The self-heal on retry proves it's token **expiry**, not signing/JWKS — the Clerk token was occasionally already-expired at verify time, made worse by (1) jose's **zero default clock tolerance** and (2) a frontend retry that **replayed the cached near-expired token** (no `skipCache`).

## Fixes
- **`src/server/auth.js` + `server.js`** — `clockTolerance: '30s'` on all 7 `jwtVerify` call sites.
- **`ComplianceGatePage.tsx`** — retry with `getToken({ template, skipCache: true })` to force a fresh full-life token; clear the error banner at submit start.

## Test plan
- `node --check server.js` → OK
- `npm run lint` → clean
- `npm run typecheck` → clean
- `vitest` → **65/65 pass**

## Rollback
Revert — options-only backend change + two FE lines.

Pairs with #229 (features).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_