### PR TITLE
feat(geo): public AI Visibility scan lead magnet at /scan

### DIFF
--- a/server.js
+++ b/server.js
@@ -8861,22 +8861,37 @@ app.get('/api/content-generator/enriched-briefs/:brandProfileId', requireAuth, a
 });
 
 
-// POST /api/geo/cold-scan — AI Visibility scan for a prospect we have NO content for.
-// Scrape their homepage, infer the buyer questions their category gets asked, then
-// probe all four engines to MEASURE how often AI cites them vs who it cites instead.
-// This powers the shareable lead-magnet report. Synchronous (30-90s): the four-engine
-// probe runs inline. adminPassword bypass for testing; otherwise requires a Clerk JWT.
-// NOTE: before going public as a lead magnet this needs rate-limiting + abuse controls
-// (it spends SerpAPI + LLM credits per call). Gated to auth/admin for now.
+// POST /api/geo/cold-scan — public AI Visibility scan (the lead magnet at /scan).
+// Scrape a prospect's homepage, infer the buyer questions their category gets asked,
+// then probe all four engines to MEASURE how often AI cites them vs who it cites
+// instead. Synchronous (30-90s): the four-engine probe runs inline.
+//
+// PUBLIC + rate-limited: each scan spends SerpAPI + LLM credits, so anonymous callers
+// are capped per-IP and globally per-day to bound spend. adminPassword bypasses the
+// cap (testing). The limiter is in-memory — approximate across Render instances; a
+// Redis/DB-backed limiter is the hardening follow-up before heavy traffic.
+const _coldScanIpHits = new Map();        // ip -> [timestamps within the hour]
+let _coldScanDay = { day: '', count: 0 }; // global daily counter
+const COLD_SCAN_PER_IP_PER_HOUR = 3;
+const COLD_SCAN_GLOBAL_PER_DAY = 250;
+function coldScanRateCheck(ip) {
+  const now = Date.now();
+  const today = new Date().toISOString().slice(0, 10);
+  if (_coldScanDay.day !== today) _coldScanDay = { day: today, count: 0 };
+  if (_coldScanDay.count >= COLD_SCAN_GLOBAL_PER_DAY) return 'global';
+  const recent = (_coldScanIpHits.get(ip) || []).filter(t => now - t < 3600000);
+  if (recent.length >= COLD_SCAN_PER_IP_PER_HOUR) return 'ip';
+  recent.push(now); _coldScanIpHits.set(ip, recent); _coldScanDay.count++;
+  return null;
+}
+
 app.post('/api/geo/cold-scan', async (req, res) => {
   const isAdmin = req.body?.adminPassword && req.body.adminPassword === process.env.ADMIN_RELAY_PASSWORD;
   if (!isAdmin) {
-    const authHeader = req.headers.authorization;
-    if (!authHeader?.startsWith('Bearer ')) return res.status(401).json({ success: false, error: 'Unauthorized' });
-    try {
-      const { payload } = await jwtVerify(authHeader.split(' ')[1], clerkJWKS, { algorithms: ['RS256'], clockTolerance: '30s' });
-      req.userId = payload.sub;
-    } catch { return res.status(401).json({ success: false, error: 'Invalid token' }); }
+    const ip = (req.headers['x-forwarded-for'] || '').split(',')[0].trim() || req.ip || 'unknown';
+    const limited = coldScanRateCheck(ip);
+    if (limited === 'ip') return res.status(429).json({ success: false, error: "You've run a few scans already — try again in an hour." });
+    if (limited === 'global') return res.status(429).json({ success: false, error: "We've hit today's free-scan limit. Check back tomorrow, or book a teardown." });
   }
 
   const { url } = req.body;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,6 +34,7 @@ import DocsPage from './pages/DocsPage';
 import AcceptableUsePage from './pages/AcceptableUsePage';
 import EmailCampaignPage from './pages/EmailCampaignPage';
 import QuickStartPage from './pages/QuickStartPage';
+import AiVisibilityScanPage from './pages/AiVisibilityScanPage';
 import './index.css';
 
 
@@ -117,6 +118,9 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/about" element={<About />} />
           <Route path="/faq" element={<Faq />} />
         <Route path="/welcome" element={<WelcomePage />} />
+
+        {/* Public AI Visibility scan — lead magnet, no auth, no AppProvider */}
+        <Route path="/scan" element={<AiVisibilityScanPage />} />
 
         {/* Public Quick Start onramp — no Clerk gate, no AppProvider. Founders
             without a marketing website fill the Founder Brief here; submission

--- a/src/pages/AiVisibilityScanPage.css
+++ b/src/pages/AiVisibilityScanPage.css
@@ -1,0 +1,108 @@
+/* Public AI Visibility scan (/scan) — the lead-magnet landing + report.
+   Uses the app's light design tokens (defined in index.css :root). */
+
+.avs-page{
+  min-height:100vh;
+  background:var(--color-bg-base);
+  color:var(--color-text-primary);
+  font-family:Inter,system-ui,sans-serif;
+  -webkit-font-smoothing:antialiased;
+  padding:48px 20px 72px;
+}
+.avs-wrap{max-width:860px;margin:0 auto;}
+
+/* ── top brand bar ── */
+.avs-top{display:flex;align-items:center;gap:10px;margin-bottom:42px;}
+.avs-diamond{width:20px;height:20px;border-radius:5px;
+  background:linear-gradient(135deg,var(--color-accent),#7a93ff);transform:rotate(45deg);}
+.avs-logo{font-weight:700;letter-spacing:.2px;font-size:16px;}
+.avs-logo span{color:var(--color-text-muted);font-weight:500;}
+
+/* ── hero / form ── */
+.avs-hero{text-align:center;max-width:680px;margin:0 auto;}
+.avs-eyebrow{font-size:12px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--color-accent);font-weight:700;}
+.avs-hero h1{font-size:38px;line-height:1.1;margin:14px 0 14px;font-weight:800;
+  color:var(--color-text-emphasis);letter-spacing:-.5px;}
+.avs-hero p.lede{font-size:17px;line-height:1.55;color:var(--color-text-secondary);}
+
+.avs-form{display:flex;gap:10px;margin:34px auto 12px;max-width:540px;}
+.avs-input{flex:1;height:52px;border:1px solid var(--color-border-input);border-radius:var(--radius-md);
+  padding:0 16px;font-size:15px;background:var(--color-bg-card);color:var(--color-text-primary);
+  font-family:inherit;outline:none;transition:border-color .15s, box-shadow .15s;}
+.avs-input:focus{border-color:var(--color-accent);box-shadow:0 0 0 3px var(--color-accent-muted);}
+.avs-btn{height:52px;padding:0 26px;border:none;border-radius:var(--radius-md);
+  background:var(--color-accent);color:#fff;font-weight:700;font-size:15px;cursor:pointer;
+  white-space:nowrap;transition:background .15s;}
+.avs-btn:hover:not(:disabled){background:var(--color-accent-hover);}
+.avs-btn:disabled{opacity:.55;cursor:default;}
+.avs-formnote{font-size:12.5px;color:var(--color-text-muted);}
+.avs-err{color:var(--color-error);font-size:14px;margin-top:14px;}
+
+/* ── loading ── */
+.avs-loading{text-align:center;margin:60px auto;max-width:520px;}
+.avs-spinner{width:42px;height:42px;border:3px solid var(--color-accent-muted);
+  border-top-color:var(--color-accent);border-radius:50%;margin:0 auto 22px;animation:avs-spin .9s linear infinite;}
+@keyframes avs-spin{to{transform:rotate(360deg)}}
+.avs-loading .step{font-size:16px;font-weight:600;color:var(--color-text-primary);min-height:24px;}
+.avs-loading .sub{font-size:13.5px;color:var(--color-text-muted);margin-top:8px;}
+
+/* ── report ── */
+.avs-report{margin-top:30px;background:var(--color-bg-card);border:1px solid var(--color-border);
+  border-radius:18px;overflow:hidden;box-shadow:0 18px 50px rgba(53,99,255,.07);}
+.avs-rhd{display:flex;align-items:center;justify-content:space-between;
+  padding:20px 30px;border-bottom:1px solid var(--color-border);background:var(--color-bg-elevated);}
+.avs-rhd .who{font-weight:700;font-size:16px;color:var(--color-text-emphasis);}
+.avs-rhd .tagpill{font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--color-accent);
+  font-weight:700;background:var(--color-accent-muted);padding:5px 11px;border-radius:999px;}
+.avs-rbody{padding:30px;}
+
+.avs-scorewrap{display:flex;gap:26px;align-items:center;
+  background:var(--color-bg-elevated);border:1px solid var(--color-border);
+  border-radius:14px;padding:26px 30px;}
+.avs-score{font-size:76px;font-weight:800;line-height:1;letter-spacing:-2px;}
+.avs-score.bad{color:var(--color-error);} .avs-score.warn{color:var(--color-warning);} .avs-score.ok{color:var(--color-success);}
+.avs-score small{font-size:30px;font-weight:700;}
+.avs-scoretext .l{font-size:16px;font-weight:700;color:var(--color-text-emphasis);}
+.avs-scoretext .s{font-size:13.5px;color:var(--color-text-secondary);margin-top:6px;line-height:1.5;}
+
+.avs-sec{margin-top:32px;}
+.avs-sec h2{font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:var(--color-text-muted);
+  font-weight:700;margin-bottom:14px;}
+
+.avs-bars{display:flex;flex-direction:column;gap:12px;}
+.avs-bar{display:grid;grid-template-columns:160px 1fr 50px;align-items:center;gap:14px;}
+.avs-bar .nm{font-size:14px;font-weight:600;}
+.avs-track{height:10px;background:var(--color-bg-hover);border-radius:6px;overflow:hidden;}
+.avs-fill{height:100%;border-radius:6px;background:var(--color-accent);}
+.avs-fill.zero{background:var(--color-error);}
+.avs-bar .pc{text-align:right;font-variant-numeric:tabular-nums;font-weight:700;font-size:14px;}
+.avs-bar .pc.zero{color:var(--color-error);}
+
+.avs-cols{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
+@media(max-width:640px){.avs-cols{grid-template-columns:1fr;} .avs-form{flex-direction:column;} .avs-hero h1{font-size:30px;}}
+.avs-card{background:var(--color-bg-card);border:1px solid var(--color-border);border-radius:12px;padding:18px 20px;}
+.avs-card h3{font-size:13.5px;margin-bottom:4px;color:var(--color-text-emphasis);}
+.avs-card .cap{color:var(--color-text-secondary);font-size:12px;margin-bottom:14px;line-height:1.45;}
+.avs-chips{display:flex;flex-wrap:wrap;gap:8px;}
+.avs-chip{background:var(--color-bg-elevated);border:1px solid var(--color-border);border-radius:999px;
+  padding:5px 11px;font-size:12.5px;font-weight:600;color:var(--color-text-primary);}
+.avs-chip b{color:var(--color-text-muted);font-weight:600;font-variant-numeric:tabular-nums;margin-left:4px;}
+.avs-chip.vendor{border-color:rgba(53,99,255,.28);background:var(--color-accent-muted);}
+
+.avs-qlist{display:flex;flex-direction:column;gap:9px;}
+.avs-q{display:flex;gap:11px;align-items:flex-start;font-size:13.5px;line-height:1.4;
+  background:var(--color-bg-elevated);border:1px solid var(--color-border);border-radius:9px;padding:11px 14px;color:var(--color-text-secondary);}
+.avs-q .x{color:var(--color-error);font-weight:800;flex-shrink:0;}
+.avs-q .c{color:var(--color-success);font-weight:800;flex-shrink:0;}
+
+.avs-cta{margin-top:30px;display:flex;align-items:center;justify-content:space-between;gap:18px;
+  background:linear-gradient(135deg,#eef2ff,#e6ecff);border:1px solid rgba(53,99,255,.22);
+  border-radius:14px;padding:22px 26px;}
+.avs-cta .t{font-size:16px;font-weight:700;color:var(--color-text-emphasis);}
+.avs-cta .s{color:var(--color-text-secondary);font-size:13px;margin-top:4px;}
+.avs-cta a{background:var(--color-accent);color:#fff;border-radius:9px;padding:12px 22px;font-weight:700;
+  font-size:14px;text-decoration:none;white-space:nowrap;}
+.avs-again{display:block;margin:22px auto 0;background:none;border:none;color:var(--color-accent);
+  font-weight:600;font-size:14px;cursor:pointer;}
+.avs-foot{text-align:center;color:var(--color-text-muted);font-size:12px;margin-top:26px;}

--- a/src/pages/AiVisibilityScanPage.tsx
+++ b/src/pages/AiVisibilityScanPage.tsx
@@ -1,0 +1,229 @@
+import { useState, useEffect, useRef } from 'react';
+import './AiVisibilityScanPage.css';
+
+// Engines AI answer-engines we probe, in display order.
+const ENGINES: { id: string; label: string }[] = [
+  { id: 'perplexity', label: 'Perplexity' },
+  { id: 'chatgpt', label: 'ChatGPT' },
+  { id: 'gemini', label: 'Gemini' },
+  { id: 'aiOverviews', label: 'Google AI Overviews' },
+];
+
+// Generic platforms vs. brands/vendors — a light, honest split for the
+// "who AI cites instead" panel. Anything not in this set is treated as a
+// brand/vendor name worth surfacing.
+const GENERIC = new Set([
+  'youtube.com', 'linkedin.com', 'reddit.com', 'wikipedia.org', 'medium.com',
+  'github.com', 'quora.com', 'facebook.com', 'x.com', 'twitter.com', 'substack.com',
+]);
+
+type ScanResult = {
+  success: boolean;
+  error?: string;
+  brandName?: string;
+  brandDomain?: string;
+  visibility?: number;
+  totalChecks?: number;
+  totalCited?: number;
+  byEngine?: Record<string, { checks: number; cited: number; pct: number }>;
+  questions?: string[];
+  citedQueries?: string[];
+  sources?: { domain: string; mentions: number }[];
+};
+
+const LOADING_STEPS = [
+  'Reading your site…',
+  'Figuring out what your buyers ask AI…',
+  'Asking ChatGPT…',
+  'Asking Perplexity…',
+  'Asking Gemini…',
+  'Checking Google AI Overviews…',
+  'Counting who gets cited instead…',
+  'Scoring your AI visibility…',
+];
+
+export default function AiVisibilityScanPage() {
+  const [url, setUrl] = useState('');
+  const [phase, setPhase] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [stepIdx, setStepIdx] = useState(0);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<ScanResult | null>(null);
+  const stepTimer = useRef<number | null>(null);
+
+  useEffect(() => () => { if (stepTimer.current) window.clearInterval(stepTimer.current); }, []);
+
+  async function runScan(e?: React.FormEvent) {
+    e?.preventDefault();
+    const clean = url.trim();
+    if (!clean) return;
+    setPhase('loading'); setError(''); setResult(null); setStepIdx(0);
+    stepTimer.current = window.setInterval(
+      () => setStepIdx(i => Math.min(i + 1, LOADING_STEPS.length - 1)), 9000
+    );
+    try {
+      const res = await fetch('/api/geo/cold-scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: clean }),
+      });
+      const data: ScanResult = await res.json();
+      if (stepTimer.current) window.clearInterval(stepTimer.current);
+      if (!res.ok || !data.success) {
+        setError(data.error || `Scan failed (${res.status}). Try again shortly.`);
+        setPhase('error');
+        return;
+      }
+      setResult(data);
+      setPhase('done');
+    } catch {
+      if (stepTimer.current) window.clearInterval(stepTimer.current);
+      setError('Something went wrong reaching the scanner. Try again in a moment.');
+      setPhase('error');
+    }
+  }
+
+  function reset() { setPhase('idle'); setResult(null); setError(''); setUrl(''); }
+
+  const vis = result?.visibility ?? 0;
+  const scoreClass = vis === 0 ? 'bad' : vis < 25 ? 'warn' : 'ok';
+
+  const sources = result?.sources || [];
+  const vendors = sources.filter(s => !GENERIC.has(s.domain)).slice(0, 7);
+  const generic = sources.filter(s => GENERIC.has(s.domain)).slice(0, 5);
+  const lostQuestions = (result?.questions || [])
+    .filter(q => !(result?.citedQueries || []).includes(q))
+    .slice(0, 4);
+
+  return (
+    <div className="avs-page">
+      <div className="avs-wrap">
+        <div className="avs-top">
+          <span className="avs-diamond" />
+          <span className="avs-logo">Forge Intelligence <span>· AI Visibility Scan</span></span>
+        </div>
+
+        {(phase === 'idle' || phase === 'error') && (
+          <div className="avs-hero">
+            <div className="avs-eyebrow">Generative Engine Optimization</div>
+            <h1>How often does AI recommend you?</h1>
+            <p className="lede">
+              ChatGPT, Perplexity, Gemini, and Google AI Overviews answer your buyers’ questions every day.
+              Drop your domain and we’ll measure — live — whether they name you, and who they name instead.
+            </p>
+            <form className="avs-form" onSubmit={runScan}>
+              <input
+                className="avs-input"
+                type="text"
+                inputMode="url"
+                placeholder="yourcompany.com"
+                value={url}
+                onChange={e => setUrl(e.target.value)}
+                autoFocus
+              />
+              <button className="avs-btn" type="submit" disabled={!url.trim()}>Run free scan</button>
+            </form>
+            <div className="avs-formnote">Free · no signup · ~60 seconds · measured across all four engines</div>
+            {phase === 'error' && <div className="avs-err">{error}</div>}
+          </div>
+        )}
+
+        {phase === 'loading' && (
+          <div className="avs-loading">
+            <div className="avs-spinner" />
+            <div className="step">{LOADING_STEPS[stepIdx]}</div>
+            <div className="sub">Running real queries against four AI engines — this takes up to a minute.</div>
+          </div>
+        )}
+
+        {phase === 'done' && result && (
+          <>
+            <div className="avs-report">
+              <div className="avs-rhd">
+                <span className="who">{result.brandName || result.brandDomain}</span>
+                <span className="tagpill">AI Visibility Report</span>
+              </div>
+              <div className="avs-rbody">
+                <div className="avs-scorewrap">
+                  <div className={`avs-score ${scoreClass}`}>{vis}<small>%</small></div>
+                  <div className="avs-scoretext">
+                    <div className="l">
+                      {result.brandName || 'You'} appeared in {result.totalCited} of {result.totalChecks} AI answers.
+                    </div>
+                    <div className="s">
+                      {vis === 0
+                        ? 'Not once. Across every engine and every question your buyers ask, AI never named you.'
+                        : 'Across the questions your buyers ask AI about your category — measured live, not modeled.'}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="avs-sec">
+                  <h2>Visibility by engine</h2>
+                  <div className="avs-bars">
+                    {ENGINES.map(eng => {
+                      const pct = result.byEngine?.[eng.id]?.pct ?? 0;
+                      return (
+                        <div className="avs-bar" key={eng.id}>
+                          <span className="nm">{eng.label}</span>
+                          <div className="avs-track"><div className={`avs-fill ${pct === 0 ? 'zero' : ''}`} style={{ width: `${Math.max(pct, 1)}%` }} /></div>
+                          <span className={`pc ${pct === 0 ? 'zero' : ''}`}>{pct}%</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {(vendors.length > 0 || generic.length > 0) && (
+                  <div className="avs-sec">
+                    <h2>Who AI cites instead</h2>
+                    <div className="avs-cols">
+                      {vendors.length > 0 && (
+                        <div className="avs-card">
+                          <h3>Brands &amp; vendors AI names</h3>
+                          <div className="cap">When buyers ask about your category, these come up. You don’t.</div>
+                          <div className="avs-chips">
+                            {vendors.map(v => <span className="avs-chip vendor" key={v.domain}>{v.domain}<b>{v.mentions}</b></span>)}
+                          </div>
+                        </div>
+                      )}
+                      {generic.length > 0 && (
+                        <div className="avs-card">
+                          <h3>Where else AI sends your buyers</h3>
+                          <div className="cap">Generic sources AI falls back to when no clear vendor wins.</div>
+                          <div className="avs-chips">
+                            {generic.map(g => <span className="avs-chip" key={g.domain}>{g.domain}<b>{g.mentions}</b></span>)}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {lostQuestions.length > 0 && (
+                  <div className="avs-sec">
+                    <h2>{vis === 0 ? 'The questions you’re losing' : 'Questions you’re not winning'}</h2>
+                    <div className="avs-qlist">
+                      {lostQuestions.map((q, i) => (
+                        <div className="avs-q" key={i}><span className="x">✕</span><span>“{q}”</span></div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="avs-cta">
+                  <div>
+                    <div className="t">Turn these answers in your favor.</div>
+                    <div className="s">Forge maps every buyer question to the content that earns the AI citation — and tracks your score weekly across all four engines.</div>
+                  </div>
+                  <a href="/?utm_source=ai-visibility-scan">Get your GEO plan →</a>
+                </div>
+              </div>
+            </div>
+            <button className="avs-again" onClick={reset}>← Scan another domain</button>
+            <div className="avs-foot">Measured live across ChatGPT · Perplexity · Gemini · Google AI Overviews · {result.totalChecks} checks</div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

The cold-scan (#268) proved out — Nova came back **0% across all four engines** with named competitors AI recommends instead. This makes it a public **lead magnet**: a prospect drops their domain at `/scan`, gets the real measured report, and sees exactly where they're invisible.

## What

**Frontend** — `src/pages/AiVisibilityScanPage.tsx` + `.css`:
- New **public** route `/scan` (no auth, no `AppProvider` — same pattern as Quick Start / public articles).
- **Light theme** built from the app's real design tokens (`--color-bg-base` lavender, white cards, `#3563FF` accent, slate text) — matches the current app, **not** the dark mock.
- Flow: domain form → loading (rotating status, ~60s) → report: visibility score, per-engine bars, "who AI cites instead" (brands/vendors vs generic sources), the buyer questions being lost, and a GEO-plan CTA.

**Backend** — `server.js`: `/api/geo/cold-scan` is now **public + rate-limited** instead of auth-gated. Per-IP cap (3/hr) + global daily cap (250) bound SerpAPI/LLM spend; `adminPassword` still bypasses. **No new route** — only the gating changed, so the route snapshot is unchanged.

## Known follow-ups (called out, not done here)

- **Rate limiter is in-memory** → approximate across Render instances. Redis/DB-backed limiter before heavy traffic.
- **Lead capture** → the CTA links out for now; wiring email/domain to a CRM/DB is a deliberate fast-follow (and conversion-wise, better to show the score *first*, then capture).
- Bundle size warning is pre-existing (whole app is one chunk).

## Test plan

- `npm run build` (tsc + vite) green; lint clean; suite **125 green**; route snapshot unchanged.
- Live probe is key-gated → can't run in CI. After deploy: visit `/scan`, enter a domain (no login), confirm the report renders in light theme and a 4th rapid scan from one IP returns the friendly 429.

## Rollback

Revert — removes the `/scan` route + page and restores the auth gate on the endpoint. No schema changes.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_