### PR TITLE
docs: checkpoint route-group phase pt.2 (6 groups + 2 shared modules)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,75 @@
+## 2026-06-06 (cont.) — route-group phase pt.2: groups 3–6 + 2 shared modules + publishing deferred
+
+Continued the route-group extractions (see the prior entry for the guard design,
+auth convention, and the #243→#244 mis-merge). Four more groups + two shared
+modules the gate forced out, all guard-verified at 213 byte-identical.
+
+### Groups extracted
+- **`social-generator.js` (#247)** — 6 handlers + moved `ensureSocialPostsTable`
+  (its boot-time table init moved with it; fires on import). Best cross-module
+  stress test so far: this router reaches into **seven** prior modules — `x`
+  (publish-x), `images` (social image gen), `streams`, `llm`, `db`, `auth`,
+  `llm-json`. The dependency graph between extracted modules held.
+- **`campaign.js` (#248)** — 9 handlers, **per-route auth** (mixed group: public
+  `GET /:id`). Moved `enrichAngleForCampaign`; `generateArticleImage` rode along
+  as an inner closure. Surfaced a shared table helper → `content-table.js`.
+- **`topic-ideas.js` (#249)** — 5 handlers, the cleanest extraction of the whole
+  effort: contiguous, uniform auth, `pool`-only, zero local-helper blockers,
+  clean on the first lint pass.
+- **`precog.js` (#250)** — 5 handlers (scorer + reads), `pool` + `verifyBrandAccess`.
+
+### Shared modules the no-undef gate surfaced
+- **`streams.js`** (#245) — the `globalThis`-backed `activeStreams` SSE registry,
+  shared between email-campaign and (still-inline-then) social-generator.
+- **`content-table.js`** (#248) — `ensureGeneratedContentTable`, the idempotent
+  per-brand `generated_content_<id>` schema helper, shared by the content-generator
+  route (still in server.js) and campaign generate.
+
+Both are the same pattern: a route move surfaces shared state/helpers that can't
+live in either router, so they become their own small module both import. In each
+case a naive move would've left an undefined reference — caught at lint, not on
+deploy. The gate has now justified itself repeatedly on route groups, not just
+helper cuts.
+
+### Lesson: prompt-template literals break naive boundary detection
+
+The campaign `generate` handler and `enrichAngleForCampaign` contain prompt
+template literals with `}` at **column 0** (JSON examples inside the prompt). My
+build script's "function ends at the first `^}`" detection cut one short
+mid-build, stranding the tail and producing a syntax error. `node --check` caught
+it immediately; restored from git, re-cut using **next-statement boundary
+detection** (a block ends right before the next top-level `app.`/`function`/etc.,
+not at a naive brace). This is now the default for route extractions. Twice this
+session a scripting slip was caught by `node --check` before anything shipped —
+the verify-before-commit discipline is doing real work.
+
+### Publishing: deferred to last (deliberate)
+
+Scoped `/api/publishing/*` and pushed back on doing it next: **22 routes scattered
+across the whole file (943→11570), mixed auth, and a 1,138-line `publish`
+dispatcher** (inline per-channel logic for LinkedIn/X/Reddit/Facebook/Ghost/Medium/
+My Website) + a `pipedreamProxy` helper. It's the single most entangled group and
+the one where a slip eventually means broken publishing in prod. Brian's call:
+defer it to last (do it — likely split into queue / channels / dispatcher
+sub-routers — when the surrounding dep web is smallest), and take cleaner groups
+first. Logged so the next session doesn't re-scope it from scratch.
+
+### Net state
+
+`development` has 6 route modules (compliance, email-campaign, social-generator,
+campaign, topic-ideas, precog) + 2 shared modules (streams, content-table) on top
+of the ~18 helper modules. Route count 213 (snapshot-locked). server.js is
+materially lighter. No production-lane changes this stretch.
+
+### What's next
+
+The clean contiguous groups are exhausted; the remainder lean scattered/mixed and
+need multi-span + per-route handling: `/api/analytics` (11), `/api/content` (6,
++`requireApiKeyScope`), `/api/context-hub` (5), `/api/geo-strategist` (3). Then the
+zernio subsystem (one module across 4 prefixes), and publishing last.
+
+---
+
 ## 2026-06-06 (cont.) — route-group phase: mount-aware guard, first 2 routers, a mis-merge caught
 
 The decomposition crossed a threshold: from extracting helpers to extracting

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,25 +10,34 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
-### 2026-06-06 (cont.) — route-group surgery begins (2 groups) + a mis-merge recovery
+### 2026-06-06 (cont.) — route-group surgery: 6 groups extracted + 2 shared modules
 
-The decomposition crossed from helpers into **route GROUPS**: handlers move into `src/server/routes/*.js` mounted via `app.use('/prefix', router)`, with the guard reconstructing full paths so the snapshot stays byte-identical.
+The decomposition crossed from helpers into **route GROUPS**: handlers move into `src/server/routes/*.js` mounted via `app.use('/prefix', router)`, with the guard reconstructing full paths so the snapshot stays byte-identical (213 throughout).
 
-- **Guard mount-prefix (#242)** — taught `test/route-inventory.mjs` to resolve `app.use('/prefix', router)` mounts: reads the router module and prefixes its `router.METHOD('/sub')` as `/prefix/sub`. No-op until routers exist (snapshot stayed 213). Pure core `resolveRoutes()` + helpers, unit-tested.
-- **`/api/compliance/*` (#243 → recovered as #244)** — first router. 8 handlers + the compliance-only `ensureComplianceColumns` → `routes/compliance.js`, mounted `app.use('/api/compliance', requireAuth, complianceRouter)`. Every dep already extracted; zero new coupling.
-- **`/api/email-campaign/*` (#245)** — 9 handlers → `routes/email-campaign.js`. Surfaced + fixed a shared `globalThis` SSE registry → **`streams.js`** (`activeStreams`), shared with the still-inline social-generator handler. The **no-undef gate caught it** — a naive move would've left an undefined `activeStreams` (silent SSE break on deploy).
+- **Guard mount-prefix (#242)** — taught `test/route-inventory.mjs` to resolve `app.use('/prefix', router)` mounts: reads the router module and prefixes its `router.METHOD('/sub')` as `/prefix/sub`. Pure core `resolveRoutes()` + helpers, unit-tested. (Bare `/api/x` route → `router.METHOD('/')`.)
 
-**Mis-merge recovery (#243 → #244).** #243 was opened stacked on the #242 branch, then retargeted to `development`. The retarget didn't take before merge, so #243 merged back into the already-shipped #242 branch — **compliance never reached `development`.** Caught it (the `routes/` dir was missing on dev), re-landed via #244. **Lesson: after retargeting a stacked PR's base, RE-READ the PR to confirm the flip — `update_pull_request` returning success is not proof.**
+**6 route groups extracted → `src/server/routes/`:**
+- `compliance.js` (#243→#244, 8 routes) + moved `ensureComplianceColumns`
+- `email-campaign.js` (#245, 9) — surfaced shared SSE registry → **`streams.js`** (`activeStreams`)
+- `social-generator.js` (#247, 6) + moved `ensureSocialPostsTable`; reaches into 7 prior modules (x/images/streams/llm/db/auth/llm-json)
+- `campaign.js` (#248, 9, **per-route** auth) + moved `enrichAngleForCampaign`; surfaced shared table helper → **`content-table.js`** (`ensureGeneratedContentTable`)
+- `topic-ideas.js` (#249, 5) — cleanest, pool-only
+- `precog.js` (#250, 5)
 
-#### Router auth convention (set this phase)
-- **Router-level** `requireAuth` (`app.use('/prefix', requireAuth, router)`) when **all** routes in the group are authed — compliance, email-campaign.
-- **Per-route** auth when **mixed** — e.g. zernio's `GET /api/zernio/connect/:platform` (OAuth redirect, unauthed) and geo-strategist's `GET /briefs/:id` (unauthed). Those groups keep per-route middleware and mount without auth.
+**2 shared modules** the no-undef gate forced into the open: `streams.js` (globalThis SSE Map shared with still-inline handlers), `content-table.js` (per-brand `generated_content_<id>` schema helper, shared by content-generator + campaign). Naive moves would've left undefined refs → silent deploy breaks. Gate caught both.
 
-#### What's next (route groups)
-- **`/api/social-generator/*`** (6) — uniform auth; now imports the landed `streams.js`. Natural next.
-- **`/api/publishing/*`** (22) — biggest single group.
+#### Router auth convention
+- **Router-level** `requireAuth` when **all** routes are authed (compliance, email-campaign, social-generator, topic-ideas, precog).
+- **Per-route** auth when **mixed** (campaign has a public `GET /:id`; mount without auth, keep per-route middleware).
+
+#### Lessons logged this phase
+- **Mis-merge (#243→#244):** a stacked PR's base retarget didn't take before merge → compliance landed on the wrong branch, never reached `development`. Caught (missing `routes/` dir), re-landed. **Re-read a retargeted PR to confirm the base flipped; prefer branching the child fresh off `development` over deep stacks.**
+- **Prompt-template boundary hazard:** the campaign/social handlers contain template literals with `}` at column 0, which broke naive "first `^}`" function-end detection mid-build (caught by `node --check`, restored from git, re-cut). **Default to next-statement boundary detection for route extractions, not brace-matching.**
+
+#### What's next (route groups) — the remaining are the hard ones
+- **Publishing DEFERRED to last** (Brian's call): 22 routes scattered 943→11570, mixed auth, a **1,138-line `publish` dispatcher** + `pipedreamProxy`. Do it (likely split) when the dep web is smallest.
+- Remaining lean scattered/mixed → multi-span + per-route care: `/api/analytics` (11, mixed), `/api/content` (6, scattered+mixed+`requireApiKeyScope`), `/api/context-hub` (5, scattered+mixed), `/api/geo-strategist` (3, mixed).
 - **zernio subsystem pass** — ~15 routes across 4 prefixes (`/api/zernio`, `/auth/zernio`, `/integrations/zernio`, `/api/admin/zernio`) + mixed auth → one dedicated module, not piecemeal.
-- **`/api/geo-strategist/*`** (3) — small, mixed auth → per-route.
 
 ---
 


### PR DESCRIPTION
## Why
Checkpoint before the harder remaining groups (scattered/mixed). Captures the 4 groups + 2 shared modules since the last docs PR (#246), plus the publishing-deferral decision and two process lessons.

## What
**`WORKING-STATE.md`** (100 lines) — revised the route-group block to cover all **6** extracted groups (compliance, email-campaign, social-generator, campaign, topic-ideas, precog) + the **2 shared modules** the no-undef gate surfaced (`streams.js`, `content-table.js`), the router auth convention, both lessons, and the **publishing-deferred-to-last** decision with its scope (22 routes, mixed auth, 1,138-line dispatcher).

**`PLAN.md`** — long-form retrospective pt.2: groups 3–6, the two shared-module extractions (and why the gate keeps catching them on route moves), the prompt-template boundary hazard → next-statement detection, the publishing deferral rationale, net state.

Docs only — **no code change**.

## Test plan
N/A (Markdown). Ordering verified newest-first.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_