### PR TITLE
refactor(server): extract last thin leaves → geo.js / ghost.js / promo.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,6 +24,9 @@ import { buildXOAuthHeader, uploadXMedia, refreshXOAuth2Token } from './src/serv
 import { generateHeroImage, buildImagePrompt, buildSocialImagePrompt, generateSocialImage } from './src/server/images.js';
 import { MARKETING_META, renderMarketingPage } from './src/server/marketing.js';
 import { findCitationSources } from './src/server/citations.js';
+import { normalizeGeoData } from './src/server/geo.js';
+import { buildGhostJWT } from './src/server/ghost.js';
+import { PROMO_CODES } from './src/server/promo.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -4916,56 +4919,7 @@ app.get('/api/email-campaign/brief-templates/:brandProfileId', requireAuth, asyn
 });
 
 // ── GEO data normalizer — shared by fresh + cached responses ─────────────────
-function normalizeGeoData(briefData, topicalMap, geoOpportunities, entitySchema, profile) {
-  const gaps = (topicalMap && topicalMap.gapsByCluster) || [];
-  if (gaps.length > 0) console.log('[GEO] normalizer gaps[0] RAW:', JSON.stringify(gaps[0]));
-  const topicalAuthorityMap = gaps.map(g => {
-    const score = g.geoCitationScore || g.citationProbability || g.score || g.geoScore || g.probability || 0;
-    return {
-      topic: g.topic || g.cluster || g.name || g.title || 'Unknown',
-      coverage: g.rationale || g.description || g.reason || g.owner || g.gap || '',
-      citationProbability: score,
-      priority: score >= 70 ? 'high' : score >= 40 ? 'medium' : 'low'
-    };
-  });
-
-  const topicMap = {};
-  (geoOpportunities || []).forEach(o => {
-    const t = o.topic || 'Unknown';
-    if (!topicMap[t]) topicMap[t] = { topic: t, chatgpt: 0, perplexity: 0, aiOverviews: 0, gemini: 0, quickWin: o.quickWin || false };
-    const p = (o.platform || '').toLowerCase().replace(/\s/g, '');
-    if (p.includes('chatgpt') || p.includes('openai')) topicMap[t].chatgpt = o.score || 0;
-    else if (p.includes('perplexity')) topicMap[t].perplexity = o.score || 0;
-    else if (p.includes('overview') || p.includes('google')) topicMap[t].aiOverviews = o.score || 0;
-    else if (p.includes('gemini')) topicMap[t].gemini = o.score || 0;
-    if (o.quickWin) topicMap[t].quickWin = true;
-  });
-  const geoOpportunitiesNorm = Object.values(topicMap);
-
-  const entitySchemaMap = (entitySchema || []).map(e => ({
-    entity: e.entity || '',
-    schemaType: Array.isArray(e.schemaTypes) ? e.schemaTypes[0] : (e.schemaType || 'Article'),
-    competitorCited: e.competitorCiting || e.competitorCited || false,
-    recommendation: e.rationale || e.recommendation || ''
-  }));
-
-  const h2sRaw = briefData.h2s || [];
-  const geoBrief = {
-    title: briefData.titleTag || briefData.title || briefData.targetTopic || (profile && profile.brand_name) || '',
-    h1: briefData.h1 || briefData.targetTopic || '',
-    h2s: h2sRaw.map(h => typeof h === 'string' ? h : h.heading || h.h2 || ''),
-    faqItems: (briefData.faqStructure || briefData.faqItems || []).map(f => ({
-      q: f.question || f.q || '',
-      a: f.answerDirection || f.answer || f.a || ''
-    })),
-    geoAnchors: briefData.geoAnchors || [],
-    estimatedCitationLift: briefData.geoScorecard
-      ? `+${Math.round((briefData.geoScorecard.currentReadiness || 0) * 0.4)}% in 90 days`
-      : '+15–30% in 90 days'
-  };
-
-  return { topicalAuthorityMap, geoOpportunities: geoOpportunitiesNorm, entitySchemaMap, geoBrief };
-}
+// normalizeGeoData moved to src/server/geo.js (imported at top).
 
 // ── GEO Strategist API (Stage 2) ──────────────────────────────────────────────
 
