### PR TITLE
feat(geo): weekly citation-tracking cron entrypoint (/api/geo/track-all)

### DIFF
--- a/server.js
+++ b/server.js
@@ -8997,6 +8997,45 @@ Return ONLY a raw JSON object: {"brandName":"string","questions":["q1",...]}. No
   }
 });
 
+// POST /api/geo/track-all — WEEKLY citation-tracking entrypoint for an external
+// cron (EasyCron). adminPassword-gated. Loops active brands and kicks the
+// per-brand /api/geo/track (fire-and-forget) with a stagger so the four-engine
+// probes don't thunder. Brands with no published content no-op cheaply (no
+// engine calls). Deliberately NOT an in-process setInterval: with autoscale
+// (2-4 instances) a timer fires on every instance — multiplying engine cost —
+// and resets on every deploy. A single weekly external trigger is the right,
+// idempotent cadence.
+app.post('/api/geo/track-all', async (req, res) => {
+  if (req.body?.adminPassword !== process.env.ADMIN_RELAY_PASSWORD) {
+    return res.status(403).json({ success: false, error: 'Forbidden' });
+  }
+  res.json({ success: true, status: 'started' }); // ack fast; process in background
+  (async () => {
+    try {
+      const brandsRes = await pool.query('SELECT id FROM brand_profiles WHERE is_active = true');
+      const baseUrl = process.env.BASE_URL || 'http://localhost:' + (process.env.PORT || 3000);
+      console.log(`[CitationTracking] weekly run — ${brandsRes.rows.length} active brand(s)`);
+      let kicked = 0;
+      for (const { id } of brandsRes.rows) {
+        try {
+          await fetch(`${baseUrl}/api/geo/track/${id}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ adminPassword: process.env.ADMIN_RELAY_PASSWORD })
+          });
+          kicked++;
+        } catch (e) {
+          console.error(`[CitationTracking] ${id} failed:`, e.message);
+        }
+        await new Promise(r => setTimeout(r, 8000)); // stagger background probe jobs
+      }
+      console.log(`[CitationTracking] weekly run complete — kicked ${kicked}/${brandsRes.rows.length} brand(s)`);
+    } catch (e) {
+      console.error('[CitationTracking]', e.message);
+    }
+  })();
+});
+
 app.post('/api/geo/track/:brandProfileId', async (req, res) => {
   const { brandProfileId } = req.params;
   // Allow cron/admin bypass with adminPassword, otherwise require Clerk JWT

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -169,6 +169,7 @@
   "POST /api/geo/topic-brief/:id/backlog",
   "POST /api/geo/topic-brief/:id/resurface",
   "POST /api/geo/topic-brief/from-topic",
+  "POST /api/geo/track-all",
   "POST /api/geo/track/:brandProfileId",
   "POST /api/integrations/website/:brandProfileId/config",
   "POST /api/integrations/website/:brandProfileId/generate-token",


### PR DESCRIPTION
## Why

GEO citation tracking was **manual-only** (the "Run Citation Check" button) — but the `/scan` and dashboard copy promises scores are **"tracked weekly."** This makes that true.

## What

New **`POST /api/geo/track-all`** (adminPassword-gated): loops active brands and kicks the per-brand `/api/geo/track` (fire-and-forget) with an 8s stagger so the four-engine probes don't thunder. Brands with no published content **no-op with zero engine calls**. Acks fast, runs in the background.

## Why an endpoint, not a `setInterval`

This is the important bit: an in-process weekly timer would be **wrong under autoscale**. With min 2 instances, the timer runs on *every* instance → the weekly job fires 2-4× → **2-4× the engine cost** (the exact spend we just cut by moving off SerpAPI). It'd also reset on every deploy, so the cadence would drift. A single **external weekly trigger** fires exactly once — same pattern you already use for `/api/outreach/send`.

## Your setup step

Add a **weekly EasyCron job**: `POST https://forgeintelligence.ai/api/geo/track-all` with body `{"adminPassword":"<ADMIN_RELAY_PASSWORD>"}`. That's the whole wiring.

## Test plan
`node --check` + full vitest + lint green. Route snapshot **212 → 213** (regenerated). After deploy: POST it once manually with the adminPassword and confirm `geo_citations` gets fresh rows for active brands.

## Rollback
Revert — removes the one route; manual button unaffected.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_