### PR TITLE
test(route-guard): handle combined import form in parseImports

### DIFF
--- a/test/route-inventory.mjs
+++ b/test/route-inventory.mjs
@@ -49,8 +49,11 @@ export function joinPath(prefix, sub) {
 // Handles `import X from './a.js'` and `import { X, Y as Z } from './b.js'`.
 export function parseImports(src) {
   const map = {};
-  for (const m of src.matchAll(/import\s+(\w+)\s+from\s+['"](\.[^'"]+)['"]/g)) map[m[1]] = m[2];
-  for (const m of src.matchAll(/import\s*\{([^}]+)\}\s*from\s+['"](\.[^'"]+)['"]/g)) {
+  // Default import — also handles the combined `import X, { … } from '…'` form
+  // (the optional `, { … }` is consumed so X is still captured).
+  for (const m of src.matchAll(/import\s+(\w+)\s*(?:,\s*\{[^}]*\})?\s*from\s+['"](\.[^'"]+)['"]/g)) map[m[1]] = m[2];
+  // Named imports — optional leading `Default,` before the brace (combined form).
+  for (const m of src.matchAll(/import\s+(?:\w+\s*,\s*)?\{([^}]+)\}\s*from\s+['"](\.[^'"]+)['"]/g)) {
     for (const part of m[1].split(',')) {
       const name = part.trim().split(/\s+as\s+/).pop().trim();
       if (name) map[name] = m[2];

--- a/test/route-mounts.test.js
+++ b/test/route-mounts.test.js
@@ -25,6 +25,25 @@ describe('parseImports / parseMounts', () => {
     expect(parseMounts(`app.use('/api/compliance', requireAuth, compliance);`))
       .toEqual([{ prefix: '/api/compliance', ident: 'compliance' }]);
   });
+
+  it('parses the combined `import Default, { Named } from` form (both sides)', () => {
+    const m = parseImports(`import pubRouter, { runScheduledPublishes } from './src/server/routes/publishing-publish.js';`);
+    expect(m.pubRouter).toBe('./src/server/routes/publishing-publish.js');         // default
+    expect(m.runScheduledPublishes).toBe('./src/server/routes/publishing-publish.js'); // named
+  });
+
+  it('a combined-import router still resolves through resolveRoutes (regression for #260)', () => {
+    const server = `
+      import publishRouter, { runScheduledPublishes } from './src/server/routes/publishing-publish.js';
+      app.use('/api/publishing', publishRouter);
+      runScheduledPublishes();
+    `;
+    const router = `const router = express.Router(); router.post('/publish', h); router.post('/generate-post-copy', h);`;
+    expect(resolveRoutes(server, () => router)).toEqual([
+      'POST /api/publishing/generate-post-copy',
+      'POST /api/publishing/publish',
+    ]);
+  });
 });
 
 describe('resolveRoutes — mount-prefix resolution', () => {


### PR DESCRIPTION
## Why
Closes the guard gap surfaced in #260: the route-inventory guard's `parseImports` didn't parse the combined `import Default, { Named } from '…'` form, so a router imported that way wasn't recognized as mounted and its routes were **silently dropped** from the inventory (read 209 vs 211 until I split the import). Hardening it so a future combined-import mount can't under-count unseen.

## What
**`test/route-inventory.mjs`** — `parseImports`:
- Default-import regex tolerates an optional `, { … }` after the identifier → captures the default in the combined form.
- Named-import regex tolerates an optional leading `Default,` before the brace → captures the named members in the combined form.
- Both stay anchored to relative (`'./…'`) specifiers.

**`test/route-mounts.test.js`** — +2 tests: `parseImports` captures both sides of a combined import; `resolveRoutes` reconstructs a combined-import router's routes end-to-end (regression for #260).

Test-infra only — **no app code**.

## Test plan
- `npm run lint` → clean
- `vitest` → **95/95** (+2)
- real-repo `collectRoutes()` → **211** (unchanged — additive fix, no regression)

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_