### PR TITLE
fix(analytics): scope LinkedIn Insight Tag to marketing pages only

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,22 +33,22 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-<!-- LinkedIn Insight Tag -->
+<!-- LinkedIn Insight Tag — marketing pages only; never loads on the authenticated /app -->
     <script type="text/javascript">
-      _linkedin_partner_id = "8912978";
-      window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
-      window._linkedin_data_partner_ids.push(_linkedin_partner_id);
-    </script>
-    <script type="text/javascript">
-      (function(l) {
-        if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
-        window.lintrk.q=[]}
-        var s = document.getElementsByTagName("script")[0];
-        var b = document.createElement("script");
-        b.type = "text/javascript";b.async = true;
-        b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
-        s.parentNode.insertBefore(b, s);
-      })(window.lintrk);
+      if (!window.location.pathname.startsWith("/app")) {
+        _linkedin_partner_id = "8912978";
+        window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+        window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+        (function(l) {
+          if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+          window.lintrk.q=[]}
+          var s = document.getElementsByTagName("script")[0];
+          var b = document.createElement("script");
+          b.type = "text/javascript";b.async = true;
+          b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+          s.parentNode.insertBefore(b, s);
+        })(window.lintrk);
+      }
     </script>
     </head>
   <body>


### PR DESCRIPTION
## Why

The LinkedIn Insight Tag was in the global `index.html`, so it loaded on **every** route — including the authenticated `/app/*` dashboard. That fired tracking beacons (and the `blocked:other` devtools noise) for logged-in users, and it contradicted our own privacy policy (`PrivacyPage.tsx:112`), which states the tag is only on marketing pages.

## What

Gate the entire tag (partner-id push + loader) behind a path check so it only initializes when the initial load is **not** under `/app`:

```js
if (!window.location.pathname.startsWith("/app")) { /* ...tag... */ }
```

- Marketing pages (`/`, `/pricing`, `/privacy`, …) still fire it on load — conversion tracking unchanged.
- The app (`/app/*`) never loads `snap.licdn.com` / `px.ads.linkedin.com`.
- Every authenticated route lives under `/app/*` (verified against `TopBar.tsx` route map), so the prefix check is exact.

GTM is left as-is — it also loads site-wide, but that's a separate call and site-wide GTM is often intentional. Happy to scope it too if you want.

## Test plan

- `npm run build` passes (tsc + vite).
- After deploy to dev: load `/app/performance` → no LinkedIn requests in Network; load a marketing page → tag fires as before. The reds you saw will be gone on app pages.

## Rollback

Revert — the tag returns to unconditional load. No other surface touched.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_