### PR TITLE
fix(geo): count brand-name mentions in cold scan, not just domain citations

### DIFF
--- a/server.js
+++ b/server.js
@@ -8912,7 +8912,7 @@ app.post('/api/geo/cold-scan', async (req, res) => {
     const qRes = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 1200,
-      messages: [{ role: 'user', content: `From this company's homepage, identify the brand name and write 10 natural questions a B2B buyer would type into ChatGPT or Perplexity when researching this category — the questions where this company would WANT to be recommended. Do NOT mention the company's own name in any question (we are measuring unprompted visibility). Keep each question under 110 characters.
+      messages: [{ role: 'user', content: `From this company's homepage, identify the brand name and write 10 natural questions a buyer or customer (B2B or consumer, whichever fits) would type into ChatGPT or Perplexity when researching this category — the questions where this company would WANT to be recommended. Do NOT mention the company's own name in any question (we are measuring unprompted visibility). Keep each question under 110 characters.
 
 HOMEPAGE (${brandDomain}):
 ${pageText}

--- a/src/server/geoProbe.js
+++ b/src/server/geoProbe.js
@@ -144,8 +144,9 @@ export async function coldScan({ brandName, brandDomain, questions }) {
     throw new Error('No GEO engines configured — set at least one of PERPLEXITY_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, SERPAPI_KEY. Refusing to emit modeled scores.');
   }
   const qs = (questions || []).filter(q => typeof q === 'string' && q.trim());
-  const byEngine = Object.fromEntries(engines.map(e => [e.id, { checks: 0, cited: 0 }]));
-  let totalChecks = 0, totalCited = 0;
+  // per engine: checks, cited(=visible: linked or mentioned), linked(=domain cited)
+  const byEngine = Object.fromEntries(engines.map(e => [e.id, { checks: 0, cited: 0, linked: 0 }]));
+  let totalChecks = 0, totalCited = 0, totalLinked = 0;
   const allUrls = [];
   const citedQueries = [];
   const perQuestion = [];
@@ -155,11 +156,15 @@ export async function coldScan({ brandName, brandDomain, questions }) {
     await Promise.all(engines.map(async (engine) => {
       try {
         const { text, urls } = await engine.probe(q);
-        const cited = isCited({ text, urls, brandDomain });
+        const v = scanVisibility({ text, urls, brandName, brandDomain });
         byEngine[engine.id].checks++; totalChecks++;
-        if (cited) { byEngine[engine.id].cited++; totalCited++; if (!citedQueries.includes(q)) citedQueries.push(q); }
+        if (v.visible) {
+          byEngine[engine.id].cited++; totalCited++;
+          if (v.status === 'cited') { byEngine[engine.id].linked++; totalLinked++; }
+          if (!citedQueries.includes(q)) citedQueries.push(q);
+        }
         allUrls.push(...(urls || []));
-        row.engines[engine.id] = cited ? 'cited' : 'absent';
+        row.engines[engine.id] = v.status;
       } catch (e) {
         console.error(`[COLD-SCAN] ${engine.id} "${q}":`, e.message);
         row.engines[engine.id] = 'error';
@@ -171,8 +176,9 @@ export async function coldScan({ brandName, brandDomain, questions }) {
   const pct = (c, n) => (n ? Math.round((c / n) * 100) : 0);
   return {
     brandName, brandDomain,
+    // visibility = share of answers where the brand shows up at all (named or linked)
     visibility: pct(totalCited, totalChecks),
-    totalChecks, totalCited,
+    totalChecks, totalCited, totalLinked,
     byEngine: Object.fromEntries(engines.map(e => [e.id, { ...byEngine[e.id], pct: pct(byEngine[e.id].cited, byEngine[e.id].checks) }])),
     sources: aggregateSources(allUrls, brandDomain),
     citedQueries,
@@ -193,6 +199,34 @@ export function urlHasDomain(url, brandDomain) {
 export function isCited({ text = '', urls = [], brandDomain = '' }) {
   if (!brandDomain) return false;
   return (urls || []).some(u => urlHasDomain(u, brandDomain)) || (text || '').toLowerCase().includes(brandDomain.toLowerCase());
+}
+
+// Name tokens used to detect a brand MENTION (vs a domain citation): the brand
+// name and the domain's second-level label, length-guarded so short/common
+// fragments don't match. e.g. nike.com -> ["nike"]; novaintelligenceai.com +
+// "Nova Intelligence" -> ["nova intelligence", "novaintelligenceai"].
+export function brandTokens(brandName, brandDomain) {
+  const toks = new Set();
+  const n = (brandName || '').toLowerCase().trim();
+  if (n.length > 2) toks.add(n);
+  const sld = (brandDomain || '').toLowerCase().replace(/^www\./, '').split('.')[0];
+  if (sld && sld.length > 3) toks.add(sld);
+  return [...toks];
+}
+
+// Visibility for the cold scan: the brand is "visible" in an answer if its domain
+// is cited/linked (strong) OR its name appears in the answer text (a mention).
+// Domain-only badly undercounts well-known brands that engines name without
+// linking (e.g. an answer that recommends "Nike" but links a review site).
+// Returns { visible, status: 'cited' | 'mentioned' | 'absent' }.
+export function scanVisibility({ text = '', urls = [], brandName = '', brandDomain = '' }) {
+  if (isCited({ text, urls, brandDomain })) return { visible: true, status: 'cited' };
+  const t = (text || '').toLowerCase();
+  for (const tok of brandTokens(brandName, brandDomain)) {
+    const re = new RegExp(`(^|[^a-z0-9])${tok.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([^a-z0-9]|$)`);
+    if (re.test(t)) return { visible: true, status: 'mentioned' };
+  }
+  return { visible: false, status: 'absent' };
 }
 
 // Which part of the article got cited: section bodies first, then FAQs, then a

--- a/test/geoProbe.test.js
+++ b/test/geoProbe.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { urlHasDomain, isCited, findCitedSection, CITATION_ENGINES, extractDomain, aggregateSources } from '../src/server/geoProbe.js';
+import { urlHasDomain, isCited, findCitedSection, CITATION_ENGINES, extractDomain, aggregateSources, brandTokens, scanVisibility } from '../src/server/geoProbe.js';
 
 describe('urlHasDomain', () => {
   it('matches a domain inside a URL (case-insensitive)', () => {
@@ -94,6 +94,41 @@ describe('aggregateSources', () => {
   it('is empty-safe', () => {
     expect(aggregateSources([], 'brand.com')).toEqual([]);
     expect(aggregateSources(null, 'brand.com')).toEqual([]);
+  });
+});
+
+describe('brandTokens', () => {
+  it('includes the brand name and the domain SLD', () => {
+    expect(brandTokens('Nova Intelligence', 'novaintelligenceai.com')).toEqual(['nova intelligence', 'novaintelligenceai']);
+  });
+  it('drops too-short tokens', () => {
+    // name "Hi" (<=2) dropped; SLD "ab" (<=3) dropped
+    expect(brandTokens('Hi', 'ab.com')).toEqual([]);
+  });
+  it('dedupes when name equals SLD', () => {
+    expect(brandTokens('nike', 'nike.com')).toEqual(['nike']);
+  });
+});
+
+describe('scanVisibility', () => {
+  it('cited when the brand domain is linked', () => {
+    expect(scanVisibility({ text: 'great shoes', urls: ['https://nike.com/x'], brandName: 'Nike', brandDomain: 'nike.com' }))
+      .toEqual({ visible: true, status: 'cited' });
+  });
+  it('mentioned when the brand NAME appears in text but no link (the Nike bug)', () => {
+    const r = scanVisibility({ text: 'Nike and Adidas dominate running.', urls: ['https://runrepeat.com'], brandName: 'Nike', brandDomain: 'nike.com' });
+    expect(r).toEqual({ visible: true, status: 'mentioned' });
+  });
+  it('matches a possessive ("Nike’s") via word boundary', () => {
+    expect(scanVisibility({ text: "Nike's Vaporfly is popular", urls: [], brandName: 'Nike', brandDomain: 'nike.com' }).visible).toBe(true);
+  });
+  it('absent when neither name nor domain appears', () => {
+    expect(scanVisibility({ text: 'Adidas and Puma lead here', urls: ['https://x.com'], brandName: 'Nike', brandDomain: 'nike.com' }))
+      .toEqual({ visible: false, status: 'absent' });
+  });
+  it('does not match the token as a substring of another word', () => {
+    // "nova" should not match "innovation"
+    expect(scanVisibility({ text: 'this drives innovation forward', urls: [], brandName: 'Nova', brandDomain: 'nova.io' }).visible).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

Scanning **nike.com** via the live `/scan` returned **0%** — obviously wrong; Nike is one of the most-cited brands alive. (Surfaced right after #269 merged.)

## Root cause

The cold scan reused the Performance Dashboard's citation check, which only scores a hit when the brand **domain** (`nike.com`) is linked or typed in the answer. That's correct for "is *your article* cited," but wrong for a brand-visibility scan: engines recommend **"Nike"** by name while linking review sites (highsnobiety, runrepeat), so every answer scored as *absent*.

## Fix

New `scanVisibility()` counts a brand as visible if **either**:
- its domain is cited/linked → `cited` (strong), or
- its **name** appears in the answer text → `mentioned`

Name matching uses `brandTokens()` (brand name + domain second-level label, length-guarded, **word-boundary** matched so "nova" doesn't match "innovation"). `coldScan` now tracks visible (named-or-linked) vs linked-only; the headline visibility % reflects named-or-linked. Also generalized the question prompt from "B2B buyer" → "buyer or customer (B2B or consumer)" so B2C brands get sensible questions.

## Test plan

- +8 unit tests (`brandTokens`, `scanVisibility` incl. the exact Nike mention case + the "innovation" substring guard); suite **133 green**; build + lint clean.
- Live probe is key-gated → can't run in CI. **After merge + deploy I'll re-scan Nike to confirm it reads realistically.**

## Known tradeoff

Name-matching can slightly over-count brands whose name is a common word (a brand literally named "Notion" could catch "the notion that…"); word boundaries handle substrings but not true homonyms. If it bites, lean on the `cited` (linked) tier for the headline and label mentions separately.

## Rollback

Revert — `coldScan` reverts to domain-only `isCited`. No schema changes.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_