### PR TITLE
fix(routes): ESM __dirname regression (prod) + nodeBuiltin lint guard

### DIFF
--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -7,8 +7,12 @@
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { pool } from '../db.js';
 import { anthropic } from '../llm.js';
+
+// ESM has no __dirname; resolve the repo root (this file lives at src/server/routes/).
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 import { extractJSON, safeParseLLM } from '../llm-json.js';
 import { requireAuth, verifyBrandAccess } from '../auth.js';
 import { stripScaffoldingArtifacts } from '../text.js';
@@ -256,7 +260,7 @@ router.post('/plan', requireAuth, async (req, res) => {
     };
 
     const systemPrompt = fs.readFileSync(
-      path.join(__dirname, 'src/agents/stage4_campaign_planner/system_prompt.md'), 'utf8'
+      path.join(REPO_ROOT, 'src/agents/stage4_campaign_planner/system_prompt.md'), 'utf8'
     );
 
     // Build the direction block — arc expansion is the strongest signal, custom prompt is medium, nothing is fallback.
@@ -490,7 +494,7 @@ router.get('/generate/:id', requireAuth, async (req, res) => {
     };
 
     const cgSystemPrompt = fs.readFileSync(
-      path.join(__dirname, 'src/agents/stage4_content_generator/system_prompt.md'), 'utf8'
+      path.join(REPO_ROOT, 'src/agents/stage4_content_generator/system_prompt.md'), 'utf8'
     );
 
     await pool.query(`UPDATE campaigns SET status = 'generating', updated_at = NOW() WHERE id = $1`, [req.params.id]);

--- a/src/server/routes/email-campaign.js
+++ b/src/server/routes/email-campaign.js
@@ -6,8 +6,12 @@
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { pool } from '../db.js';
 import { safeParseLLM } from '../llm-json.js';
+
+// ESM has no __dirname; resolve the repo root (this file lives at src/server/routes/).
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 import { stripScaffoldingArtifacts } from '../text.js';
 import { dateContext } from '../llm.js';
 import { activeStreams } from '../streams.js';
@@ -264,7 +268,7 @@ router.get('/generate/:id', async (req, res) => {
     ]);
 
     const systemPrompt = fs.readFileSync(
-      path.join(__dirname, 'src/agents/stage46_email_campaign/system_prompt.md'), 'utf8'
+      path.join(REPO_ROOT, 'src/agents/stage46_email_campaign/system_prompt.md'), 'utf8'
     );
 
     const trimTo = (obj, max = 3000) => {

--- a/src/server/routes/social-generator.js
+++ b/src/server/routes/social-generator.js
@@ -8,9 +8,13 @@
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { randomUUID } from 'crypto';
 import { pool } from '../db.js';
 import { anthropic, dateContext } from '../llm.js';
+
+// ESM has no __dirname; resolve the repo root (this file lives at src/server/routes/).
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 import { safeParseLLM } from '../llm-json.js';
 import { verifyBrandAccess } from '../auth.js';
 import { activeStreams } from '../streams.js';
@@ -144,7 +148,7 @@ router.get('/generate', async (req, res) => {
       : '';
 
     // Load system prompt
-    const systemPromptPath = path.join(__dirname, 'src/agents/stage4_social_generator/system_prompt.md');
+    const systemPromptPath = path.join(REPO_ROOT, 'src/agents/stage4_social_generator/system_prompt.md');
     const systemPrompt = fs.existsSync(systemPromptPath)
       ? fs.readFileSync(systemPromptPath, 'utf8')
       : 'You are a short-form social writer. Produce 4 platform-native posts.';


### PR DESCRIPTION
## 🔴 Prod hotfix + the CI guard that would've caught it

**Live error:** `[SOCIAL-GEN] Error: __dirname is not defined` on `/api/social-generator/generate`.

### Bug (commit 1)
When the social/campaign/email route groups were extracted from `server.js` into ESM modules under `src/server/routes/`, their `path.join(__dirname, 'src/agents/.../system_prompt.md')` prompt-loads came along — but **`__dirname` doesn't exist in ES modules**. `server.js` shims it; the extracted modules didn't → `ReferenceError` on every generate call. Latent since the route-group decomposition.

**Fix:** three modules (social-generator ×1, campaign ×2, email-campaign ×1) now derive `REPO_ROOT` from `import.meta.url` and join the unchanged `'src/agents/...'` path. Verified all four prompt files resolve. Scanned `src/server/**` — these three were the *only* `__dirname` users, so this closes the class.

### Guard (commit 2) — so this never recurs
`no-undef` missed it because `eslint.config.js` loaded `globals.node`, which *defines* the CommonJS-only globals (`__dirname`/`__filename`/`require`/`module`/`exports`) — valid to the linter, nonexistent at runtime in ESM. Switched to **`globals.nodeBuiltin`** (ESM-safe set; drops exactly those 5, keeps `process`/`fetch`/`Buffer`). Now a bare `__dirname`/`require` in any linted file **fails the PR gate**.

**Proof:** lint clean across the repo (zero fallout, verified), and a probe `const p = __dirname` now errors `'__dirname' is not defined`. Declared shims (`server.js`) still pass.

## Test plan
`node --check` + lint (stricter) + full vitest + clean `server.js` boot-import all green. After deploy: social/campaign/email generate with no `__dirname` error.

## Urgency
Generators are down in **prod** (dev==main). Recommend fast-track: merge here, then a quick `development → main` promotion. Happy to drive the promotion the moment CI's green.

## Rollback
Revert — forward-fix only (revert restores the broken state).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7