### PR TITLE
test(route-guard): teach the inventory guard mount-prefix resolution

### DIFF
--- a/test/route-inventory.mjs
+++ b/test/route-inventory.mjs
@@ -1,14 +1,24 @@
 // Route-inventory helper for the decomposition safety net.
 //
-// Statically scans the backend source for Express route registrations and
-// returns a sorted `"METHOD /path"` list. No app boot, no DB, no env — pure
-// text scan, so it runs anywhere (CI, local, this harness).
+// Statically scans the backend for Express route registrations and returns a
+// sorted `"METHOD /path"` list. No app boot, no DB, no env — pure text scan, so
+// it runs anywhere (CI, local, this harness).
 //
-// As server.js is decomposed into src/server/*.js route modules, ADD each new
-// module to BACKEND_FILES. If a module is mounted under a prefix via
-// app.use('/prefix', factory(...)), extend collectRoutes() to prepend that
-// prefix so the full path stays identical across the move. Keeping the snapshot
-// green is the contract: an extraction must not add, drop, or rename a route.
+// MOUNT-PREFIX RESOLUTION (added for the route-group phase): as route handlers
+// move out of server.js into router modules mounted via
+// `app.use('/prefix', router)`, a router's `router.get('/sub')` must still show
+// up in the inventory as `GET /prefix/sub` — not `GET /sub` — so the snapshot
+// stays byte-identical across the move. collectRoutes() therefore:
+//   1. emits every top-level `app.<method>(...)` in server.js as-is, then
+//   2. finds each `app.use('<prefix>', <ident>)` whose <ident> is a default/
+//      named import of a local module, reads that module, and emits its
+//      `<routerVar>.<method>('<sub>')` registrations as `<prefix><sub>`.
+// Until the first router exists this is a no-op (server.js has no path-mounts),
+// so today's output is unchanged.
+//
+// Keeping the snapshot green is the contract: a pure move (helper OR route) must
+// not add, drop, or rename a route. After an INTENTIONAL route change, run
+// `npm run routes:snapshot` and commit the diff.
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -17,17 +27,81 @@ import { dirname, resolve, join } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 
-export const BACKEND_FILES = ['server.js'];
+const METHODS = 'get|post|put|patch|delete|all';
 
