### PR TITLE
feat(content-gen): guarantee the TL;DR is authored at generation

### DIFF
--- a/server.js
+++ b/server.js
@@ -4012,6 +4012,23 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
       }
     }
 
+    // Guarantee the TL;DR (keyTakeaway) is never missing. It's the article's
+    // required TL;DR block — rendered at the top of every publish path — and the
+    // prompt mandates it, but if the model still omits it, synthesize a publishable
+    // fallback from the meta description / opening so a TL;DR ALWAYS exists in the
+    // stored article_json. Logged so model misses are visible.
+    if (parsed && typeof parsed === 'object' && !String(parsed.keyTakeaway || '').trim()) {
+      const firstBody = Array.isArray(parsed.sections)
+        ? String(parsed.sections.find(s => (s.body || s.content || '').trim())?.body
+            || parsed.sections.find(s => (s.body || s.content || '').trim())?.content || '').trim()
+        : '';
+      const fallback = String(parsed.metaDescription || '').trim()
+        || (firstBody ? truncateAtSentence(firstBody, 300) : '')
+        || (parsed.title ? `${parsed.title}.` : '');
+      parsed.keyTakeaway = stripEmDashes(fallback);
+      console.warn('[CONTENT-GEN] keyTakeaway missing from model output — synthesized TL;DR fallback');
+    }
+
     const tableName = await ensureGeneratedContentTable(brandProfileId);
     const contentInsert = await pool.query(
       `INSERT INTO ${tableName} (brand_profile_id, enriched_brief_id, title, article_json, overall_confidence, brain_match_score, status)

--- a/src/agents/stage4_content_generator/system_prompt.md
+++ b/src/agents/stage4_content_generator/system_prompt.md
@@ -50,7 +50,7 @@ Return a JSON object with this exact structure:
 
 ### GEO-specific requirements (keyTakeaway + faqs)
 
-**keyTakeaway** (required, ~40-80 words): This is the single highest-leverage field in the article for LLM citation. Write it as a self-contained summary of the core argument: no references to 'this article' or 'we'll explore'. Declarative statements only. If the article has a named framework or core claim, name it here verbatim.
+**keyTakeaway** (MANDATORY — this is the article's TL;DR block, ~40-80 words): The single highest-leverage field for LLM citation, and it is NEVER optional. It renders as a bolded TL;DR immediately after the hero on every published surface (the brand's site, Smart Export, and every CMS), so it must be able to stand completely alone. Structure it the way the strongest-cited articles do: **(1) name the problem, (2) name the mechanism or framework that solves it (verbatim if the article has a named framework), (3) state what the reader should take away.** Self-contained, declarative, no hedging, no "this article"/"we'll explore", no questions. If you are about to return the JSON without a populated keyTakeaway, stop and write it — an article without a TL;DR is an incomplete generation.
 
 **faqs** (required, 4-6 items): Extract questions that a reader likely typed into ChatGPT/Claude/Perplexity before landing here. Sources for good FAQ questions:
 - The article's H2 section headings, rephrased as questions


### PR DESCRIPTION
## Why

Your point: fix it at the source so the brief is *built* with the TL;DR — "if it's not written it can't be published." The `keyTakeaway` field was already *required*, but a model can still under-deliver and there was **no backstop**, so a missing/empty TL;DR could slip through to the stored draft, where no render path can ship what was never written.

## What (generation layer — pairs with #289's render layer)

- **Stage-4 prompt:** `keyTakeaway` is now **MANDATORY** and **structured** — name the problem → name the mechanism/framework → state the takeaway (the format the most-cited articles use), explicitly "the article's TL;DR block… an article without a TL;DR is an incomplete generation."
- **Handler backstop** (`/api/content-generator/generate`): after parsing, if `keyTakeaway` is empty, **synthesize a publishable fallback** from `metaDescription` / the opening section (em-dash-stripped) and log the miss. The stored `article_json` is now guaranteed to carry a TL;DR.

So: **generation always writes it; render (#289) always ships it** on Forge's page, Smart Export, and every CMS.

## Test plan
`node --check` + lint + full suite green. After deploy: generate an article and confirm `article_json.keyTakeaway` is always populated (and structured); the `[CONTENT-GEN] keyTakeaway missing` warning fires only on a true model miss.

## Note
The campaign generator also authors articles via the same Stage-4 prompt — it inherits the stronger prompt; if you want the deterministic backstop there too it's a one-line reuse (say the word).

## Rollback
Revert — prompt + backstop only, no schema change.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_