### PR TITLE
fix(geo): repair Gemini probe (live model + fail-loud) so dead engines never read as 0%

### DIFF
--- a/server.js
+++ b/server.js
@@ -8193,7 +8193,7 @@ app.get('/api/geo/debug/:brandProfileId', async (req, res) => {
     try {
       const controller = new AbortController();
       setTimeout(() => controller.abort(), 12000);
-      const gRes = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${process.env.GEMINI_API_KEY}`, {
+      const gRes = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${process.env.GEMINI_API_KEY}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ contents: [{ role: 'user', parts: [{ text: 'What are the best running shoe brands?' }] }], tools: [{ google_search: {} }] }),

--- a/src/pages/AiVisibilityScanPage.css
+++ b/src/pages/AiVisibilityScanPage.css
@@ -78,6 +78,7 @@
 .avs-fill.zero{background:var(--color-error);}
 .avs-bar .pc{text-align:right;font-variant-numeric:tabular-nums;font-weight:700;font-size:14px;}
 .avs-bar .pc.zero{color:var(--color-error);}
+.avs-bar .pc.na{color:var(--color-text-muted);font-weight:600;font-size:13px;}
 
 .avs-cols{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
 @media(max-width:640px){.avs-cols{grid-template-columns:1fr;} .avs-form{flex-direction:column;} .avs-hero h1{font-size:30px;}}

--- a/src/pages/AiVisibilityScanPage.tsx
+++ b/src/pages/AiVisibilityScanPage.tsx
@@ -25,7 +25,7 @@ type ScanResult = {
   visibility?: number;
   totalChecks?: number;
   totalCited?: number;
-  byEngine?: Record<string, { checks: number; cited: number; pct: number }>;
+  byEngine?: Record<string, { checks: number; cited: number; pct: number; available?: boolean }>;
   questions?: string[];
   citedQueries?: string[];
   sources?: { domain: string; mentions: number }[];
@@ -161,7 +161,20 @@ export default function AiVisibilityScanPage() {
                   <h2>Visibility by engine</h2>
                   <div className="avs-bars">
                     {ENGINES.map(eng => {
-                      const pct = result.byEngine?.[eng.id]?.pct ?? 0;
+                      const stats = result.byEngine?.[eng.id];
+                      // available:false (or missing) => the engine couldn't be queried;
+                      // show "not measured" rather than a misleading 0%.
+                      const available = stats ? stats.available !== false && stats.checks > 0 : false;
+                      const pct = stats?.pct ?? 0;
+                      if (!available) {
+                        return (
+                          <div className="avs-bar" key={eng.id}>
+                            <span className="nm">{eng.label}</span>
+                            <div className="avs-track" />
+                            <span className="pc na">n/a</span>
+                          </div>
+                        );
+                      }
                       return (
                         <div className="avs-bar" key={eng.id}>
                           <span className="nm">{eng.label}</span>

--- a/src/server/geoProbe.js
+++ b/src/server/geoProbe.js
@@ -26,6 +26,7 @@ export async function probePerplexity(query, doFetch = defaultFetch) {
     body: JSON.stringify({ model: 'sonar', messages: [{ role: 'user', content: query }], max_tokens: 400 }),
   });
   const data = await res.json();
+  if (!res.ok || data.error) throw new Error(`perplexity ${res.status}: ${data.error?.message || res.statusText}`);
   return { text: data.choices?.[0]?.message?.content || '', urls: data.citations || [] };
 }
 
@@ -36,6 +37,7 @@ export async function probeOpenAI(query, doFetch = defaultFetch) {
     body: JSON.stringify({ model: 'gpt-4o-mini', tools: [{ type: 'web_search_preview' }], input: query }),
   });
   const data = await res.json();
+  if (!res.ok || data.error) throw new Error(`openai ${res.status}: ${data.error?.message || res.statusText}`);
   const msgItem = data.output?.find(o => o.type === 'message');
   const textContent = msgItem?.content?.find(c => c.type === 'output_text');
   const text = textContent?.text || data.output_text || '';
@@ -47,11 +49,11 @@ export async function probeOpenAI(query, doFetch = defaultFetch) {
 }
 
 export async function probeGemini(query, doFetch = defaultFetch) {
-  // Gemini 2.0 Flash with Google Search grounding. Grounding chunks carry a Google
-  // redirect URI plus the resolved source title — keep both so domain matching can
-  // hit either.
+  // Gemini 2.5 Flash with Google Search grounding. (gemini-2.0-flash was retired —
+  // the API now 404s it.) Grounding chunks carry a Google redirect URI plus the
+  // resolved source title — keep both so domain matching can hit either.
   const res = await doFetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${process.env.GEMINI_API_KEY}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${process.env.GEMINI_API_KEY}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -59,6 +61,10 @@ export async function probeGemini(query, doFetch = defaultFetch) {
     }
   );
   const data = await res.json();
+  // An expired/invalid key or quota error returns 4xx + {error}. Throw so the
+  // caller EXCLUDES this engine rather than scoring it a false 0% (an unanswered
+  // engine is "unavailable", not "brand absent").
+  if (!res.ok || data.error) throw new Error(`gemini ${res.status}: ${data.error?.message || res.statusText}`);
   const cand = data.candidates?.[0];
   const text = (cand?.content?.parts || []).map(p => p.text || '').join(' ');
   const chunks = cand?.groundingMetadata?.groundingChunks || [];
@@ -73,6 +79,7 @@ export async function probeAIOverviews(query, doFetch = defaultFetch) {
   const base = 'https://serpapi.com/search.json';
   const res = await doFetch(`${base}?engine=google&q=${encodeURIComponent(query)}&api_key=${process.env.SERPAPI_KEY}`);
   let data = await res.json();
+  if (!res.ok || data.error) throw new Error(`serpapi ${res.status}: ${data.error || res.statusText}`);
   let ov = data.ai_overview;
   if (ov?.page_token && !ov.text_blocks) {
     const res2 = await doFetch(`${base}?engine=google_ai_overview&page_token=${encodeURIComponent(ov.page_token)}&api_key=${process.env.SERPAPI_KEY}`);
@@ -179,7 +186,9 @@ export async function coldScan({ brandName, brandDomain, questions }) {
     // visibility = share of answers where the brand shows up at all (named or linked)
     visibility: pct(totalCited, totalChecks),
     totalChecks, totalCited, totalLinked,
-    byEngine: Object.fromEntries(engines.map(e => [e.id, { ...byEngine[e.id], pct: pct(byEngine[e.id].cited, byEngine[e.id].checks) }])),
+    // available:false means every call to that engine failed (e.g. expired key) —
+    // the UI must show "not measured", never a false 0%.
+    byEngine: Object.fromEntries(engines.map(e => [e.id, { ...byEngine[e.id], pct: pct(byEngine[e.id].cited, byEngine[e.id].checks), available: byEngine[e.id].checks > 0 }])),
     sources: aggregateSources(allUrls, brandDomain),
     citedQueries,
     perQuestion,

--- a/test/geoProbe.test.js
+++ b/test/geoProbe.test.js
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { urlHasDomain, isCited, findCitedSection, CITATION_ENGINES, extractDomain, aggregateSources, brandTokens, scanVisibility } from '../src/server/geoProbe.js';
+import { urlHasDomain, isCited, findCitedSection, CITATION_ENGINES, extractDomain, aggregateSources, brandTokens, scanVisibility, probeGemini, probePerplexity } from '../src/server/geoProbe.js';
+
+const fakeRes = (status, body) => ({ ok: status >= 200 && status < 300, status, statusText: 'x', json: async () => body });
+
+describe('engine probes throw on API errors (so a dead engine is excluded, not scored a false 0%)', () => {
+  it('probeGemini throws on an expired-key 400', async () => {
+    await expect(probeGemini('q', async () => fakeRes(400, { error: { message: 'API key expired. Please renew the API key.' } })))
+      .rejects.toThrow(/gemini 400/);
+  });
+  it('probePerplexity throws on a non-OK response', async () => {
+    await expect(probePerplexity('q', async () => fakeRes(401, { error: { message: 'unauthorized' } })))
+      .rejects.toThrow(/perplexity 401/);
+  });
+  it('probeGemini returns text + grounding urls on success', async () => {
+    const body = { candidates: [{ content: { parts: [{ text: 'Nike leads.' }] }, groundingMetadata: { groundingChunks: [{ web: { uri: 'https://nike.com' } }] } }] };
+    const out = await probeGemini('q', async () => fakeRes(200, body));
+    expect(out.text).toContain('Nike');
+    expect(out.urls).toContain('https://nike.com');
+  });
+});
 
 describe('urlHasDomain', () => {
   it('matches a domain inside a URL (case-insensitive)', () => {


### PR DESCRIPTION
## Why

Gemini showed **0% on every scan** (Forge, Nova, Nike at 90/90/**0**/80). The `/api/geo/debug` diagnostic from #271 revealed it was **two stacked bugs**:

1. The `GEMINI_API_KEY` in Render was **expired** → `400 "API key expired"`. (Ops — you've rotated it.)
2. With the fresh key, the next error surfaced: model **`gemini-2.0-flash` is retired** → `404 "no longer available, use a newer model"`.

And the deeper product problem: a failed engine call was silently treated as **"brand absent"**, rendering a false `0%` — dangerous for a sales tool (it tells a prospect "AI never mentions you" when we simply failed to ask).

## What

- **Live model:** bump Gemini to **`gemini-2.5-flash`** (probe + debug test). `google_search` grounding unchanged.
- **Fail loud:** all four probes now **throw** on a non-OK / `{error}` response instead of returning empty.
- **No false zeros:** `coldScan` marks an engine `available:false` when every call to it failed; `/scan` renders **"n/a"** for that engine, and the headline visibility excludes unqueryable engines (denominator = answers we actually got). An expired key can never again read as `0%`.

## Test plan

- +3 probe-error unit tests (expired-key throw, non-OK throw, success path); suite **136 green**; build + lint clean.
- Live calls are key-gated → can't run in CI. **After deploy:** `curl /api/geo/debug/<id>` should show `apiTest.gemini` status **200**, `textLen > 0`; then a fresh Nike scan should light up **all four** engines.

## Rollback

Revert — probes return to non-throwing; UI back to numeric-only. No schema changes.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_