### PR TITLE
fix(geo): probe AI engines for real instead of modeling citation scores

### DIFF
--- a/src/server/geoProbe.js
+++ b/src/server/geoProbe.js
@@ -1,0 +1,221 @@
+// Real GEO engine probing. This is the module that makes the GEO scan honest:
+// instead of asking Claude to *imagine* how often ChatGPT/Perplexity/Gemini/Google
+// AI Overviews cite a brand (the old Tool 2, which produced lockstep, fabricated
+// numbers), we actually query each engine with natural buyer questions and MEASURE
+// whether the brand is cited.
+//
+// Each engine is env-gated by its own API key. A missing key disables that engine
+// (its column comes back null) rather than throwing — but if NO engine is available
+// the caller must treat the run as a failure, never fall back to modeled numbers.
+//
+// Scoring per (topic, engine): we run a few natural queries and grade each answer
+//   100 — brand domain is cited/linked (the real, defensible "you are cited" signal)
+//    50 — brand named in the answer text but not linked (mentioned, not sourced)
+//     0 — brand absent from the answer
+// and average across the queries. So the 0-100 is a measured citation-strength rate,
+// not a guess. Three queries gives a 0/17/33/50/.../100 granularity grounded in
+// observable engine behavior.
+
+const DEFAULT_QUERIES_PER_TOPIC = 3;
+const TOPIC_CONCURRENCY = 3;     // how many topics probed in parallel (rate-limit safety)
+const ENGINE_TIMEOUT_MS = 30000;
+
+// ── Engine registry ─────────────────────────────────────────────────────────
+// Each engine exposes: key presence flag + a probe(query) -> { text, urls } fn.
+// `text` is the engine's answer; `urls` are the cited/grounding source links.
+
+function timeoutFetch(url, opts = {}) {
+  return fetch(url, { ...opts, signal: AbortSignal.timeout(ENGINE_TIMEOUT_MS) });
+}
+
+async function probePerplexity(query) {
+  const res = await timeoutFetch('https://api.perplexity.ai/chat/completions', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${process.env.PERPLEXITY_API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: 'sonar', messages: [{ role: 'user', content: query }], max_tokens: 400 }),
+  });
+  const data = await res.json();
+  return { text: data.choices?.[0]?.message?.content || '', urls: data.citations || [] };
+}
+
+async function probeOpenAI(query) {
+  const res = await timeoutFetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: 'gpt-4o-mini', tools: [{ type: 'web_search_preview' }], input: query }),
+  });
+  const data = await res.json();
+  const msgItem = data.output?.find(o => o.type === 'message');
+  const textContent = msgItem?.content?.find(c => c.type === 'output_text');
+  const text = textContent?.text || data.output_text || '';
+  const urls = (textContent?.annotations || [])
+    .filter(a => a.type === 'url_citation')
+    .map(a => a.url || a.url_citation?.url || '')
+    .filter(Boolean);
+  return { text, urls };
+}
+
+async function probeGemini(query) {
+  // Gemini with Google Search grounding. Grounding URIs come back as redirect
+  // links on vertexaisearch.cloud.google.com plus the resolved domain in title.
+  const res = await timeoutFetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${process.env.GEMINI_API_KEY}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: query }] }],
+        tools: [{ google_search: {} }],
+      }),
+    }
+  );
+  const data = await res.json();
+  const cand = data.candidates?.[0];
+  const text = (cand?.content?.parts || []).map(p => p.text || '').join(' ');
+  const chunks = cand?.groundingMetadata?.groundingChunks || [];
+  // web.uri is a Google redirect; web.title is the source domain/title — keep both
+  // so brand-domain matching can hit either.
+  const urls = chunks.flatMap(c => [c.web?.uri, c.web?.title].filter(Boolean));
+  return { text, urls };
+}
+
+async function probeAIOverviews(query) {
+  // Google AI Overviews has no first-party API — SerpAPI surfaces the AI Overview
+  // block. Sometimes it's inline; sometimes only a page_token is returned and the
+  // block must be fetched with a follow-up engine=google_ai_overview call.
+  const base = 'https://serpapi.com/search.json';
+  const res = await timeoutFetch(
+    `${base}?engine=google&q=${encodeURIComponent(query)}&api_key=${process.env.SERPAPI_KEY}`
+  );
+  let data = await res.json();
+  let ov = data.ai_overview;
+  if (ov?.page_token && !ov.text_blocks) {
+    const res2 = await timeoutFetch(
+      `${base}?engine=google_ai_overview&page_token=${encodeURIComponent(ov.page_token)}&api_key=${process.env.SERPAPI_KEY}`
+    );
+    const data2 = await res2.json();
+    ov = data2.ai_overview || ov;
+  }
+  if (!ov) return { text: '', urls: [], absent: true }; // no AI Overview shown for this query
+  const text = (ov.text_blocks || [])
+    .map(b => b.snippet || (b.list || []).map(li => li.snippet).join(' ') || '')
+    .join(' ');
+  const urls = (ov.references || []).map(r => r.link).filter(Boolean);
+  return { text, urls };
+}
+
+const ENGINES = [
+  { id: 'perplexity', label: 'Perplexity', enabled: () => !!process.env.PERPLEXITY_API_KEY, probe: probePerplexity },
+  { id: 'chatgpt',    label: 'ChatGPT',    enabled: () => !!process.env.OPENAI_API_KEY,     probe: probeOpenAI },
+  { id: 'gemini',     label: 'Gemini',     enabled: () => !!process.env.GEMINI_API_KEY,      probe: probeGemini },
+  { id: 'aiOverviews', label: 'Google AI Overviews', enabled: () => !!process.env.SERPAPI_KEY, probe: probeAIOverviews },
+];
+
+export function enabledEngines() {
+  return ENGINES.filter(e => e.enabled()).map(e => e.id);
+}
+
+// ── Scoring helpers (pure, unit-tested) ──────────────────────────────────────
+
+// Normalize a URL or title fragment to a comparable host string.
+export function hostOf(value) {
+  if (!value || typeof value !== 'string') return '';
+  let v = value.trim().toLowerCase();
+  try { v = new URL(v.startsWith('http') ? v : `https://${v}`).hostname; } catch { /* keep raw */ }
+  return v.replace(/^www\./, '');
+}
+
+// Grade one engine answer for brand presence: 100 cited, 50 mentioned, 0 absent.
+export function gradeAnswer({ text = '', urls = [], brandDomain = '', brandName = '' }) {
+  const dom = (brandDomain || '').toLowerCase().replace(/^www\./, '');
+  const t = (text || '').toLowerCase();
+  if (dom) {
+    const cited = (urls || []).some(u => hostOf(u).includes(dom) || (u || '').toLowerCase().includes(dom)) || t.includes(dom);
+    if (cited) return { score: 100, status: 'cited' };
+  }
+  const name = (brandName || '').toLowerCase().trim();
+  if (name && name.length > 2 && t.includes(name)) return { score: 50, status: 'mentioned' };
+  return { score: 0, status: 'absent' };
+}
+
+// Average a set of per-query grades into a 0-100 engine score for one topic.
+export function scoreFromGrades(grades) {
+  const valid = grades.filter(g => g && typeof g.score === 'number');
+  if (!valid.length) return null; // no observation — distinct from a measured 0
+  return Math.round(valid.reduce((a, g) => a + g.score, 0) / valid.length);
+}
+
+// Default natural buyer queries for a topic, used when the LLM query-writer is
+// unavailable. Deliberately brand-free: we measure UNPROMPTED citation, the honest
+// "do engines surface you on their own" signal.
+export function defaultQueries(topic) {
+  const t = (topic || '').trim();
+  return [
+    t,
+    `What is the best approach to ${t}?`,
+    `Who are the leading providers for ${t}?`,
+  ];
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────────
+
+async function mapWithConcurrency(items, limit, fn) {
+  const results = new Array(items.length);
+  let i = 0;
+  async function worker() {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+// Probe a brand across topics on every enabled engine.
+// Returns:
+//   opportunities: [{ platform, topic, score, quickWin }]  — one row per (engine, topic),
+//                   shaped exactly like the old Tool 2 output so downstream is unchanged.
+//   evidence:      [{ topic, engine, query, status, urls }] — raw observations for the report.
+//   engines:       enabled engine ids actually probed.
+export async function probeBrandTopics({ brandName, brandDomain, topics, queryMap = {}, queriesPerTopic = DEFAULT_QUERIES_PER_TOPIC }) {
+  const engines = ENGINES.filter(e => e.enabled());
+  if (!engines.length) {
+    throw new Error('No GEO engines configured — set at least one of PERPLEXITY_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, SERPAPI_KEY. Refusing to emit modeled scores.');
+  }
+  const cleanTopics = (topics || []).map(t => (typeof t === 'string' ? t : t?.topic)).filter(Boolean);
+
+  const opportunities = [];
+  const evidence = [];
+
+  await mapWithConcurrency(cleanTopics, TOPIC_CONCURRENCY, async (topic) => {
+    const queries = (queryMap[topic] && queryMap[topic].length ? queryMap[topic] : defaultQueries(topic)).slice(0, queriesPerTopic);
+
+    // For each engine, probe every query, grade, average.
+    await Promise.all(engines.map(async (engine) => {
+      const grades = await Promise.all(queries.map(async (q) => {
+        try {
+          const { text, urls } = await engine.probe(q);
+          const g = gradeAnswer({ text, urls, brandDomain, brandName });
+          evidence.push({ topic, engine: engine.id, query: q, status: g.status, urls: (urls || []).slice(0, 5) });
+          return g;
+        } catch (e) {
+          console.error(`[GEO-PROBE] ${engine.id} failed for "${q}":`, e.message);
+          return null; // failed observation — excluded from the average, not scored 0
+        }
+      }));
+      const score = scoreFromGrades(grades);
+      if (score === null) return; // engine produced no usable observation for this topic
+      opportunities.push({
+        platform: engine.label,
+        topic,
+        score,
+        // A quick win is a relevant topic where the brand is measurably weak/absent
+        // (real whitespace to capture), not where it already ranks.
+        quickWin: score < 40,
+      });
+    }));
+  });
+
+  return { opportunities, evidence, engines: engines.map(e => e.id) };
+}

--- a/src/server/routes/geo-strategist.js
+++ b/src/server/routes/geo-strategist.js
@@ -10,6 +10,7 @@ import { anthropic } from '../llm.js';
 import { extractJSON } from '../llm-json.js';
 import { requireAuth } from '../auth.js';
 import { normalizeGeoData } from '../geo.js';
+import { probeBrandTopics, enabledEngines } from '../geoProbe.js';
 
 const router = express.Router();
 
@@ -106,7 +107,11 @@ BRAIN MISTAKES (DO NOT repeat for this brand): ${JSON.stringify(brainMistakes)}`
         const cachedTopical = bd.topicalAuthorityMap || [];
         const cachedGeo = bd.geoOpportunitiesNorm || [];
         const topicalIsReal = cachedTopical.length > 0 && cachedTopical.some(t => t.topic && t.topic !== 'Unknown' && t.citationProbability > 0);
-        const geoIsReal = cachedGeo.length > 0 && cachedGeo.some(g => g.topic && (g.chatgpt > 0 || g.perplexity > 0));
+        // A measured scan is real even if scores are 0 (an invisible brand is a valid
+        // result). Trust the explicit scoreBasis marker; fall back to the legacy
+        // "any engine > 0" heuristic for pre-probe briefs.
+        const geoIsReal = bd.geoScorecard?.scoreBasis === 'measured'
+          || (cachedGeo.length > 0 && cachedGeo.some(g => g.topic && (g.chatgpt > 0 || g.perplexity > 0 || g.gemini > 0 || g.aiOverviews > 0)));
         if (!topicalIsReal || !geoIsReal) {
           console.log('[GEO] Cache stale — topical or geo has bad data, forcing fresh run');
           // fall through to fresh analysis
@@ -182,35 +187,58 @@ Return ONLY the raw JSON array. No markdown. No backticks. No explanation. No ot
     console.log(`[GEO] Tool 1 gaps: ${topicalMap.gapsByCluster.length}`);
     if (topicalMap.gapsByCluster.length > 0) console.log("[GEO] Tool 1 sample:", JSON.stringify(topicalMap.gapsByCluster.slice(0,2)));
 
-    // ── Tool 2: GEO Opportunity Scorer ────────────────────────────────────────
-    console.log('[GEO] Tool 2: GEO Opportunity Scorer...');
-    const scorerRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
-      max_tokens: 3000,
-      messages: [{ role: 'user', content: `You are the GEO Opportunity Scorer for Forge Intelligence.
+    // ── Tool 2: GEO Opportunity Scorer — REAL ENGINE PROBING ──────────────────
+    // Was: a single Claude call asked to *imagine* citation probability across the
+    // four engines. That produced fabricated, lockstep numbers and never queried
+    // anything. Now we MEASURE: ask natural buyer questions against each engine and
+    // score how strongly the brand is actually cited. See src/server/geoProbe.js.
+    const topTopics = (topicalMap.gapsByCluster || [])
+      .map(g => ({ ...g, _score: g.geoCitationScore || g.citationProbability || g.score || g.geoScore || g.probability || 0 }))
+      .sort((a, b) => b._score - a._score)
+      .slice(0, 10)
+      .map(g => g.topic)
+      .filter(Boolean);
 
-BRAND: ${profile.brand_name} (${profile.brand_url})
-TOPICAL GAPS: ${JSON.stringify(
-  (topicalMap.gapsByCluster || [])
-    .map(g => ({ ...g, _score: g.geoCitationScore || g.citationProbability || g.score || g.geoScore || g.probability || 0 }))
-    .sort((a, b) => b._score - a._score)
-    .slice(0, 10)
-    .map(({ _score, ...rest }) => rest)
-)}
-WHITESPACE: ${whitespace.slice(0, 300)}
+    // Tool 2a: write natural, brand-free buyer queries per topic (one batched call).
+    // Brand-free on purpose — we measure UNPROMPTED citation, not "does the engine
+    // echo a query that already names you." Falls back to deterministic templates.
+    let queryMap = {};
+    if (topTopics.length) {
+      try {
+        const qRes = await anthropic.messages.create({
+          model: 'claude-sonnet-4-6',
+          max_tokens: 1500,
+          messages: [{ role: 'user', content: `For each topic below, write 3 natural questions a B2B buyer would type into ChatGPT or Perplexity when researching this area. Do NOT mention any specific company or brand name. Keep each question under 110 characters.
 
-For each topic gap, score citation probability 0-100 across all 4 AI platforms. quickWin=true if score >= 70 and low brand presence.
+TOPICS: ${JSON.stringify(topTopics)}
 
-Return ONLY a raw JSON array (no markdown, no explanation):
-[{"platform":"ChatGPT","topic":"string","score":80,"quickWin":true},{"platform":"Perplexity","topic":"string","score":70,"quickWin":false},{"platform":"Google AI Overviews","topic":"string","score":65,"quickWin":false},{"platform":"Gemini","topic":"string","score":60,"quickWin":false}]` }]
-    });
+Return ONLY a raw JSON object mapping each topic string to an array of 3 question strings. No markdown, no explanation.
+Example: {"topic one":["q1","q2","q3"],"topic two":["q1","q2","q3"]}` }],
+        });
+        const qj = extractJSON(qRes.content[0].text, 'object');
+        if (qj) queryMap = JSON.parse(qj);
+      } catch (e) { console.log('[GEO] Tool 2a query-writer warn (using templates):', e.message); }
+    }
+
+    console.log(`[GEO] Tool 2: probing ${topTopics.length} topics across [${enabledEngines().join(', ') || 'NONE'}]...`);
+    const brandDomain = (profile.brand_url || '').replace(/^https?:\/\//, '').replace(/^www\./, '').split('/')[0].toLowerCase();
     let geoOpportunities = [];
+    let probeEvidence = [];
     try {
-      const go = extractJSON(scorerRes.content[0].text, 'array');
-      if (!go) throw new Error('No JSON array found in Tool 2 response');
-      geoOpportunities = JSON.parse(go);
-    } catch(e) { console.log('[GEO] Tool 2 parse warn:', e.message, '| raw:', scorerRes.content[0].text.slice(0,200)); }
-    console.log(`[GEO] Tool 2 opportunities: ${(geoOpportunities||[]).length}`);
+      const probed = await probeBrandTopics({
+        brandName: profile.brand_name,
+        brandDomain,
+        topics: topTopics,
+        queryMap,
+      });
+      geoOpportunities = probed.opportunities;
+      probeEvidence = probed.evidence;
+      console.log(`[GEO] Tool 2 MEASURED ${geoOpportunities.length} engine-topic scores across ${probed.engines.length} engine(s), ${probeEvidence.length} probes`);
+    } catch (e) {
+      // Never fall back to fabricated numbers — fail loudly instead.
+      console.error('[GEO] Tool 2 probe failed:', e.message);
+      return res.status(503).json({ success: false, error: `GEO engine probing unavailable: ${e.message}` });
+    }
 
     // ── Tool 3: Entity & Schema Mapper ────────────────────────────────────────
     console.log('[GEO] Tool 3: Entity & Schema Mapper...');
@@ -351,6 +379,10 @@ Return ONLY valid JSON array:
     }
     console.log(`[GEO] Persisted ${persistedOpportunities.length} opportunities in session ${discoverySessionId}`);
 
+    // Honest headline: mean measured citation strength across probed topics (0 if none).
+    const _scored = persistedOpportunities.map(o => o.avgScore || 0);
+    const meanReadiness = _scored.length ? Math.round(_scored.reduce((a, b) => a + b, 0) / _scored.length) : 0;
+
     // Build legacy brief shape for response compatibility — stub values, no real brief yet
     // The actual per-topic brief building happens in Stage 2.1 when user selects topics
     const briefData = {
@@ -362,15 +394,21 @@ Return ONLY valid JSON array:
       faqStructure: [],
       geoAnchors: [],
       schemaRequirements: [],
-      overallOpportunityScore: persistedOpportunities.length ? Math.round(Math.max(...persistedOpportunities.map(o => o.avgScore || 0))) : 0,
-      targetPlatforms: [],
+      // Headline = MEAN measured citation strength across all probed topics, not the
+      // single best topic (MAX). MAX let one strong niche overstate overall visibility;
+      // the mean is the honest "how cited is this brand across its opportunity set."
+      overallOpportunityScore: meanReadiness,
+      targetPlatforms: enabledEngines(),
       contentCalendar: { month1: [], month2: [], month3: [] },
       quickWins: quickWins.map(q => ({ topic: q.topic, rationale: '', geoTarget: '' })),
       geoScorecard: {
-        currentReadiness: persistedOpportunities.length ? Math.round(Math.max(...persistedOpportunities.map(o => o.avgScore || 0))) : 0,
+        currentReadiness: meanReadiness,
+        scoreBasis: 'measured',           // measured engine citations, not modeled
+        enginesProbed: enabledEngines(),
         primaryGap: 'User selection pending',
         topOpportunity: quickWins[0]?.topic || persistedOpportunities[0]?.topic || ''
       },
+      probeEvidence: probeEvidence.slice(0, 200),
       briefRationale: `${persistedOpportunities.length} opportunities discovered. Cherry-pick topics to build briefs.`,
       discoverySessionId,
       pendingUserSelection: true

--- a/test/geoProbe.test.js
+++ b/test/geoProbe.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { hostOf, gradeAnswer, scoreFromGrades, defaultQueries } from '../src/server/geoProbe.js';
+
+describe('hostOf', () => {
+  it('extracts host from a full URL and strips www', () => {
+    expect(hostOf('https://www.forge.example.com/path?q=1')).toBe('forge.example.com');
+  });
+  it('handles a bare domain', () => {
+    expect(hostOf('forge.example.com')).toBe('forge.example.com');
+  });
+  it('is null-safe', () => {
+    expect(hostOf(null)).toBe('');
+    expect(hostOf(undefined)).toBe('');
+  });
+});
+
+describe('gradeAnswer', () => {
+  const brand = { brandDomain: 'forge.example.com', brandName: 'Forge' };
+  it('scores 100 when the brand domain is in the citation URLs', () => {
+    const g = gradeAnswer({ text: 'Some answer.', urls: ['https://forge.example.com/post'], ...brand });
+    expect(g).toEqual({ score: 100, status: 'cited' });
+  });
+  it('scores 100 when the brand domain appears in the answer text', () => {
+    const g = gradeAnswer({ text: 'According to forge.example.com it works.', urls: [], ...brand });
+    expect(g.score).toBe(100);
+  });
+  it('scores 50 when the brand is named but not linked', () => {
+    const g = gradeAnswer({ text: 'Forge is one option in this space.', urls: ['https://competitor.com'], ...brand });
+    expect(g).toEqual({ score: 50, status: 'mentioned' });
+  });
+  it('scores 0 when the brand is absent', () => {
+    const g = gradeAnswer({ text: 'Competitors A and B lead here.', urls: ['https://competitor.com'], ...brand });
+    expect(g).toEqual({ score: 0, status: 'absent' });
+  });
+  it('prefers cited over mentioned when both are true', () => {
+    const g = gradeAnswer({ text: 'Forge says so.', urls: ['https://forge.example.com'], ...brand });
+    expect(g.status).toBe('cited');
+  });
+  it('ignores a too-short brand name to avoid false mentions', () => {
+    const g = gradeAnswer({ text: 'an example of work', urls: [], brandDomain: 'x.io', brandName: 'X' });
+    expect(g.status).toBe('absent');
+  });
+});
+
+describe('scoreFromGrades', () => {
+  it('averages and rounds the grades', () => {
+    expect(scoreFromGrades([{ score: 100 }, { score: 50 }, { score: 0 }])).toBe(50);
+  });
+  it('rounds to nearest integer', () => {
+    expect(scoreFromGrades([{ score: 100 }, { score: 0 }, { score: 0 }])).toBe(33);
+  });
+  it('returns null (no observation) for an all-failed set, distinct from a measured 0', () => {
+    expect(scoreFromGrades([null, null])).toBeNull();
+    expect(scoreFromGrades([])).toBeNull();
+  });
+  it('excludes failed observations from the average', () => {
+    expect(scoreFromGrades([{ score: 100 }, null])).toBe(100);
+  });
+});
+
+describe('defaultQueries', () => {
+  it('returns 3 brand-free queries including the bare topic', () => {
+    const qs = defaultQueries('event attribution');
+    expect(qs).toHaveLength(3);
+    expect(qs[0]).toBe('event attribution');
+    expect(qs.every(q => !/forge/i.test(q))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

The GEO scan's per-engine numbers (ChatGPT / Perplexity / Gemini / Google AI Overviews) were **never measured.** Stage 2 "Tool 2" was a single Claude call asked to *imagine* citation probability across the four engines — producing fabricated, lockstep scores (each engine a near-constant offset from the next) that never queried anything.

We've represented this as real engine probing in articles and pitch decks. That makes it a genuine correctness/credibility gap, not cosmetic. Confirmed against real data: the modeled scan says brands score ~72–79, while the *real* citation probe (Performance Dashboard, already live) shows ChatGPT cites these brands **1.7%** of the time and Perplexity 18%. The two systems disagreed by an order of magnitude.

## What

- **New `src/server/geoProbe.js`** — real probing across all four engines:
  - Perplexity Sonar + OpenAI web search reuse the proven Performance Dashboard probe pattern.
  - **Gemini** (`google_search` grounding) and **Google AI Overviews** (via SerpAPI, with `page_token` follow-up) are new.
  - Each engine is env-gated by its own key; a missing key disables that engine rather than throwing. If **no** engine is configured the scan returns `503` — it never falls back to modeled numbers again.
- **Measured scoring, not guessed:** per (topic, engine) we ask 3 natural, brand-free buyer questions and grade each answer **100** (brand cited/linked) / **50** (named, not linked) / **0** (absent), then average. The 0–100 is a real citation-strength rate. A batched Claude call writes the natural queries (deterministic templated fallback).
- **`geo-strategist` Tool 2 now calls `probeBrandTopics()`** — output shape unchanged, so dedup, persistence, `normalizeGeoData`, and the UI table all keep working; only the numbers become real.
- **Honest headline:** `currentReadiness` switched from `MAX` (single best topic — let one niche overstate visibility) to **`MEAN`** across probed topics. Brief now carries `scoreBasis: 'measured'`, `enginesProbed`, and `probeEvidence`.
- Cache-staleness heuristic honors the `measured` marker so a genuinely invisible brand (real 0s) isn't re-probed forever.

## Required before merge to prod

Set in Render env (prod + dev): **`GEMINI_API_KEY`**, **`SERPAPI_KEY`**.
(`PERPLEXITY_API_KEY` + `OPENAI_API_KEY` already set for the dashboard probe.)

## Test plan

- 14 new unit tests for the pure scoring helpers (`hostOf`, `gradeAnswer`, `scoreFromGrades`, `defaultQueries`); full suite **119 green**.
- Lint + `node --check` clean; route inventory unchanged (no new routes).
- Live engine calls are env-gated, so they can't run in CI — verify on dev after the keys land by running a GEO scan and confirming non-lockstep per-engine numbers + `scoreBasis: 'measured'` in the brief.

## Rollback

Revert this PR. The old modeled Tool 2 returns; no schema/migration changes (evidence rides in the existing `brief_data` JSONB).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_