### PR TITLE
docs: checkpoint route-group phase (guard + 2 routers + mis-merge recovery)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,96 @@
+## 2026-06-06 (cont.) — route-group phase: mount-aware guard, first 2 routers, a mis-merge caught
+
+The decomposition crossed a threshold: from extracting helpers to extracting
+**route groups** — moving whole families of handlers into `src/server/routes/*.js`
+mounted behind `app.use('/prefix', router)`. This is the first structural change
+to routing, and the one that needed the guard taught new tricks before any handler
+moved.
+
+### Step 1 — mount-prefix resolution in the route guard (#242)
+
+A router's `router.get('/sub')` reads as `GET /sub`, not `GET /prefix/sub`. Left
+alone, the route-inventory snapshot would break on what is supposed to be a pure
+move. So before touching a single handler, `collectRoutes()` learned to:
+1. emit top-level `app.<method>(...)` in server.js as before, then
+2. resolve each `app.use('<prefix>', <ident>)` whose `<ident>` is a local import,
+   read that module, and emit its `router.<method>('<sub>')` as `<prefix><sub>`.
+
+Refactored the pure core to `resolveRoutes(serverSrc, readModule)` + exported
+helpers (`joinPath`/`parseImports`/`parseMounts`) so mount-prefixing is unit-
+testable on synthetic strings without touching the repo. No-op until a router
+existed (snapshot stayed 213). 7 tests including the false-positive guards
+(express.static / non-import mounts ignored; non-default router var honored).
+
+### Step 2 — `/api/compliance/*` → routes/compliance.js (#243, recovered via #244)
+
+First router. 8 handlers + the compliance-only `ensureComplianceColumns` moved
+out; `callCritique` rode along as an inner closure. Every shared dep was already
+in a module (pool/anthropic/safeParseLLM/stripScaffoldingArtifacts/verifyBrandAccess/
+findCitationSources) — zero new coupling. Guard reconstructed all 8 paths;
+snapshot held 213 byte-identical.
+
+### Step 3 — `/api/email-campaign/*` → routes/email-campaign.js (#245)
+
+9 handlers. This one earned the safety net its keep on a route group: the
+`generate` handler uses `activeStreams`, a `globalThis`-backed SSE dedupe Map
+**shared** with the social-generator handler still inline in server.js. A naive
+move leaves the module referencing an undefined `activeStreams` — the SSE dedupe
+silently no-ops or crashes, and `node --check` wouldn't catch it. **The no-undef
+gate flagged it** (plus `fs`/`path`), so it got extracted properly to a shared
+`src/server/streams.js` that both server.js and the router import. Exactly the
+class of bug the gate was built to stop, first time it fired on a route move.
+
+### Router auth convention (established this phase)
+
+- **Router-level** `requireAuth` — `app.use('/prefix', requireAuth, router)` — when
+  EVERY route in the group is authed (compliance, email-campaign). Behavior-
+  identical to per-route for the current routes; the per-route `requireAuth` args
+  are dropped.
+- **Per-route** auth when the group is MIXED — zernio's `GET /connect/:platform`
+  (OAuth redirect, no bearer possible) and geo-strategist's `GET /briefs/:id` are
+  unauthed, so those groups will mount without auth and keep per-route middleware.
+
+### The mis-merge, and the lesson (#243 → #244)
+
+#243 was opened stacked on the #242 branch so its diff showed only the compliance
+move. After #242 merged, I retargeted #243's base to `development` via
+`update_pull_request` (got a success response) and reported it ready. But the base
+**didn't actually flip** — so when #243 merged, it merged back into the already-
+shipped #242 branch, and the compliance router **never reached `development`**.
+No breakage (development stayed self-consistent with inline compliance), but the
+extraction was stranded.
+
+Caught it at the start of the next extraction: `src/server/routes/` didn't exist
+on the branch I'd just cut from `development`. Diagnosed (origin/development HEAD
+was the #242 merge, no routes dir, inline `/api/compliance/approve` still present),
+located the stranded commit on the #242 branch, and re-landed it via a fresh PR
+(#244) — exactly 1 commit / 2 files, re-verified on the correct base.
+
+**Lessons logged:**
+- **After retargeting a stacked PR's base, RE-READ the PR to confirm the flip.**
+  `update_pull_request` returning a success object is not proof the base changed.
+  (Prefer: avoid deep stacks — once the parent merges, branch the child fresh off
+  `development` instead of relying on a retarget.)
+- **Verify a merge landed where you think.** The webhook says "merged"; it doesn't
+  say "merged into the branch you intended." A 10-second `git ls-tree origin/<base>`
+  check would have caught it immediately.
+
+### Net state
+
+`development` has the mount-aware guard + 2 route modules (`compliance`,
+`email-campaign`) + `streams.js`. Route count still 213 (snapshot-locked).
+~20 modules total now. No production-lane changes this stretch (refactor is
+development-only until the next `development → main` rollup).
+
+### What's next
+
+- `/api/social-generator/*` (6, uniform auth, now imports the landed `streams.js`).
+- `/api/publishing/*` (22 — the biggest group).
+- zernio as a dedicated subsystem pass (~15 routes / 4 prefixes / mixed auth).
+- `/api/geo-strategist/*` (3, mixed auth → per-route).
+
+---
+
 ## 2026-06-06 — decomposition Stage 2 continues: 5 more cuts + 3 production fixes
 
 Continuation of the `server.js` dismemberment (see the 2026-06-05 entry for the

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,6 +10,28 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-06 (cont.) — route-group surgery begins (2 groups) + a mis-merge recovery
+
+The decomposition crossed from helpers into **route GROUPS**: handlers move into `src/server/routes/*.js` mounted via `app.use('/prefix', router)`, with the guard reconstructing full paths so the snapshot stays byte-identical.
+
+- **Guard mount-prefix (#242)** — taught `test/route-inventory.mjs` to resolve `app.use('/prefix', router)` mounts: reads the router module and prefixes its `router.METHOD('/sub')` as `/prefix/sub`. No-op until routers exist (snapshot stayed 213). Pure core `resolveRoutes()` + helpers, unit-tested.
+- **`/api/compliance/*` (#243 → recovered as #244)** — first router. 8 handlers + the compliance-only `ensureComplianceColumns` → `routes/compliance.js`, mounted `app.use('/api/compliance', requireAuth, complianceRouter)`. Every dep already extracted; zero new coupling.
+- **`/api/email-campaign/*` (#245)** — 9 handlers → `routes/email-campaign.js`. Surfaced + fixed a shared `globalThis` SSE registry → **`streams.js`** (`activeStreams`), shared with the still-inline social-generator handler. The **no-undef gate caught it** — a naive move would've left an undefined `activeStreams` (silent SSE break on deploy).
+
+**Mis-merge recovery (#243 → #244).** #243 was opened stacked on the #242 branch, then retargeted to `development`. The retarget didn't take before merge, so #243 merged back into the already-shipped #242 branch — **compliance never reached `development`.** Caught it (the `routes/` dir was missing on dev), re-landed via #244. **Lesson: after retargeting a stacked PR's base, RE-READ the PR to confirm the flip — `update_pull_request` returning success is not proof.**
+
+#### Router auth convention (set this phase)
+- **Router-level** `requireAuth` (`app.use('/prefix', requireAuth, router)`) when **all** routes in the group are authed — compliance, email-campaign.
+- **Per-route** auth when **mixed** — e.g. zernio's `GET /api/zernio/connect/:platform` (OAuth redirect, unauthed) and geo-strategist's `GET /briefs/:id` (unauthed). Those groups keep per-route middleware and mount without auth.
+
+#### What's next (route groups)
+- **`/api/social-generator/*`** (6) — uniform auth; now imports the landed `streams.js`. Natural next.
+- **`/api/publishing/*`** (22) — biggest single group.
+- **zernio subsystem pass** — ~15 routes across 4 prefixes (`/api/zernio`, `/auth/zernio`, `/integrations/zernio`, `/api/admin/zernio`) + mixed auth → one dedicated module, not piecemeal.
+- **`/api/geo-strategist/*`** (3) — small, mixed auth → per-route.
+
+---
+
 ### 2026-06-06 — decomposition continues (5 more cuts) + 3 production fixes
 
 Kept dismembering `server.js`, same pure-move discipline + CI safety net. **16 modules out now** (14 files; `text.js` grew):


### PR DESCRIPTION
## Why
Checkpoint the route-group phase before continuing — a distinct chapter from the helper extractions, and the #243→#244 mis-merge is exactly the kind of gotcha that should be in `PLAN.md` before it's forgotten.

## What
**`WORKING-STATE.md`** (91 lines, under cap) — new top block:
- Guard mount-prefix (#242), compliance router (#243→#244), email-campaign + `streams.js` (#245)
- The **router auth convention** (router-level when uniform, per-route when mixed)
- The #243 mis-merge recovery + lesson
- The route-group queue (social-generator → publishing → zernio subsystem → geo-strategist)

**`PLAN.md`** — long-form retrospective: the guard-upgrade design, both router extractions, the `activeStreams`/`streams.js` shared-state catch by the no-undef gate, and the #243→#244 mis-merge with two lessons logged:
1. After retargeting a stacked PR's base, **re-read the PR to confirm the flip** — a success response isn't proof. Prefer branching the child fresh off `development` once the parent merges, over deep stacks.
2. **Verify a merge landed on the intended branch** — the webhook says "merged," not "merged where you meant."

Docs only — **no code change**.

## Test plan
N/A (Markdown). Ordering verified newest-first.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_