### PR TITLE
ci(lint): nodeBuiltin globals so CJS-in-ESM (bare __dirname) fails the gate

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,15 @@ export default [
       ecmaVersion: 2023,
       sourceType: 'module',
       globals: {
-        ...globals.node,
+        // nodeBuiltin (NOT node): the ESM-safe global set. It excludes the
+        // CommonJS-only globals __dirname/__filename/require/module/exports,
+        // which don't exist in ES modules (this codebase is "type":"module").
+        // With plain globals.node, no-undef treats a bare __dirname as valid and
+        // it blows up only at runtime — exactly the regression (#277) that shipped
+        // when route groups were extracted into ESM modules. nodeBuiltin makes
+        // no-undef flag it at the PR gate. Files that legitimately shim these
+        // (server.js: `const __dirname = …`) are declarations, so they pass.
+        ...globals.nodeBuiltin,
         // server.js runs browser code inside Puppeteer page.evaluate /
         // waitForFunction callbacks (forgeScrape). document/window are legit
         // there, so whitelist them rather than flag false positives.


### PR DESCRIPTION
## Why

Re-landing a guard that got **stranded** off #277. #277 shipped the `__dirname` prod fix; this CI change was pushed to that branch *after* it was merged, so it never reached development/main. Confirmed `globals.nodeBuiltin` is on neither branch.

## What

`eslint.config.js`: `...globals.node` → `...globals.nodeBuiltin`. `no-undef` missed the #277 regression because `globals.node` *defines* the CommonJS-only globals (`__dirname`/`__filename`/`require`/`module`/`exports`) — valid to the linter, nonexistent at runtime in ESM (`"type":"module"`). `nodeBuiltin` is the ESM-safe set (drops exactly those 5; keeps `process`/`fetch`/`Buffer`). Now a bare `__dirname`/`require` in any linted file **fails the PR gate** instead of deploying.

## Test plan

- `npm run lint` **clean** across `server.js` + `src/server/**` — zero fallout (development already has #277's fix; legit shims like `server.js`'s `const __dirname` are declarations and pass).
- Verified separately that a probe `const p = __dirname` now errors `no-undef: '__dirname' is not defined`.

## Rollback

Revert — returns to `globals.node` (linter stops catching CJS-in-ESM).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_