-export const ROUTE_RE = /\b(?:app|router)\.(get|post|put|patch|delete|all)\(\s*(['"`])([^'"`]+)\2/g;
+// Match `<obj>.<method>('<path>'` for the given object identifiers.
+function routesFor(src, objectNames) {
+  const names = objectNames.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  const re = new RegExp(`\\b(?:${names})\\.(${METHODS})\\(\\s*(['"\`])([^'"\`]+)\\2`, 'g');
+  const out = [];
+  for (const m of src.matchAll(re)) out.push({ method: m[1].toUpperCase(), path: m[3] });
+  return out;
+}
 
-export function collectRoutes() {
-  const routes = [];
-  for (const rel of BACKEND_FILES) {
-    const src = readFileSync(join(ROOT, rel), 'utf8');
-    for (const m of src.matchAll(ROUTE_RE)) {
-      routes.push(`${m[1].toUpperCase()} ${m[3]}`);
+// Join a mount prefix and a sub-path into one normalized path:
+// ('/api/x', '/sub') -> '/api/x/sub', ('/api/x', '/') -> '/api/x', collapse '//'.
+export function joinPath(prefix, sub) {
+  const joined = `${prefix}${sub}`.replace(/\/{2,}/g, '/');
+  return joined.length > 1 ? joined.replace(/\/$/, '') : joined;
+}
+
+// Map imported identifiers -> their relative module path.
+// Handles `import X from './a.js'` and `import { X, Y as Z } from './b.js'`.
+export function parseImports(src) {
+  const map = {};
+  for (const m of src.matchAll(/import\s+(\w+)\s+from\s+['"](\.[^'"]+)['"]/g)) map[m[1]] = m[2];
+  for (const m of src.matchAll(/import\s*\{([^}]+)\}\s*from\s+['"](\.[^'"]+)['"]/g)) {
+    for (const part of m[1].split(',')) {
+      const name = part.trim().split(/\s+as\s+/).pop().trim();
+      if (name) map[name] = m[2];
     }
   }
+  return map;
+}
+
+// Find `app.use('<prefix>', [middleware, ...] <ident>)` mounts. Captures the
+// LAST bare identifier in the arg list (the router; any middleware precede it).
+export function parseMounts(src) {
+  const mounts = [];
+  for (const m of src.matchAll(/app\.use\(\s*(['"`])([^'"`]+)\1\s*,\s*([^)]*)\)/g)) {
+    const prefix = m[2];
+    const idents = (m[3].match(/[A-Za-z_$][\w$]*/g) || []);
+    const last = idents[idents.length - 1];
+    if (last) mounts.push({ prefix, ident: last });
+  }
+  return mounts;
+}
+
+// The router variable name in a module (`const router = express.Router()`),
+// defaulting to 'router'.
+function routerVar(src) {
+  const m = src.match(/(?:const|let|var)\s+(\w+)\s*=\s*express\.Router\(\)/);
+  return m ? m[1] : 'router';
+}
+
+// Pure core: compute the sorted route inventory from in-memory sources.
+// `readModule(relPath)` returns a module's source (or null if unreadable).
+// Exported so tests can exercise mount-prefixing without touching the repo.
+export function resolveRoutes(serverSrc, readModule) {
+  const routes = [];
+  // 1. top-level routes registered directly on the app
+  for (const r of routesFor(serverSrc, ['app'])) routes.push(`${r.method} ${r.path}`);
+  // 2. mounted routers -> prefix each sub-path
+  const imports = parseImports(serverSrc);
+  for (const { prefix, ident } of parseMounts(serverSrc)) {
+    const relPath = imports[ident];
+    if (!relPath) continue;                 // not an imported module (inline middleware, etc.)
+    const routerSrc = readModule(relPath);
+    if (!routerSrc) continue;               // unreadable / not a real file — skip
+    const rv = routerVar(routerSrc);
+    for (const r of routesFor(routerSrc, [rv])) routes.push(`${r.method} ${joinPath(prefix, r.path)}`);
+  }
   return routes.sort();
+}
+
+export function collectRoutes() {
+  const serverSrc = readFileSync(join(ROOT, 'server.js'), 'utf8');
+  return resolveRoutes(serverSrc, (rel) => {
+    try { return readFileSync(join(ROOT, rel), 'utf8'); } catch { return null; }
+  });
 }

--- a/test/route-mounts.test.js
+++ b/test/route-mounts.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRoutes, joinPath, parseImports, parseMounts } from './route-inventory.mjs';
+
+describe('joinPath', () => {
+  it('joins prefix + sub and collapses slashes', () => {
+    expect(joinPath('/api/x', '/sub')).toBe('/api/x/sub');
+    expect(joinPath('/api/x', '/')).toBe('/api/x');      // index route -> the prefix itself
+    expect(joinPath('/api/x/', '/sub')).toBe('/api/x/sub');
+    expect(joinPath('/', '/')).toBe('/');
+  });
+});
+
+describe('parseImports / parseMounts', () => {
+  it('maps default + named imports to module paths', () => {
+    const m = parseImports(`
+      import compliance from './src/server/routes/compliance.js';
+      import { zernio as zRouter, other } from './src/server/routes/zernio.js';
+    `);
+    expect(m.compliance).toBe('./src/server/routes/compliance.js');
+    expect(m.zRouter).toBe('./src/server/routes/zernio.js');
+    expect(m.other).toBe('./src/server/routes/zernio.js');
+  });
+
+  it('captures the router identifier even with middleware in front', () => {
+    expect(parseMounts(`app.use('/api/compliance', requireAuth, compliance);`))
+      .toEqual([{ prefix: '/api/compliance', ident: 'compliance' }]);
+  });
+});
+
+describe('resolveRoutes — mount-prefix resolution', () => {
+  it('prefixes a mounted router\'s sub-paths with its mount path', () => {
+    const server = `
+      import compliance from './src/server/routes/compliance.js';
+      app.get('/health', (req, res) => {});
+      app.use('/api/compliance', requireAuth, compliance);
+    `;
+    const router = `
+      const router = express.Router();
+      router.post('/approve', h);
+      router.get('/find-sources', h);
+      export default router;
+    `;
+    const out = resolveRoutes(server, (rel) => rel.endsWith('compliance.js') ? router : null);
+    expect(out).toEqual([
+      'GET /api/compliance/find-sources',
+      'GET /health',
+      'POST /api/compliance/approve',
+    ]);
+  });
+
+  it('honors a non-default router variable name', () => {
+    const server = `
+      import { zRouter } from './src/server/routes/zernio.js';
+      app.use('/api/zernio', zRouter);
+    `;
+    const router = `const zernioRtr = express.Router(); zernioRtr.get('/status', h);`;
+    expect(resolveRoutes(server, () => router)).toEqual(['GET /api/zernio/status']);
+  });
+
+  it('ignores path-mounts whose identifier is not an imported module', () => {
+    // express.static / inline middleware must NOT be treated as routers.
+    const server = `app.use('/assets', express.static('dist')); app.get('/x', h);`;
+    expect(resolveRoutes(server, () => 'SHOULD_NOT_BE_READ')).toEqual(['GET /x']);
+  });
+
+  it('maps a router index route (/) to the bare prefix', () => {
+    const server = `import api from './src/server/routes/api.js'; app.use('/api', api);`;
+    const router = `const router = express.Router(); router.get('/', h);`;
+    expect(resolveRoutes(server, () => router)).toEqual(['GET /api']);
+  });
+});


### PR DESCRIPTION
## Why
**Safety-net-first** step for the route-group phase. Before any handler moves behind `app.use('/prefix', router)`, the route-inventory guard must keep reporting **full** paths — otherwise a router's `router.get('/sub')` would register as `GET /sub` instead of `GET /prefix/sub` and break the snapshot on what is supposed to be a pure move. This PR teaches the guard mount-prefix resolution; no routes move yet.

## What
`collectRoutes()` now:
1. emits every top-level `app.<method>(...)` in `server.js` as before, then
2. resolves each `app.use('<prefix>', <ident>)` whose `<ident>` is a local import, reads that module, and emits its `<routerVar>.<method>('<sub>')` registrations as `<prefix><sub>` (slash-normalized; an index route `'/'` → the bare prefix).

**Until the first router exists this is a no-op** — `server.js` has no path-mounts and no `router.` calls today, so `collectRoutes()` still returns the **identical 213-route snapshot** (verified).

Refactor: the pure core is `resolveRoutes(serverSrc, readModule)` with exported helpers (`joinPath` / `parseImports` / `parseMounts`), so mount-prefixing is unit-testable without touching the repo. `collectRoutes()` is now a thin fs wrapper.

**False-positive guards (tested):** path-mounts whose identifier isn't an imported module (`express.static`, inline middleware) are ignored; a non-default router variable name is honored.

## Test plan
- `collectRoutes()` on the real repo → **213** (snapshot test green, unchanged)
- `npm run lint` → clean
- `vitest` → **93/93** (+7 new mount-resolution tests: joinPath, import/mount parsing, prefixing, non-default router var, static/non-import ignore, index-route)

## Rollback
Revert — **test-infra only, no app code**.

## Next
With the guard ready, the first router extraction (a cohesive group like `/api/compliance/*` behind `app.use('/api/compliance', router)`) becomes a snapshot-verified pure move. I'll put that first one up for review before going wide.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_