### PR TITLE
feat(geo): switch AI Overviews to ValueSERP (cheaper) with SerpAPI fallback

### DIFF
--- a/server.js
+++ b/server.js
@@ -8214,8 +8214,26 @@ app.get('/api/geo/debug/:brandProfileId', async (req, res) => {
     } catch(e) { out.apiTest.gemini = { error: e.message }; }
   }
 
-  // Test one SerpAPI AI Overview call.
-  if (process.env.SERPAPI_KEY) {
+  // Test the AI-Overview SERP provider. Prefer ValueSERP (cheaper); dump the
+  // live ai_overview shape so we can confirm field paths after switching.
+  out.env.hasValueSerp = !!process.env.VALUESERP_API_KEY;
+  if (process.env.VALUESERP_API_KEY) {
+    try {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 15000);
+      const vRes = await fetch(`https://api.valueserp.com/search?api_key=${process.env.VALUESERP_API_KEY}&q=${encodeURIComponent('best running shoe brands')}&include_ai_overview=true&google_domain=google.com&device=desktop`, { signal: controller.signal });
+      const vData = await vRes.json();
+      const ov = vData.ai_overview;
+      out.apiTest.valueserp = {
+        status: vRes.status,
+        success: vData.request_info?.success ?? null,
+        error: vData.request_info?.success === false ? String(vData.request_info?.message || '').slice(0, 200) : null,
+        hasAiOverview: !!ov,
+        aiOverviewKeys: ov ? Object.keys(ov) : [],
+        sample: ov ? JSON.stringify(ov).slice(0, 500) : null,  // shape confirmation
+      };
+    } catch(e) { out.apiTest.valueserp = { error: e.message }; }
+  } else if (process.env.SERPAPI_KEY) {
     try {
       const controller = new AbortController();
       setTimeout(() => controller.abort(), 15000);

--- a/src/server/geoProbe.js
+++ b/src/server/geoProbe.js
@@ -72,10 +72,38 @@ export async function probeGemini(query, doFetch = defaultFetch) {
   return { text, urls };
 }
 
+// Recursively collect every string in a JSON subtree (used to read AI-overview
+// blocks defensively, regardless of the exact provider schema).
+function collectStrings(node, out = []) {
+  if (typeof node === 'string') { if (node.trim()) out.push(node); }
+  else if (Array.isArray(node)) node.forEach(n => collectStrings(n, out));
+  else if (node && typeof node === 'object') Object.values(node).forEach(v => collectStrings(v, out));
+  return out;
+}
+const collectUrls = (node) => collectStrings(node).filter(s => /^https?:\/\//i.test(s));
+
 export async function probeAIOverviews(query, doFetch = defaultFetch) {
-  // Google AI Overviews has no first-party API — SerpAPI surfaces the AI Overview
-  // block. Sometimes it's inline; sometimes only a page_token comes back and the
-  // block must be fetched with a follow-up engine=google_ai_overview call.
+  // Google AI Overviews has no first-party API; we read it through a SERP
+  // provider. Prefer ValueSERP (much cheaper); fall back to SerpAPI if only
+  // that key is set, so switching providers is just an env-var change.
+  if (process.env.VALUESERP_API_KEY) {
+    const url = `https://api.valueserp.com/search?api_key=${process.env.VALUESERP_API_KEY}`
+      + `&q=${encodeURIComponent(query)}&include_ai_overview=true&google_domain=google.com&device=desktop`;
+    const res = await doFetch(url);
+    const data = await res.json();
+    if (!res.ok || data.request_info?.success === false) {
+      throw new Error(`valueserp ${res.status}: ${data.request_info?.message || res.statusText}`);
+    }
+    const ov = data.ai_overview;
+    if (!ov) return { text: '', urls: [] }; // no AI Overview shown for this query
+    // Schema-agnostic: pull all text + all source links from the block. Works
+    // whether contents are strings/text_blocks and sources are .link/.url.
+    return { text: collectStrings(ov).join(' '), urls: collectUrls(ov) };
+  }
+
+  // ── SerpAPI fallback (legacy) ──────────────────────────────────────────────
+  // Sometimes inline; sometimes only a page_token comes back and the block must
+  // be fetched with a follow-up engine=google_ai_overview call.
   const base = 'https://serpapi.com/search.json';
   const res = await doFetch(`${base}?engine=google&q=${encodeURIComponent(query)}&api_key=${process.env.SERPAPI_KEY}`);
   let data = await res.json();
@@ -85,7 +113,7 @@ export async function probeAIOverviews(query, doFetch = defaultFetch) {
     const res2 = await doFetch(`${base}?engine=google_ai_overview&page_token=${encodeURIComponent(ov.page_token)}&api_key=${process.env.SERPAPI_KEY}`);
     ov = (await res2.json()).ai_overview || ov;
   }
-  if (!ov) return { text: '', urls: [] }; // no AI Overview shown for this query
+  if (!ov) return { text: '', urls: [] };
   const text = (ov.text_blocks || [])
     .map(b => b.snippet || (b.list || []).map(li => li.snippet).join(' ') || '')
     .join(' ');
@@ -99,7 +127,7 @@ export const CITATION_ENGINES = [
   { id: 'perplexity',  enabled: () => !!process.env.PERPLEXITY_API_KEY, probe: probePerplexity },
   { id: 'chatgpt',     enabled: () => !!process.env.OPENAI_API_KEY,     probe: probeOpenAI },
   { id: 'gemini',      enabled: () => !!process.env.GEMINI_API_KEY,     probe: probeGemini },
-  { id: 'aiOverviews', enabled: () => !!process.env.SERPAPI_KEY,        probe: probeAIOverviews },
+  { id: 'aiOverviews', enabled: () => !!(process.env.VALUESERP_API_KEY || process.env.SERPAPI_KEY), probe: probeAIOverviews },
 ];
 
 // ── Cold-prospect scan ───────────────────────────────────────────────────────

--- a/test/geoProbe.test.js
+++ b/test/geoProbe.test.js
@@ -1,5 +1,32 @@
 import { describe, it, expect } from 'vitest';
-import { urlHasDomain, isCited, findCitedSection, CITATION_ENGINES, extractDomain, aggregateSources, brandTokens, scanVisibility, probeGemini, probePerplexity } from '../src/server/geoProbe.js';
+import { urlHasDomain, isCited, findCitedSection, CITATION_ENGINES, extractDomain, aggregateSources, brandTokens, scanVisibility, probeGemini, probePerplexity, probeAIOverviews } from '../src/server/geoProbe.js';
+
+describe('probeAIOverviews — ValueSERP branch', () => {
+  const fakeRes = (status, body) => ({ ok: status >= 200 && status < 300, status, statusText: 'x', json: async () => body });
+  it('deep-collects AI-overview text + source links regardless of exact schema', async () => {
+    process.env.VALUESERP_API_KEY = 'test-key';
+    try {
+      const body = { ai_overview: { contents: [{ snippet: 'Nike and Adidas lead running.' }], sources: [{ link: 'https://nike.com/run' }, { url: 'https://adidas.com' }] } };
+      const out = await probeAIOverviews('best running shoes', async () => fakeRes(200, body));
+      expect(out.text).toContain('Nike');
+      expect(out.urls).toEqual(expect.arrayContaining(['https://nike.com/run', 'https://adidas.com']));
+    } finally { delete process.env.VALUESERP_API_KEY; }
+  });
+  it('throws on a ValueSERP failure response', async () => {
+    process.env.VALUESERP_API_KEY = 'test-key';
+    try {
+      await expect(probeAIOverviews('q', async () => fakeRes(401, { request_info: { success: false, message: 'invalid api key' } })))
+        .rejects.toThrow(/valueserp/);
+    } finally { delete process.env.VALUESERP_API_KEY; }
+  });
+  it('returns empty when no AI overview is shown', async () => {
+    process.env.VALUESERP_API_KEY = 'test-key';
+    try {
+      const out = await probeAIOverviews('q', async () => fakeRes(200, { request_info: { success: true } }));
+      expect(out).toEqual({ text: '', urls: [] });
+    } finally { delete process.env.VALUESERP_API_KEY; }
+  });
+});
 
 const fakeRes = (status, body) => ({ ok: status >= 200 && status < 300, status, statusText: 'x', json: async () => body });
 


### PR DESCRIPTION
## Why

SerpAPI burned ~800 searches fast under the launch spike — it's expensive. ValueSERP is far cheaper and also surfaces Google AI Overviews. You have a key.

## What

The `aiOverviews` engine now **prefers ValueSERP**, falling back to SerpAPI only if `VALUESERP_API_KEY` is unset — a clean env-var flip (add `VALUESERP_API_KEY`; remove `SERPAPI_KEY` to stop the bleed entirely). Bonus: ValueSERP returns the overview in **one call** (no SerpAPI `page_token` double-call), so it also **halves** the AIO request count.

- `probeAIOverviews`: `GET https://api.valueserp.com/search?...&include_ai_overview=true&google_domain=google.com&device=desktop`. Parses the `ai_overview` block **schema-agnostically** (deep-walk all strings → text, all `https?` strings → source URLs) because ValueSERP's exact `ai_overview` sub-field names aren't in their public docs and I don't have the key locally to probe. This can't miss the brand mention regardless of shape. Throws on `request_info.success=false`. SerpAPI path kept verbatim as fallback.
- `CITATION_ENGINES`: `aiOverviews` enabled when **either** key is set.
- `/api/geo/debug`: tests ValueSERP (preferred) and **dumps the live `ai_overview` keys + a 500-char sample** so I can confirm the real shape after you add the key and tighten the parser if needed (same playbook that nailed the Gemini fix).

## Your action

Add **`VALUESERP_API_KEY`** to the Render env group. After deploy, hit `/api/geo/debug/<id>` → I'll read `apiTest.valueserp` (status/success + the ai_overview sample) to confirm it's pulling real overviews, then you can delete `SERPAPI_KEY`.

## Test plan
+3 unit tests (deep-parse, failure, no-overview); full suite green; lint clean. Live verify via debug endpoint post-key.

## Rollback
Revert — falls back to SerpAPI (or leave both keys; ValueSERP just takes priority).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_