### PR TITLE
feat: TL;DR (all surfaces) + per-brand BreadcrumbList — Frank's recurring asks

### DIFF
--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -895,6 +895,31 @@ export default function PublishingQueuePage() {
     </div>`).join('')}
   </section>` : '';
 
+    // ── BreadcrumbList schema (Frank's #1 recurring ask — was absent on every
+    //    Smart Export, forcing a manual add each publish). Home → Articles → title.
+    //    NOTE: the middle node is a sensible default; a per-brand hierarchy
+    //    (e.g. Sandbox-XM's "The Sandbox" → /sandbox.html) is a brand-config follow-up. ──
+    const siteRoot = brandHomeUrl.replace(/\/+$/, '');
+    const breadcrumbSchema = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": siteRoot + "/" },
+        { "@type": "ListItem", "position": 2, "name": "Articles", "item": siteRoot + "/articles" },
+        { "@type": "ListItem", "position": 3, "name": item.title },
+      ],
+    };
+
+    // ── TL;DR / Key Takeaway block (Frank's other recurring ask — keyTakeaway was
+    //    generated but never rendered into the export). Sits right after the
+    //    back-link, before the body. Inline-styled so it renders standalone. ──
+    const tldr = String(aj.keyTakeaway || '').trim();
+    const tldrHtml = tldr ? `
+      <aside class="article-tldr" style="margin:1.5em 0;padding:1.25em 1.5em;border-left:4px solid #4F46E5;background:#f5f6ff;border-radius:8px">
+        <p style="margin:0 0 .4em;font-weight:700;text-transform:uppercase;letter-spacing:.08em;font-size:.78em;color:#4F46E5">TL;DR</p>
+        <p style="margin:0;line-height:1.6">${tldr.replace(/</g, '&lt;')}</p>
+      </aside>` : '';
+
     return `<!-- Forge Intelligence content_id: ${item.content_id} | brand_id: ${item.brand_profile_id} | exported: ${new Date().toISOString()} -->
 <!DOCTYPE html>
 <html lang="en">
@@ -928,6 +953,7 @@ export default function PublishingQueuePage() {
   ${hero ? `<meta name="twitter:image" content="${hero}" />` : ''}
   <script type="application/ld+json">${JSON.stringify(articleSchema, null, 2)}</script>${faqSchema ? `
   <script type="application/ld+json">${JSON.stringify(faqSchema, null, 2)}</script>` : ''}
+  <script type="application/ld+json">${JSON.stringify(breadcrumbSchema, null, 2)}</script>
 </head>
 <body>
 
@@ -945,6 +971,7 @@ export default function PublishingQueuePage() {
   <section class="${C.bodySection}">
     <div class="${C.body}">
       <a href="${C.backHref}" class="${C.backClass}">${C.backText}</a>
+${tldrHtml}
 ${bodyHtml}
 ${faqDomHtml}
 ${authorFooterHtml}

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -896,18 +896,30 @@ export default function PublishingQueuePage() {
   </section>` : '';
 
     // ── BreadcrumbList schema (Frank's #1 recurring ask — was absent on every
-    //    Smart Export, forcing a manual add each publish). Home → Articles → title.
-    //    NOTE: the middle node is a sensible default; a per-brand hierarchy
-    //    (e.g. Sandbox-XM's "The Sandbox" → /sandbox.html) is a brand-config follow-up. ──
+    //    Smart Export). Per-brand hierarchy from settings.breadcrumb (array of
+    //    {name, url} intermediate nodes); Home is derived from the brand root and
+    //    the article title is the leaf. Falls back to a generic "Articles" node.
+    //    e.g. Sandbox-XM = [{name:"The Sandbox", url:"https://sandbox-xm.com/sandbox.html"}]. ──
     const siteRoot = brandHomeUrl.replace(/\/+$/, '');
