### PR TITLE
fix(images): port fal.ai expand_prompt:false + 60s timeout to development

### DIFF
--- a/src/server/images.js
+++ b/src/server/images.js
@@ -17,10 +17,18 @@ export async function generateHeroImage(prompt) {
       prompt,
       aspect_ratio: '16:9',
       style: 'realistic',
-      expand_prompt: true,            // Ideogram's MagicPrompt — expands our terse prompt into a richer one before generation
+      // expand_prompt OFF: our prompt is already a carefully brand-voice-tuned
+      // sentence (buildImagePrompt, with explicit anti-AI-stock + don't-take-
+      // brand-name-literally constraints). Ideogram's MagicPrompt rewrites the
+      // prompt and can re-inject the generic/stock aesthetic we deliberately
+      // excluded, so we hand it our prompt verbatim.
+      expand_prompt: false,
       negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
       num_images: 1
-    })
+    }),
+    // Cap a hung fal.ai call. Image gen runs ~10-20s; 60s is generous headroom
+    // while still preventing an indefinite block on the generate/publish path.
+    signal: AbortSignal.timeout(60000)
   });
   if (!falRes.ok) throw new Error(`fal.ai ${falRes.status}: ${await falRes.text()}`);
   const falData = await falRes.json();
@@ -148,10 +156,14 @@ export async function generateSocialImage(prompt) {
       prompt,
       aspect_ratio: '1:1',
       style: 'realistic',
-      expand_prompt: true,
+      // expand_prompt OFF — see generateHeroImage. Our buildSocialImagePrompt
+      // output is already tuned; MagicPrompt would rewrite it and can undo the
+      // anti-stock / single-focal-subject constraints.
+      expand_prompt: false,
       negative_prompt: HERO_IMAGE_NEGATIVE_PROMPT,
       num_images: 1
-    })
+    }),
+    signal: AbortSignal.timeout(60000) // cap a hung fal.ai call (see generateHeroImage)
   });
   if (!falRes.ok) throw new Error(`fal.ai social ${falRes.status}: ${await falRes.text()}`);
   const falData = await falRes.json();


### PR DESCRIPTION
## Why

While reviewing the development→main rollup conflicts, I found one prod hotfix that **never made it back into development**: the fal.ai image fix (#226, live on main). Development's extracted `images.js` still had `expand_prompt: true` and no fetch timeout at **both** image sites.

That's a landmine for the rollup: resolving `server.js`/image conflicts as "take development" would **silently revert the fix in prod** — re-enabling Ideogram's MagicPrompt (the "weird images" regression that #226 cured) and dropping the hung-call guard.

## What

Port the fix into `src/server/images.js` to match main exactly, at both sites:
- `generateHeroImage` (16:9) and `generateSocialImage` (1:1): **`expand_prompt: false`** — send our brand-voice-tuned prompt verbatim (MagicPrompt was re-injecting the AI-stock look the negative prompt explicitly excludes).
- Add **`signal: AbortSignal.timeout(60000)`** to cap a hung fal.ai call.

This makes development a true superset of main for images, so the rollup can resolve cleanly to "take development" with no regression.

## Context (rollup review)

I verified the **other 5** main-only hotfixes are already in development: JWT clock-skew, citation recency-scoping + Sonar timeout, captureLog stringify guard, lovable `lovableHasData` gate, scrape SSRF. fal.ai was the only gap.

## Test plan

`node --check`, lint, full vitest suite all green. After deploy, generate a hero + social image and confirm the output isn't MagicPrompt-rewritten (and a hung fal call aborts at 60s).

## Rollback

Revert — returns to `expand_prompt: true` / no timeout.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_