### PR TITLE
refactor(server): move quickStartTruncate + stripScaffoldingArtifacts → text.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ import { jwtVerify } from 'jose';
 import { pool } from './src/server/db.js';
 import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
-import { truncateStr, truncateAtSentence, stripSocialMarkdown } from './src/server/text.js';
+import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripScaffoldingArtifacts } from './src/server/text.js';
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
 import { callZernio, zernioPublish, getOrCreateZernioProfile, zernioGuard } from './src/server/zernio.js';
 import { forgeScrape, getBrandPageContent, discoverSubpages, _forgeScrapeRateLimited, FORGE_SCRAPE_RATE_PER_MIN } from './src/server/scrape.js';
@@ -4011,10 +4011,7 @@ app.post('/api/domain/check', async (req, res) => {
 // and so /app/context-hub re-analyze never tries to re-scrape a non-existent
 // site. Anonymous-session semantics (24h expiry, onboard_session_id) match the
 // URL-based flow exactly so Clerk signup can later claim these rows.
-function quickStartTruncate(value, maxLength) {
-  if (typeof value !== 'string') return '';
-  return value.length > maxLength ? value.slice(0, maxLength).trim() + '…' : value;
-}
+// quickStartTruncate moved to src/server/text.js (imported at top).
 
 async function handleQuickStartSynthesis(req, res) {
   const startTime = Date.now();
@@ -5128,38 +5125,7 @@ function normalizeGeoData(briefData, topicalMap, geoOpportunities, entitySchema,
 // ── GEO Strategist API (Stage 2) ──────────────────────────────────────────────
 
 // Extracts the first complete JSON object or array from a string — handles trailing text/markdown
-// ── Strip LLM scaffolding artifacts from article section bodies ──────────────
-// Enrichment briefs give the writer bracketed placeholders like "[SME Hook: ...]",
-// "[CTA: ...]", "[Author Quote: ...]" that the model is supposed to expand into
-// prose or drop. It sometimes copies them verbatim, and they leak past human
-// compliance review. This is the final safety net — called at every article
-// write path (content-gen, campaign, compliance approve, content-import).
-function stripScaffoldingArtifacts(article) {
-  if (!article || typeof article !== 'object' || !Array.isArray(article.sections)) return article;
-
-  // Inline: keyword-gated bracketed instructions (safe — won't nuke legit refs like [1] or [Appendix A])
-  const INLINE_RX = /\[(?:SME[\s-]?Hook|Author[\s-]?(?:Quote|Citation|Bio)|Writer[\s-]?Note|(?:Note|Editor[\s-]?Note)[\s-]?to[\s-]?(?:writer|editor|self)?|Insert|TODO|Placeholder|NEEDS[\s-]?CITATION|CITATION|SOURCE|CTA|Pull[\s-]?Quote|Hook|Quote|Link|Image|Tip|Callout|Stat|Fact[\s-]?Check)\s*[:\s][^\]]*\]/gi;
-  // Standalone paragraph: entire paragraph is just a bracketed instruction with a colon
-  // (e.g. "[Something: details]" alone on its own line — the scaffolding signature)
-  const STANDALONE_COLON_BRACKET_RX = /^\s*\[[^\]]*:[^\]]*\]\s*$/;
-
-  const cleanBody = (text) => {
-    if (!text || typeof text !== 'string') return text;
-    const parts = text.split(/\n\s*\n/);
-    const filtered = parts
-      .map(p => p.replace(INLINE_RX, '').replace(/[ \t]{2,}/g, ' ').trim())
-      .filter(p => p && !STANDALONE_COLON_BRACKET_RX.test(p));
-    return filtered.join('\n\n').trim();
-  };
-
-  article.sections = article.sections.map(s => {
-    const updated = { ...s };
-    if (typeof s.body === 'string') updated.body = cleanBody(s.body);
-    if (typeof s.content === 'string') updated.content = cleanBody(s.content);
-    return updated;
-  });
-  return article;
-}
+// stripScaffoldingArtifacts moved to src/server/text.js (imported at top).
 
 // ── Date-grounding for LLM prompts ─────────────────────────────────────
 // Every prompt that generates user-facing content MUST prepend this block.

--- a/src/server/text.js
+++ b/src/server/text.js
@@ -36,3 +36,47 @@ export function stripSocialMarkdown(text) {
     // __bold__ -> bold (less common; Claude uses it occasionally)
     .replace(/__([^_\n]+?)__/g, '$1');
 }
+
+// Hard-truncate to maxLength, appending an ellipsis when it cuts. Non-string
+// input returns ''. (Distinct from truncateStr — that one has no ellipsis —
+// and truncateAtSentence, which prefers a boundary.) Used across the Quick
+// Start synthesis path.
+export function quickStartTruncate(value, maxLength) {
+  if (typeof value !== 'string') return '';
+  return value.length > maxLength ? value.slice(0, maxLength).trim() + '…' : value;
+}
+
+// Strip LLM scaffolding artifacts from article section bodies.
+// Enrichment briefs give the writer bracketed placeholders like "[SME Hook: ...]",
+// "[CTA: ...]", "[Author Quote: ...]" that the model is supposed to expand into
+// prose or drop. It sometimes copies them verbatim, and they leak past human
+// compliance review. This is the final safety net — called at every article
+// write path (content-gen, campaign, compliance approve, content-import).
+// Mutates and returns the passed article (sections rebuilt); non-article input
+// is returned untouched.
+export function stripScaffoldingArtifacts(article) {
+  if (!article || typeof article !== 'object' || !Array.isArray(article.sections)) return article;
+
+  // Inline: keyword-gated bracketed instructions (safe — won't nuke legit refs like [1] or [Appendix A])
+  const INLINE_RX = /\[(?:SME[\s-]?Hook|Author[\s-]?(?:Quote|Citation|Bio)|Writer[\s-]?Note|(?:Note|Editor[\s-]?Note)[\s-]?to[\s-]?(?:writer|editor|self)?|Insert|TODO|Placeholder|NEEDS[\s-]?CITATION|CITATION|SOURCE|CTA|Pull[\s-]?Quote|Hook|Quote|Link|Image|Tip|Callout|Stat|Fact[\s-]?Check)\s*[:\s][^\]]*\]/gi;
+  // Standalone paragraph: entire paragraph is just a bracketed instruction with a colon
+  // (e.g. "[Something: details]" alone on its own line — the scaffolding signature)
+  const STANDALONE_COLON_BRACKET_RX = /^\s*\[[^\]]*:[^\]]*\]\s*$/;
+
+  const cleanBody = (text) => {
+    if (!text || typeof text !== 'string') return text;
+    const parts = text.split(/\n\s*\n/);
+    const filtered = parts
+      .map(p => p.replace(INLINE_RX, '').replace(/[ \t]{2,}/g, ' ').trim())
+      .filter(p => p && !STANDALONE_COLON_BRACKET_RX.test(p));
+    return filtered.join('\n\n').trim();
+  };
+
+  article.sections = article.sections.map(s => {
+    const updated = { ...s };
+    if (typeof s.body === 'string') updated.body = cleanBody(s.body);
+    if (typeof s.content === 'string') updated.content = cleanBody(s.content);
+    return updated;
+  });
+  return article;
+}

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { truncateStr, truncateAtSentence, stripSocialMarkdown } from '../src/server/text.js';
+import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripScaffoldingArtifacts } from '../src/server/text.js';
 
 describe('truncateStr', () => {
   it('returns null for null/undefined', () => {
@@ -43,5 +43,44 @@ describe('stripSocialMarkdown', () => {
   });
   it('passes non-strings through unchanged', () => {
     expect(stripSocialMarkdown(null)).toBeNull();
+  });
+});
+
+describe('quickStartTruncate', () => {
+  it('returns empty string for non-strings', () => {
+    expect(quickStartTruncate(123, 5)).toBe('');
+    expect(quickStartTruncate(null, 5)).toBe('');
+  });
+  it('leaves short strings unchanged (no ellipsis)', () => {
+    expect(quickStartTruncate('hi', 5)).toBe('hi');
+  });
+  it('slices and appends an ellipsis when over the limit', () => {
+    expect(quickStartTruncate('hello world', 5)).toBe('hello…');
+  });
+  it('trims trailing whitespace before the ellipsis', () => {
+    expect(quickStartTruncate('hello     world', 8)).toBe('hello…');
+  });
+});
+
+describe('stripScaffoldingArtifacts', () => {
+  it('returns non-article input untouched', () => {
+    expect(stripScaffoldingArtifacts(null)).toBeNull();
+    expect(stripScaffoldingArtifacts({ no: 'sections' })).toEqual({ no: 'sections' });
+  });
+  it('removes inline bracketed scaffolding but keeps legit refs like [1]', () => {
+    const article = { sections: [{ body: 'Real prose [CTA: sign up now] and a citation [1].' }] };
+    const out = stripScaffoldingArtifacts(article);
+    expect(out.sections[0].body).toContain('Real prose');
+    expect(out.sections[0].body).toContain('[1]');
+    expect(out.sections[0].body).not.toContain('CTA');
+  });
+  it('drops standalone bracketed-instruction paragraphs', () => {
+    const article = { sections: [{ body: 'Keep this.\n\n[SME Hook: add an anecdote here]\n\nKeep this too.' }] };
+    const out = stripScaffoldingArtifacts(article);
+    expect(out.sections[0].body).toBe('Keep this.\n\nKeep this too.');
+  });
+  it('cleans both body and content fields', () => {
+    const article = { sections: [{ content: 'Hello [TODO: finish] world' }] };
+    expect(stripScaffoldingArtifacts(article).sections[0].content).toBe('Hello world');
   });
 });


### PR DESCRIPTION
## Why
Continues the `server.js` dismemberment. Rather than spawn a new module, this **grows the existing `text.js`** with two content/text-cleanup helpers that sit naturally next to `truncateStr` / `truncateAtSentence` / `stripSocialMarkdown` — consolidating helpers instead of adding module sprawl.

## What
- **`quickStartTruncate`** (18 refs) — hard slice + ellipsis. Distinct from `truncateStr` (no ellipsis) and `truncateAtSentence` (boundary-aware), so it's a sibling, not a dup.
- **`stripScaffoldingArtifacts`** (5 refs) — strips leaked LLM bracket placeholders (`[SME Hook: ...]`, `[CTA: ...]`) from article section bodies at every write path. Joins the `strip*` family.
- `src/server/text.js` gains both exports (moved verbatim, comments intact); `server.js` imports them; inline defs → breadcrumbs.

Pure move, no logic touched.

## Test plan
- `node --check server.js` → OK
- `npm run lint` (no-undef) → clean — confirms all 23 call sites resolve to the import
- route-inventory guard → **PASS** (snapshot unchanged)
- `vitest` → **73/73 pass** (+8 new: `quickStartTruncate` non-string/short/ellipsis/trim; `stripScaffoldingArtifacts` non-article passthrough, inline-strip keeping `[1]`, standalone-paragraph drop, content+body fields)

## Rollback
Revert — pure copy, restores the inline defs exactly.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_