+    const bcConfig = exportModal?.brandSettingsData?.settings?.breadcrumb
+      ?? bs?.settings?.breadcrumb;
+    const bcMiddle: Array<{ name: string; item?: string }> = Array.isArray(bcConfig) && bcConfig.length
+      ? bcConfig.filter((n: any) => n && n.name).map((n: any) => ({ name: String(n.name), ...(n.url ? { item: String(n.url) } : {}) }))
+      : [{ name: "Articles", item: siteRoot + "/articles" }];
+    const breadcrumbNodes: Array<{ name: string; item?: string }> = [
+      { name: "Home", item: siteRoot + "/" },
+      ...bcMiddle,
+      { name: item.title }, // leaf — no URL per schema.org convention
+    ];
     const breadcrumbSchema = {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
-      "itemListElement": [
-        { "@type": "ListItem", "position": 1, "name": "Home", "item": siteRoot + "/" },
-        { "@type": "ListItem", "position": 2, "name": "Articles", "item": siteRoot + "/articles" },
-        { "@type": "ListItem", "position": 3, "name": item.title },
-      ],
+      "itemListElement": breadcrumbNodes.map((n, idx) => ({
+        "@type": "ListItem",
+        "position": idx + 1,
+        "name": n.name,
+        ...(n.item ? { "item": n.item } : {}),
+      })),
     };
 
     // ── TL;DR / Key Takeaway block (Frank's other recurring ask — keyTakeaway was

--- a/src/server/routes/publishing-publish.js
+++ b/src/server/routes/publishing-publish.js
@@ -14,6 +14,20 @@ import { stripSocialMarkdown } from '../text.js';
 import { callZernio, zernioPublish, getOrCreateZernioProfile } from '../zernio.js';
 import { buildXOAuthHeader, uploadXMedia, refreshXOAuth2Token } from '../x.js';
 import { buildGhostJWT } from '../ghost.js';
+
+// Visible TL;DR / Key Takeaway block, prepended to every published article body
+// across ALL channels (the AI-citation anchor + skim aid that earns the traction
+// Frank's Sandbox-XM articles see). keyTakeaway is generated for every article;
+// this surfaces it everywhere — not just Forge's own page + Smart Export.
+function tldrHtmlBlock(aj) {
+  const t = String(aj?.keyTakeaway || '').trim();
+  if (!t) return '';
+  return `<aside class="article-tldr" style="margin:1.5em 0;padding:1.25em 1.5em;border-left:4px solid #4F46E5;background:#f5f6ff;border-radius:8px"><p style="margin:0 0 .4em;font-weight:700;text-transform:uppercase;letter-spacing:.08em;font-size:.78em;color:#4F46E5">TL;DR</p><p style="margin:0;line-height:1.6">${t.replace(/</g, '&lt;')}</p></aside>\n`;
+}
+function tldrMarkdownBlock(aj) {
+  const t = String(aj?.keyTakeaway || '').trim();
+  return t ? `> **TL;DR** — ${t}\n\n` : '';
+}
 import { generateHeroImage } from '../images.js';
 import { pipedreamProxy } from '../pipedream.js';
 
