### PR TITLE
fix(scan): match /scan logo to the marketing topbar DiamondIcon

### DIFF
--- a/src/pages/AiVisibilityScanPage.css
+++ b/src/pages/AiVisibilityScanPage.css
@@ -13,7 +13,7 @@
 
 /* ── top brand bar ── */
 .avs-top{display:flex;align-items:center;gap:10px;margin-bottom:42px;}
-.avs-mark{width:22px;height:22px;border-radius:5px;display:block;}
+.avs-mark{display:flex;align-items:center;color:var(--color-accent);}
 .avs-logo{font-weight:700;letter-spacing:.2px;font-size:16px;}
 .avs-logo span{color:var(--color-text-muted);font-weight:500;}
 

--- a/src/pages/AiVisibilityScanPage.css
+++ b/src/pages/AiVisibilityScanPage.css
@@ -13,8 +13,7 @@
 
 /* ── top brand bar ── */
 .avs-top{display:flex;align-items:center;gap:10px;margin-bottom:42px;}
-.avs-diamond{width:20px;height:20px;border-radius:5px;
-  background:linear-gradient(135deg,var(--color-accent),#7a93ff);transform:rotate(45deg);}
+.avs-mark{width:22px;height:22px;border-radius:5px;display:block;}
 .avs-logo{font-weight:700;letter-spacing:.2px;font-size:16px;}
 .avs-logo span{color:var(--color-text-muted);font-weight:500;}
 

--- a/src/pages/AiVisibilityScanPage.tsx
+++ b/src/pages/AiVisibilityScanPage.tsx
@@ -98,7 +98,7 @@ export default function AiVisibilityScanPage() {
     <div className="avs-page">
       <div className="avs-wrap">
         <div className="avs-top">
-          <span className="avs-diamond" />
+          <img className="avs-mark" src="/favicon.svg" alt="Forge Intelligence" width={22} height={22} />
           <span className="avs-logo">Forge Intelligence <span>· AI Visibility Scan</span></span>
         </div>
 

--- a/src/pages/AiVisibilityScanPage.tsx
+++ b/src/pages/AiVisibilityScanPage.tsx
@@ -98,7 +98,11 @@ export default function AiVisibilityScanPage() {
     <div className="avs-page">
       <div className="avs-wrap">
         <div className="avs-top">
-          <img className="avs-mark" src="/favicon.svg" alt="Forge Intelligence" width={22} height={22} />
+          <span className="avs-mark" aria-label="Forge Intelligence">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="12 2 22 12 12 22 2 12" />
+            </svg>
+          </span>
           <span className="avs-logo">Forge Intelligence <span>· AI Visibility Scan</span></span>
         </div>
 


### PR DESCRIPTION
## Why

The `/scan` header used a CSS gradient diamond placeholder. The real brand mark used across the marketing topbars (Product + Landing) is the inline **`DiamondIcon`** — a stroked polygon in brand blue (`#3563FF` / `--color-accent`).

## What

Match the marketing topbar exactly on `/scan`: replace the placeholder with the same inline diamond SVG (`<polygon points="12 2 22 12 12 22 2 12" />`, 22px, accent color). Header is now consistent with the rest of the marketing site.

(First pass used `favicon.svg`, but that has a white tile baked in; the proper mark is the topbar DiamondIcon — swapped to that.)

## Test plan

`npm run build` + lint green. Visual: `/scan` header shows the same blue diamond as `/product`.

## Rollback

Revert.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7