### PR TITLE
fix(scan): mobile layout — stack CTA, tighten report, drop em dashes

### DIFF
--- a/src/pages/AiVisibilityScanPage.css
+++ b/src/pages/AiVisibilityScanPage.css
@@ -80,7 +80,20 @@
 .avs-bar .pc.na{color:var(--color-text-muted);font-weight:600;font-size:13px;}
 
 .avs-cols{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
-@media(max-width:640px){.avs-cols{grid-template-columns:1fr;} .avs-form{flex-direction:column;} .avs-hero h1{font-size:30px;}}
+@media(max-width:640px){
+  .avs-cols{grid-template-columns:1fr;}
+  .avs-form{flex-direction:column;}
+  .avs-hero h1{font-size:30px;}
+  /* CTA: stack text over button so the copy gets full width (was a flex row
+     that squeezed the text to one word per line on phones). */
+  .avs-cta{flex-direction:column;align-items:stretch;gap:14px;}
+  .avs-cta a{text-align:center;}
+  /* tighten report padding + shrink the hero score so it fits narrow screens */
+  .avs-rbody{padding:22px 18px;}
+  .avs-scorewrap{padding:22px 20px;gap:18px;}
+  .avs-score{font-size:60px;}
+  .avs-bar{grid-template-columns:120px 1fr 46px;}
+}
 .avs-card{background:var(--color-bg-card);border:1px solid var(--color-border);border-radius:12px;padding:18px 20px;}
 .avs-card h3{font-size:13.5px;margin-bottom:4px;color:var(--color-text-emphasis);}
 .avs-card .cap{color:var(--color-text-secondary);font-size:12px;margin-bottom:14px;line-height:1.45;}

--- a/src/pages/AiVisibilityScanPage.tsx
+++ b/src/pages/AiVisibilityScanPage.tsx
@@ -135,7 +135,7 @@ export default function AiVisibilityScanPage() {
           <div className="avs-loading">
             <div className="avs-spinner" />
             <div className="step">{LOADING_STEPS[stepIdx]}</div>
-            <div className="sub">Running real queries against four AI engines — this takes up to a minute.</div>
+            <div className="sub">Running real queries against four AI engines. This takes up to a minute.</div>
           </div>
         )}
 
@@ -156,7 +156,7 @@ export default function AiVisibilityScanPage() {
                     <div className="s">
                       {vis === 0
                         ? 'Not once. Across every engine and every question your buyers ask, AI never named you.'
-                        : 'Across the questions your buyers ask AI about your category — measured live, not modeled.'}
+                        : 'Across the questions your buyers ask AI about your category, measured live, not modeled.'}
                     </div>
                   </div>
                 </div>
@@ -230,7 +230,7 @@ export default function AiVisibilityScanPage() {
                 <div className="avs-cta">
                   <div>
                     <div className="t">Turn these answers in your favor.</div>
-                    <div className="s">Forge maps every buyer question to the content that earns the AI citation — and tracks your score weekly across all four engines.</div>
+                    <div className="s">Forge maps every buyer question to the content that earns the AI citation, and tracks your score weekly across all four engines.</div>
                   </div>
                   <a href="/?utm_source=ai-visibility-scan">Get your GEO plan →</a>
                 </div>


### PR DESCRIPTION
## Why

`/scan` on mobile: the CTA card rendered its headline **one word per line** ("Turn / these / answers / in / your / favor"). The `.avs-cta` is a flex *row* (text beside the "Get your GEO plan" button) with no mobile stacking, so on a phone the text column collapsed to ~80px.

## What

In the `≤640px` media query:
- **Stack the CTA** vertically (text over a full-width button) — fixes the one-word-per-line.
- Tighten report card padding, shrink the hero score `76→60px`, and narrow the per-engine bar label column so the result view fits comfortably on a phone.

The form already stacked correctly; this is the CTA + result-view polish.

**Bonus:** removed three em dashes from the scan copy (loading subtext, score subtext, CTA blurb) → comma/period per the house no-em-dash rule. (Yes, the lead-magnet had em dashes. Fixed.)

## Test plan
`tsc` + vite build + lint green. After deploy, view `/scan` on a phone: CTA copy reads on full-width lines, button spans the card, result view fits.

## Rollback
Revert — CSS/copy only.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_