### PR TITLE
feat(integrations): show connected account/page on channel cards

### DIFF
--- a/src/pages/IntegrationsPage.css
+++ b/src/pages/IntegrationsPage.css
@@ -132,6 +132,13 @@
   line-height: 1.5;
 }
 
+.int-card-account {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-top: 3px;
+}
+.int-card-account strong { color: var(--color-text-emphasis); font-weight: 600; }
+
 .int-card-right { display: flex; align-items: center; flex-shrink: 0; }
 
 .int-status-row {

--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -748,6 +748,20 @@ export default function IntegrationsPage() {
                         )}
                       </div>
                       <div className="int-card-desc">{ch.description}</div>
+                      {connected && (() => {
+                        // Surface WHICH account/page this channel posts to, from the
+                        // stored credentials. accountName: LinkedIn Page / Facebook Page
+                        // name; username: X handle; selectedTarget.name: legacy LinkedIn
+                        // company page. Pages render as-is, handles get an @.
+                        const c = (saved?.credentials || {}) as Record<string, any>;
+                        const page = c.accountName || c.pageName || c.selectedTarget?.name;
+                        const label = page || (c.username ? `@${c.username}` : null);
+                        return label ? (
+                          <div className="int-card-account" title="Connected account">
+                            Connected to <strong>{label}</strong>
+                          </div>
+                        ) : null;
+                      })()}
                     </div>
                   </div>
                   <div className="int-card-right">


### PR DESCRIPTION
## Why

Integration cards only showed "Connected" — not **which** LinkedIn Page / Facebook Page / X account the brand is wired to. Your exact ask: show the connected page on the card.

## Good news: the data's already there

I verified against **live** `publishing_channels.credentials` via the relay (name fields only, no token values):
- **LinkedIn** → `credentials.accountName` ("Forge Intelligence", "Rose + Thyme", "SYSOI.ai")
- **Facebook** → `credentials.accountName` ("Forge Intelligence", "sandboxgtm")
- **X** → `credentials.username` ("ForgeI65068", "makemysandbox")
- legacy LinkedIn → `selectedTarget.name`

(The agent's first guess of `zernioDisplayName`/`pageName` was wrong — those are null in practice. `accountName`/`username` are the populated keys.) X already persists the handle, so **no backend change needed** — pure frontend.

## What

A "Connected to **\<name\>**" line under each connected card's title (always visible, no expand needed). Pages render as-is; X handles get an `@`. Reddit intentionally left alone (subreddit is entered manually).

## Test plan
`tsc` + vite build + lint green. After deploy: connected LinkedIn/Facebook cards show the page name; X shows `@handle`.

## Rollback
Revert — cards return to plain "Connected".

---
**Separate finding (not in this PR):** that channels-list endpoint (`GET /api/publishing/channels`) returns the **full `credentials` blob — including OAuth access/refresh tokens — to the browser** for every channel except `website`. It's auth-gated (only the brand owner sees their *own* tokens), so it's **medium-severity hardening**, not a public leak — but those tokens shouldn't be in client-side JS (widens XSS blast radius). Fixing it safely needs care: the UI round-trips saved creds back on save (FB/Pipedream) and the page picker reads `selectedTarget`, so a naive strip would break those. Worth its own scoped PR — want me to spec it?

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_