### PR TITLE
docs: checkpoint route-group phase pt.3 (11 groups, publishing only left)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,67 @@
+## 2026-06-06 (cont.) — route-group phase pt.3: groups 7–11, the hard tier (publishing only remains)
+
+Finished the non-publishing route groups. After the clean contiguous ones (pt.2),
+the remainder were scattered + mixed-auth — handled with multi-span collection +
+per-route auth. All guard-verified at 213 byte-identical throughout.
+
+### Groups 7–11
+- **`geo-strategist.js` (#252)** — 3 routes, mixed auth (public `briefs/:id`). Warm-up
+  for the per-route pattern; `normalizeGeoData` was already in `geo.js`.
+- **`analytics.js` (#253)** — the biggest: **11 routes scattered across 2811→14106
+  (1,395 lines)** + the analytics-only `refreshGSCToken`. Mixed auth — 2 "open"
+  routes do the cron-bypass-OR-Clerk pattern inline (`jwtVerify`). Pulls analytics
+  from X / Ghost / Zernio, so it reaches into `zernio`/`x`/`ghost` + `auth`
+  (`clerkJWKS`) + `jose`. The gate caught FOUR missed imports here.
+- **`context-hub.js` (#254)** — 5 routes (Stage 1 crawl) + the 193-line
+  `handleQuickStartSynthesis`. Lighter than feared because the crawl already
+  delegates to the extracted `scrape.js`. `domainToName` turned out to be two
+  independent inner closures (no shared blocker).
+- **`content.js` (#255)** — 6 scattered routes, mixed + the dual-middleware
+  `import` route (`requireAuth` + `requireApiKeyScope`). Verified the segment-
+  boundary mount does NOT swallow `/api/content-library` / `/api/content-generator`
+  (different prefixes, left inline).
+- **zernio subsystem (#256)** — 10 of 14 routes across 2 files: `zernio.js`
+  (`/api/zernio`, 3, mixed) + `zernio-admin.js` (`/api/admin/zernio`, 7, all
+  `zernioGuard`-gated). The 2 OAuth callbacks (odd single-prefixes, different
+  logic) + 2 `/api/admin/backfill-*-zernio-ids` (admin-lane) left inline.
+
+### Practices that hardened this tier
+- **Guard scans one `express.Router()` per file.** `routerVar()` finds the first
+  `const x = express.Router()` and scans only it — so two routers can't share a
+  module (drove the zernio 2-file split), and one router can't mount at two
+  prefixes (double-counts). One router file, one mount. Flagged before cutting
+  zernio and chose the structure with Brian rather than fight the guard.
+- **Boot-load test.** Started `import()`-ing each new module in CI-of-one before
+  commit. `node --check` (syntax) and ESLint `no-undef` (static) both MISS a
+  missing *named* export (`import { x }` where `x` isn't exported) — that throws
+  only at module load. The bigger scattered modules (analytics, context-hub)
+  reach into many siblings, so a boot-load check is the only thing that catches a
+  typo'd or non-existent named import. Caught nothing bad (the gate had already
+  surfaced the imports) but it's the right backstop.
+- **Next-statement boundary detection** (not brace-matching) is now standard, after
+  the prompt-template `}`-at-col-0 hazard from pt.2. Held up across all 5 groups.
+- **Mixed-auth `xform`** keeps the middleware list intact (preserves `requireAuth`,
+  `requireApiKeyScope(...)`, `softAuth`, or none) and only rewrites
+  `app.METHOD('/prefix/x'` → `router.METHOD('/x'`.
+
+### Net state
+
+`development` now has **11 route groups (13 route files) + ~20 helper/shared
+modules**. Route count 213 (snapshot-locked the entire phase). server.js is down
+to: the publishing subsystem, the `/api/admin/*` mass, assorted singletons (the 2
+zernio callbacks, content-library/generator, etc.), boot/middleware wiring, and
+the inline-jwtVerify handlers. No production-lane changes this stretch.
+
+### What's next — PUBLISHING, the finale
+
+`/api/publishing/*` is all that's left of the planned groups. Deferred deliberately
+(most entangled: ~22 scattered routes, mixed auth, a ~1,138-line `publish`
+dispatcher with inline per-channel logic + `pipedreamProxy`). **Re-scope first** —
+its neighborhood shifted as everything else moved out — then decide split (queue /
+channels / dispatcher sub-routers) vs one PR before cutting.
+
+---
+
 ## 2026-06-06 (cont.) — route-group phase pt.2: groups 3–6 + 2 shared modules + publishing deferred
 
 Continued the route-group extractions (see the prior entry for the guard design,

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,34 +10,28 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
-### 2026-06-06 (cont.) — route-group surgery: 6 groups extracted + 2 shared modules
+### 2026-06-06 (cont.) — route-group surgery: 11 groups extracted (publishing only remains)
 
-The decomposition crossed from helpers into **route GROUPS**: handlers move into `src/server/routes/*.js` mounted via `app.use('/prefix', router)`, with the guard reconstructing full paths so the snapshot stays byte-identical (213 throughout).
+The decomposition crossed from helpers into **route GROUPS**: handlers move into `src/server/routes/*.js` mounted via `app.use('/prefix', router)`, the guard reconstructing full paths so the snapshot stays byte-identical (**213 throughout**). Pattern: collect each handler's span (next-statement boundaries), move verbatim, `xform` the registration line (`app.METHOD('/prefix/x', …)` → `router.METHOD('/x', …)`), re-import deps from already-extracted modules. Verify `node --check` + lint + boot-load (`import()`) + route guard + vitest.
 
-- **Guard mount-prefix (#242)** — taught `test/route-inventory.mjs` to resolve `app.use('/prefix', router)` mounts: reads the router module and prefixes its `router.METHOD('/sub')` as `/prefix/sub`. Pure core `resolveRoutes()` + helpers, unit-tested. (Bare `/api/x` route → `router.METHOD('/')`.)
+**11 route groups → `src/server/routes/` (13 files):**
+- `compliance.js` (#243→#244, 8) +`ensureComplianceColumns` · `email-campaign.js` (#245, 9) · `social-generator.js` (#247, 6) +`ensureSocialPostsTable` · `campaign.js` (#248, 9) +`enrichAngleForCampaign` · `topic-ideas.js` (#249, 5) · `precog.js` (#250, 5) · `geo-strategist.js` (#252, 3) · `analytics.js` (#253, **11**, +`refreshGSCToken`) · `context-hub.js` (#254, 5) +`handleQuickStartSynthesis` · `content.js` (#255, 6) · **zernio** (#256, 10 → `zernio.js` + `zernio-admin.js`)
 
-**6 route groups extracted → `src/server/routes/`:**
-- `compliance.js` (#243→#244, 8 routes) + moved `ensureComplianceColumns`
-- `email-campaign.js` (#245, 9) — surfaced shared SSE registry → **`streams.js`** (`activeStreams`)
-- `social-generator.js` (#247, 6) + moved `ensureSocialPostsTable`; reaches into 7 prior modules (x/images/streams/llm/db/auth/llm-json)
-- `campaign.js` (#248, 9, **per-route** auth) + moved `enrichAngleForCampaign`; surfaced shared table helper → **`content-table.js`** (`ensureGeneratedContentTable`)
-- `topic-ideas.js` (#249, 5) — cleanest, pool-only
-- `precog.js` (#250, 5)
+**Shared modules the no-undef gate forced out:** `streams.js` (globalThis SSE registry), `content-table.js` (`ensureGeneratedContentTable`). Naive moves would've left undefined refs → silent deploy breaks; gate caught both (and `fs`/`path`/`randomUUID`/`jwtVerify`/`clerkJWKS`/etc. on the bigger handlers).
 
-**2 shared modules** the no-undef gate forced into the open: `streams.js` (globalThis SSE Map shared with still-inline handlers), `content-table.js` (per-brand `generated_content_<id>` schema helper, shared by content-generator + campaign). Naive moves would've left undefined refs → silent deploy breaks. Gate caught both.
-
-#### Router auth convention
-- **Router-level** `requireAuth` when **all** routes are authed (compliance, email-campaign, social-generator, topic-ideas, precog).
-- **Per-route** auth when **mixed** (campaign has a public `GET /:id`; mount without auth, keep per-route middleware).
+#### Conventions + guard constraints (load-bearing)
+- **Auth:** router-level `requireAuth` when ALL routes authed; **per-route** when mixed (open OAuth/cron/public reads) — mount without auth, keep per-route middleware.
+- **Guard scans ONE `express.Router()` var per file** — two routers can't share a module (zernio → 2 files). Mounting one router at two prefixes double-counts. One router file, one mount.
+- **Mounts match on segment boundaries** — `app.use('/api/content', …)` does NOT capture `/api/content-library`/`-generator` (verified they stayed inline).
+- **Boundary detection:** next-statement, NOT "first `^}`" — prompt template literals have `}` at column 0 (would truncate a function mid-build).
 
 #### Lessons logged this phase
-- **Mis-merge (#243→#244):** a stacked PR's base retarget didn't take before merge → compliance landed on the wrong branch, never reached `development`. Caught (missing `routes/` dir), re-landed. **Re-read a retargeted PR to confirm the base flipped; prefer branching the child fresh off `development` over deep stacks.**
-- **Prompt-template boundary hazard:** the campaign/social handlers contain template literals with `}` at column 0, which broke naive "first `^}`" function-end detection mid-build (caught by `node --check`, restored from git, re-cut). **Default to next-statement boundary detection for route extractions, not brace-matching.**
+- **Mis-merge (#243→#244):** a stacked PR's base retarget didn't take before merge → compliance never reached `development`. Re-read a retargeted PR to confirm the flip; prefer branching the child fresh over deep stacks.
+- **Boot-load test** (`import()` the new module) catches a missing **named** export — which `node --check` + lint can't (it crashes at startup). Standard for the bigger scattered modules now.
 
-#### What's next (route groups) — the remaining are the hard ones
-- **Publishing DEFERRED to last** (Brian's call): 22 routes scattered 943→11570, mixed auth, a **1,138-line `publish` dispatcher** + `pipedreamProxy`. Do it (likely split) when the dep web is smallest.
-- Remaining lean scattered/mixed → multi-span + per-route care: `/api/analytics` (11, mixed), `/api/content` (6, scattered+mixed+`requireApiKeyScope`), `/api/context-hub` (5, scattered+mixed), `/api/geo-strategist` (3, mixed).
-- **zernio subsystem pass** — ~15 routes across 4 prefixes (`/api/zernio`, `/auth/zernio`, `/integrations/zernio`, `/api/admin/zernio`) + mixed auth → one dedicated module, not piecemeal.
+#### What's next — only PUBLISHING remains
+- **`/api/publishing/*`** — the finale, deferred deliberately: ~22 routes scattered, mixed auth, a ~1,138-line `publish` dispatcher + `pipedreamProxy`. **Re-scope before cutting** (its neighborhood shifted as routes moved out); decide split (queue / channels / dispatcher) vs one PR.
+- Left inline on purpose: zernio's 2 OAuth callbacks (odd single-prefixes) + 2 `/api/admin/backfill-*-zernio-ids` (admin-lane); the `/api/admin/*` mass; `/api/content-library` + `/api/content-generator`.
 
 ---
 


### PR DESCRIPTION
## Why
Checkpoint before the publishing finale. Captures the 5 groups since the last docs PR (geo-strategist, analytics, context-hub, content, zernio) and the load-bearing guard constraints / practices that hardened the scattered-mixed tier.

## What
**`WORKING-STATE.md`** (94 lines) — rewrote the route-group block to cover **all 11 extracted groups (13 route files)**, the guard constraints (one `express.Router()` per file; segment-boundary mounts; next-statement boundary detection), the boot-load-test practice, and "only publishing remains."

**`PLAN.md`** — retrospective pt.3: groups 7–11, the practices that hardened the hard tier (one-router-per-file → zernio 2-file split; boot-load test for missing named exports; next-statement boundaries; mixed-auth `xform`), net state, and the publishing re-scope note.

Docs only — **no code change**.

## Test plan
N/A (Markdown). Ordering newest-first; WS under cap.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_