### PR TITLE
fix(enrich): guard LLM response shape so the enricher can't crash (prod)

### DIFF
--- a/server.js
+++ b/server.js
@@ -3013,10 +3013,10 @@ Respond with this exact JSON structure:
 
     let scorerData = {};
     try {
-      const sd = extractJSON(scorerRes.content[0].text, 'object');
+      const sd = extractJSON(scorerRes?.content?.[0]?.text || '', 'object');
       if (!sd) throw new Error('No JSON in Tool 2');
       scorerData = JSON.parse(sd);
-    } catch(e) { console.log('[ENRICH] Tool 2 parse warn:', e.message, '| raw:', scorerRes.content[0].text.slice(0,200)); scorerData = { scores: {}, gaps: [], smeSignals: [], overallEEATScore: 0 }; }
+    } catch(e) { console.log('[ENRICH] Tool 2 parse warn:', e.message, '| stop:', scorerRes?.stop_reason, '| raw:', (scorerRes?.content?.[0]?.text || '').slice(0,200)); scorerData = { scores: {}, gaps: [], smeSignals: [], overallEEATScore: 0 }; }
 
     const gaps = scorerData.gaps || [];
     const needsManualInput = gaps.some(g => g.severity === 'high') && !Object.keys(manualInputs).length;
@@ -3048,10 +3048,10 @@ Respond with this exact JSON structure:
 
     let injectionData = {};
     try {
-      const id2 = extractJSON(injectionRes.content[0].text, 'object');
+      const id2 = extractJSON(injectionRes?.content?.[0]?.text || '', 'object');
       if (!id2) throw new Error('No JSON in Tool 3');
       injectionData = JSON.parse(id2);
-    } catch(e) { console.log('[ENRICH] Tool 3 parse warn:', e.message, '| raw:', injectionRes.content[0].text.slice(0,200)); injectionData = { injectionMap: [], powerPhrases: [], authorSchema: {}, contentHooks: [] }; }
+    } catch(e) { console.log('[ENRICH] Tool 3 parse warn:', e.message, '| stop:', injectionRes?.stop_reason, '| raw:', (injectionRes?.content?.[0]?.text || '').slice(0,200)); injectionData = { injectionMap: [], powerPhrases: [], authorSchema: {}, contentHooks: [] }; }
 
     // ── Tool 4: Enriched Brief Assembler ─────────────────────────────────────
     send('progress', { stage: 4, label: 'Enriched Brief Assembler', detail: 'Compiling enriched H1, sections, FAQs, schema markup...' });
@@ -3082,10 +3082,10 @@ Respond with this exact JSON structure:
 
     let assembledBrief = {};
     try {
-      const ab = extractJSON(assemblerRes.content[0].text, 'object');
+      const ab = extractJSON(assemblerRes?.content?.[0]?.text || '', 'object');
       if (!ab) throw new Error('No JSON in Tool 4');
       assembledBrief = JSON.parse(ab);
-    } catch(e) { console.log('[ENRICH] Tool 4 parse warn:', e.message, '| raw:', assemblerRes.content[0].text.slice(0,200)); assembledBrief = { enrichedSections: [], overallConfidence: 0, readyForStage4: false }; }
+    } catch(e) { console.log('[ENRICH] Tool 4 parse warn:', e.message, '| stop:', assemblerRes?.stop_reason, '| raw:', (assemblerRes?.content?.[0]?.text || '').slice(0,200)); assembledBrief = { enrichedSections: [], overallConfidence: 0, readyForStage4: false }; }
 
     // ── Sanitize eeatInjections: catch any raw-JSON leakage ─────────────────────
     // Defensive: even with a tightened prompt, Sonnet occasionally returns injectionMap objects


### PR DESCRIPTION
## Why (prod error)

```
[ENRICH] Error: TypeError: Cannot read properties of undefined (reading 'text')
    at server.js:3088   (after a 61s Tool 4 call)
```

**Double-fault.** The Anthropic assembler returned an empty/odd response (`content[0]` undefined). The parse line `extractJSON(assemblerRes.content[0].text)` threw — and the **`catch` block re-read the same `assemblerRes.content[0].text`** for its log message, so it threw *again, out of the catch*, 500ing the entire enricher. A catch that crashes itself defeats the whole guard.

Tools **2, 3, and 4** all had this exact pattern.

## What

Guard every LLM-response access with `?.content?.[0]?.text || ''` — in **both** the parse and the catch-log — across Tools 2/3/4. Also log `stop_reason` so we can see *why* the model returned empty next time (likely `max_tokens` truncating the 8096-token JSON, or a refusal). The enricher now degrades to `readyForStage4: false` (flags for manual) instead of throwing.

## Test plan
`node --check` + lint green. Can't reproduce the empty-response in CI, but the guard is purely defensive — worst case is the graceful fallback that already existed, minus the re-throw.

## Follow-up
Worth considering: **retry** the assembler on an empty/truncated response instead of falling back to an empty brief (the 61s + truncation smell suggests `max_tokens`; bumping/retrying would salvage the brief). Flagging, not doing here.

## Rollback
Revert — restores the unguarded access (and the crash).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_