@@ -220,7 +234,7 @@ router.post('/publish', async (req, res) => {
 
           const articleJson = article.article_json || {};
           const sections = articleJson.sections || [];
-          const htmlContent = sections.map(s =>
+          const htmlContent = tldrHtmlBlock(articleJson) + sections.map(s =>
             `${s.heading ? `<h2>${s.heading}</h2>` : ''}<p>${s.body || s.content || ''}</p>`
           ).join('\n');
 
@@ -251,7 +265,7 @@ router.post('/publish', async (req, res) => {
 
           const articleJson = article.article_json || {};
           const sections = articleJson.sections || [];
-          const bodyHtml = sections.map(s =>
+          const bodyHtml = tldrHtmlBlock(articleJson) + sections.map(s =>
             `${s.heading ? `<h2>${s.heading}</h2>` : ''}<p>${s.body || s.content || ''}</p>`
           ).join('\n');
           const excerpt = (sections[0]?.body || sections[0]?.content || '').slice(0, 160);
@@ -908,7 +922,7 @@ Output only the post text.` }]
           // Build HTML content from article sections
           const articleJson = article.article_json || {};
           const sections = articleJson.sections || [];
-          const htmlBody = sections.map(s =>
+          const htmlBody = tldrHtmlBlock(articleJson) + sections.map(s =>
             `<h2>${s.heading || ''}</h2><p>${(s.body || '').split('\n').join('</p><p>')}</p>`
           ).join('\n');
 
@@ -962,7 +976,7 @@ ${canonicalNote}`,
           // Build HTML from article sections — Ghost v5 accepts HTML via ?source=html
           const articleJson = article.article_json || {};
           const sections = articleJson.sections || [];
-          const htmlBody = sections.map(s =>
+          const htmlBody = tldrHtmlBlock(articleJson) + sections.map(s =>
             `<h2>${s.heading || ''}</h2>\n${(s.body || '').split('\n').filter(Boolean).map(p => `<p>${p}</p>`).join('\n')}`
           ).join('\n\n');
           const canonicalNote = `<p><em>Originally published at <a href="${utmUrl}">${process.env.BASE_DOMAIN || 'forgeintelligence.ai'}</a></em></p>`;
@@ -1013,12 +1027,12 @@ ${canonicalNote}`,
           const articleJson = article.article_json || {};
           const sections = articleJson.sections || [];
           const faqs = Array.isArray(articleJson.faqs) ? articleJson.faqs.filter(f => f?.question && f?.answer) : [];
-          const htmlContent = sections.map(s =>
+          const htmlContent = tldrHtmlBlock(articleJson) + sections.map(s =>
             `${s.heading ? `<h2>${s.heading}</h2>` : ''}<p>${s.body || s.content || ''}</p>`
           ).join('\n') + (faqs.length
             ? `\n<section class="article-faqs">\n<h2>Frequently asked questions</h2>\n${faqs.map(f => `<h3>${f.question}</h3>\n<p>${f.answer}</p>`).join('\n')}\n</section>`
             : '');
-          const markdownContent = sections.map(s =>
+          const markdownContent = tldrMarkdownBlock(articleJson) + sections.map(s =>
             `${s.heading ? `## ${s.heading}\n\n` : ''}${s.body || s.content || ''}`
           ).join('\n\n') + (faqs.length
             ? `\n\n## Frequently asked questions\n\n${faqs.map(f => `### ${f.question}\n\n${f.answer}`).join('\n\n')}`


### PR DESCRIPTION
Resolves the two structural omissions Frank logged ~13× over 6 weeks (TL;DR + BreadcrumbList). Now covers **every article surface**, not just Smart Export.

## What's in this PR

**TL;DR (the `keyTakeaway`, rendered everywhere it publishes):**
- Smart Export — TL;DR card after the back-link.
- **All 5 direct-publish channels** — WordPress, Webflow, Medium, Ghost, My-Website now prepend the TL;DR (shared `tldrHtmlBlock`/`tldrMarkdownBlock` helper). They were body-only before.
- (Forge's own article page already had it.)

**BreadcrumbList — now per-brand configurable:**
- Smart Export builds the trail from **`settings.breadcrumb`** (array of `{name, url}` intermediate nodes); Home derived from the brand root, article title as the leaf. Falls back to a generic "Articles" node.
- **Sandbox-XM seeded** → Home → **The Sandbox** (/sandbox.html) → title, the exact hierarchy Frank wanted. Zero manual edits.
- (CMS post bodies sanitize `<script>`, so breadcrumb stays on the head-controlled surfaces — Smart Export + Forge page.)

## Pairs with #290
#290 guarantees the TL;DR is *authored* at generation (mandatory + structured + backstop). This PR makes sure it's *rendered* everywhere. Both needed.

## Test plan
`tsc` + vite build + lint green across all commits. After deploy: Smart Export a Sandbox-XM article → 3 schema blocks incl. BreadcrumbList (Home → The Sandbox → title) + TL;DR card; publish to a CMS → body opens with the TL;DR.

## Follow-up
BrandSettings UI to edit `settings.breadcrumb` self-serve (today other brands set it via the settings key / seed).

## Rollback
Revert.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7