@@ -11953,16 +11907,7 @@ ${canonicalNote}`,
 
 // POST /api/analytics/sync/:brandProfileId — pull stats from channels, upsert into content_analytics
 // Ghost Admin JWT builder
-function buildGhostJWT(apiKey) {
-  const [keyId, secret] = apiKey.split(':');
-  const secretBytes = Buffer.from(secret, 'hex');
-  const now = Math.floor(Date.now() / 1000);
-  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT', kid: keyId })).toString('base64url');
-  const payload = Buffer.from(JSON.stringify({ iat: now, exp: now + 300, aud: '/admin/' })).toString('base64url');
-  const sigInput = `${header}.${payload}`;
-  const sig = createHmac('sha256', secretBytes).update(sigInput).digest('base64url');
-  return `${sigInput}.${sig}`;
-}
+// buildGhostJWT moved to src/server/ghost.js (imported at top).
 
 app.post('/api/analytics/sync/:brandProfileId', async (req, res) => {
   const { brandProfileId } = req.params;
@@ -14869,12 +14814,7 @@ pool.query(`CREATE TABLE IF NOT EXISTS promo_redemptions (
 )`).catch(() => {});
 
 // Promo codes stored server-side — never expose to client
-const PROMO_CODES = new Map([
-  ['FORGEFRIEND',   { discount: 100, description: 'Friend of Forge' }],
-  ['EARLYBIRD',     { discount: 100, description: 'Early Access' }],
-  ['SANDBOX100',    { discount: 100, description: 'Sandbox Group Internal' }],
-  ['NANGO',         { discount: 100, description: 'Nango Partnership' }],
-]);
+// PROMO_CODES moved to src/server/promo.js (imported at top).
 
 // POST /api/promo/validate — validate a promo code (unlimited use)
 app.post('/api/promo/validate', softAuth, async (req, res) => {

--- a/src/server/geo.js
+++ b/src/server/geo.js
@@ -1,0 +1,55 @@
+// GEO data normalization, extracted from server.js during the decomposition.
+// normalizeGeoData reshapes the GEO Strategist's raw brief / topical map / GEO
+// opportunities / entity schema into the normalized structure the API returns.
+// Pure transform — no DB/network.
+
+export function normalizeGeoData(briefData, topicalMap, geoOpportunities, entitySchema, profile) {
+  const gaps = (topicalMap && topicalMap.gapsByCluster) || [];
+  if (gaps.length > 0) console.log('[GEO] normalizer gaps[0] RAW:', JSON.stringify(gaps[0]));
+  const topicalAuthorityMap = gaps.map(g => {
+    const score = g.geoCitationScore || g.citationProbability || g.score || g.geoScore || g.probability || 0;
+    return {
+      topic: g.topic || g.cluster || g.name || g.title || 'Unknown',
+      coverage: g.rationale || g.description || g.reason || g.owner || g.gap || '',
+      citationProbability: score,
+      priority: score >= 70 ? 'high' : score >= 40 ? 'medium' : 'low'
+    };
+  });
+
+  const topicMap = {};
+  (geoOpportunities || []).forEach(o => {
+    const t = o.topic || 'Unknown';
+    if (!topicMap[t]) topicMap[t] = { topic: t, chatgpt: 0, perplexity: 0, aiOverviews: 0, gemini: 0, quickWin: o.quickWin || false };
+    const p = (o.platform || '').toLowerCase().replace(/\s/g, '');
+    if (p.includes('chatgpt') || p.includes('openai')) topicMap[t].chatgpt = o.score || 0;
+    else if (p.includes('perplexity')) topicMap[t].perplexity = o.score || 0;
+    else if (p.includes('overview') || p.includes('google')) topicMap[t].aiOverviews = o.score || 0;
+    else if (p.includes('gemini')) topicMap[t].gemini = o.score || 0;
+    if (o.quickWin) topicMap[t].quickWin = true;
+  });
+  const geoOpportunitiesNorm = Object.values(topicMap);
+
+  const entitySchemaMap = (entitySchema || []).map(e => ({
+    entity: e.entity || '',
+    schemaType: Array.isArray(e.schemaTypes) ? e.schemaTypes[0] : (e.schemaType || 'Article'),
+    competitorCited: e.competitorCiting || e.competitorCited || false,
+    recommendation: e.rationale || e.recommendation || ''
+  }));
+
+  const h2sRaw = briefData.h2s || [];
+  const geoBrief = {
+    title: briefData.titleTag || briefData.title || briefData.targetTopic || (profile && profile.brand_name) || '',
+    h1: briefData.h1 || briefData.targetTopic || '',
+    h2s: h2sRaw.map(h => typeof h === 'string' ? h : h.heading || h.h2 || ''),
+    faqItems: (briefData.faqStructure || briefData.faqItems || []).map(f => ({
+      q: f.question || f.q || '',
+      a: f.answerDirection || f.answer || f.a || ''
+    })),
+    geoAnchors: briefData.geoAnchors || [],
+    estimatedCitationLift: briefData.geoScorecard
+      ? `+${Math.round((briefData.geoScorecard.currentReadiness || 0) * 0.4)}% in 90 days`
+      : '+15–30% in 90 days'
+  };
+
+  return { topicalAuthorityMap, geoOpportunities: geoOpportunitiesNorm, entitySchemaMap, geoBrief };
+}

--- a/src/server/ghost.js
+++ b/src/server/ghost.js
@@ -1,0 +1,16 @@
+// Ghost CMS auth helper, extracted from server.js during the decomposition.
+// buildGhostJWT mints a short-lived (5-min) HS256 admin JWT from a Ghost Admin
+// API key ("keyId:hexSecret"), per Ghost's /admin/ token scheme. Used by the
+// Ghost publish handler + analytics sync.
+import { createHmac } from 'crypto';
+
+export function buildGhostJWT(apiKey) {
+  const [keyId, secret] = apiKey.split(':');
+  const secretBytes = Buffer.from(secret, 'hex');
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT', kid: keyId })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ iat: now, exp: now + 300, aud: '/admin/' })).toString('base64url');
+  const sigInput = `${header}.${payload}`;
+  const sig = createHmac('sha256', secretBytes).update(sigInput).digest('base64url');
+  return `${sigInput}.${sig}`;
+}

--- a/src/server/promo.js
+++ b/src/server/promo.js
@@ -1,0 +1,9 @@
+// Promo codes, extracted from server.js during the decomposition. Static map
+// of code -> { discount, description }, consumed by POST /api/promo/validate.
+// All current codes are 100% (unlimited-use comps/partnerships).
+export const PROMO_CODES = new Map([
+  ['FORGEFRIEND',   { discount: 100, description: 'Friend of Forge' }],
+  ['EARLYBIRD',     { discount: 100, description: 'Early Access' }],
+  ['SANDBOX100',    { discount: 100, description: 'Sandbox Group Internal' }],
+  ['NANGO',         { discount: 100, description: 'Nango Partnership' }],
+]);

--- a/test/geo.test.js
+++ b/test/geo.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeGeoData } from '../src/server/geo.js';
+
+describe('normalizeGeoData', () => {
+  it('buckets topical-authority priority by score and reads many score aliases', () => {
+    const out = normalizeGeoData(
+      {},
+      { gapsByCluster: [
+        { topic: 'A', geoCitationScore: 80 },
+        { cluster: 'B', score: 50 },
+        { name: 'C', probability: 10 },
+      ] },
+      [], [], null,
+    );
+    expect(out.topicalAuthorityMap.map(t => [t.topic, t.priority])).toEqual([
+      ['A', 'high'], ['B', 'medium'], ['C', 'low'],
+    ]);
+  });
+
+  it('maps GEO opportunities onto per-platform columns', () => {
+    const out = normalizeGeoData({}, {}, [
+      { topic: 'T', platform: 'ChatGPT', score: 7 },
+      { topic: 'T', platform: 'Perplexity', score: 9, quickWin: true },
+      { topic: 'T', platform: 'Google AI Overviews', score: 5 },
+    ], [], null);
+    expect(out.geoOpportunities).toEqual([
+      { topic: 'T', chatgpt: 7, perplexity: 9, aiOverviews: 5, gemini: 0, quickWin: true },
+    ]);
+  });
+
+  it('builds geoBrief with title fallback to brand_name and the default lift', () => {
+    const out = normalizeGeoData({ h2s: ['One', { heading: 'Two' }] }, {}, [], [], { brand_name: 'Acme' });
+    expect(out.geoBrief.title).toBe('Acme');
+    expect(out.geoBrief.h2s).toEqual(['One', 'Two']);
+    expect(out.geoBrief.estimatedCitationLift).toContain('90 days');
+  });
+});

--- a/test/ghost.test.js
+++ b/test/ghost.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { buildGhostJWT } from '../src/server/ghost.js';
+
+const decode = (seg) => JSON.parse(Buffer.from(seg, 'base64url').toString('utf8'));
+
+describe('buildGhostJWT', () => {
+  // "keyId:hexSecret" — secret is hex; use a valid hex string.
+  const jwt = buildGhostJWT('64ef…id:deadbeefcafe');
+
+  it('returns three base64url segments', () => {
+    expect(jwt.split('.')).toHaveLength(3);
+  });
+
+  it('header is HS256 with the kid from the key id', () => {
+    const header = decode(jwt.split('.')[0]);
+    expect(header).toMatchObject({ alg: 'HS256', typ: 'JWT', kid: '64ef…id' });
+  });
+
+  it('payload targets /admin/ with a 5-minute expiry', () => {
+    const payload = decode(jwt.split('.')[1]);
+    expect(payload.aud).toBe('/admin/');
+    expect(payload.exp - payload.iat).toBe(300);
+  });
+});

--- a/test/promo.test.js
+++ b/test/promo.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { PROMO_CODES } from '../src/server/promo.js';
+
+describe('PROMO_CODES', () => {
+  it('is a Map of known comp codes', () => {
+    expect(PROMO_CODES).toBeInstanceOf(Map);
+    expect(PROMO_CODES.get('FORGEFRIEND')).toEqual({ discount: 100, description: 'Friend of Forge' });
+    expect(PROMO_CODES.get('NANGO').discount).toBe(100);
+  });
+  it('returns undefined for unknown codes', () => {
+    expect(PROMO_CODES.get('NOPE')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why
Finishes the clean-leaf phase of the `server.js` decomposition before the route-group surgery. These three were the last standalone single-use helpers with no coupling to the rest of the monolith — knocking them out in one PR rather than three near-empty ones.

## What
Three new modules, each exporting its one symbol (moved verbatim):
- **`src/server/geo.js`** — `normalizeGeoData` (GEO Strategist data reshape; pure transform)
- **`src/server/ghost.js`** — `buildGhostJWT` (Ghost Admin HS256 JWT mint; imports `createHmac` from crypto)
- **`src/server/promo.js`** — `PROMO_CODES` (static comp-code map)

`server.js` imports all three; inline defs → breadcrumbs. Pure move, no logic touched.

## Test plan
- `node --check server.js` → OK
- `npm run lint` (no-undef gate) → clean — all three resolve, no orphaned references
- route-inventory guard → **PASS** (snapshot unchanged)
- `vitest` → **86/86 pass** (+8 new: `normalizeGeoData` priority bucketing / platform mapping / brief fallbacks; `buildGhostJWT` segment + header + payload shape; `PROMO_CODES` lookup)

## Rollback
Revert — pure copies, restore the inline defs exactly.

## Note
With these, the clean leaves are exhausted (~18 modules out). Next is the **route-group surgery** — which leads with teaching the route-inventory guard mount-prefix resolution so full paths still verify behind `app.use('/prefix', router)`.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_