### PR TITLE
feat(video-ui): Video Generator page

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,11 @@ const icons = {
       <path d="M2.7 10.3a2.41 2.41 0 0 0 0 3.41l7.59 7.59a2.41 2.41 0 0 0 3.41 0l7.59-7.59a2.41 2.41 0 0 0 0-3.41l-7.59-7.59a2.41 2.41 0 0 0-3.41 0Z"/>
     </svg>
   ),
+  film: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2" y="2" width="20" height="20" rx="2.18"/><path d="M7 2v20M17 2v20M2 12h20M2 7h5M2 17h5M17 17h5M17 7h5"/>
+    </svg>
+  ),
   calendar: (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
       <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
@@ -193,6 +198,7 @@ const NAV_ROUTES: Partial<Record<ViewType, string>> = {
   'content-generator':    '/app/content-generator',
   'campaign-generator':   '/app/campaign-generator',
   'social-generator':     '/app/social-generator',
+  'video-generator':      '/app/video-generator',
   'ads-generator':        '/app/ads-generator',
   'compliance-gate':      '/app/compliance-gate',
   'integrations':         '/app/integrations',
@@ -231,6 +237,7 @@ const topNavItems: TopNavItem[] = [
   { id: 'content-generator',     label: 'Content Generator',     icon: 'fileText',   href: '/app/content-generator' },
   { id: 'campaign-generator',    label: 'Campaign Generator',    icon: 'layers',     href: '/app/campaign-generator' },
   { id: 'social-generator',      label: 'Social Generator',      icon: 'share2',     href: '/app/social-generator' },
+  { id: 'video-generator',       label: 'Video Generator',       icon: 'film',       href: '/app/video-generator' },
   { id: 'ads-generator',         label: 'Ads Generator',          icon: 'target',     href: '/app/ads-generator' },
   { id: 'email-campaign',        label: 'Email Campaign',         icon: 'mail',       href: '/app/email-campaign' },
   { id: 'compliance-gate',       label: 'Compliance Gate',       icon: 'shieldCheck',href: '/app/compliance-gate' },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import AuthenticityEnricherPage from './pages/AuthenticityEnricherPage';
 import ContentGeneratorPage from './pages/ContentGeneratorPage';
 import CampaignGeneratorPage from './pages/CampaignGeneratorPage';
 import SocialGeneratorPage from './pages/SocialGeneratorPage';
+import VideoGeneratorPage from './pages/VideoGeneratorPage';
 import AdsGeneratorPage from './pages/AdsGeneratorPage';
 import ComplianceGatePage from './pages/ComplianceGatePage';
 import IntegrationsPage from './pages/IntegrationsPage';
@@ -138,6 +139,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/app/content-generator" element={<AppProvider><ContentGeneratorPage /></AppProvider>} />
         <Route path="/app/campaign-generator" element={<AppProvider><CampaignGeneratorPage /></AppProvider>} />
         <Route path="/app/social-generator" element={<AppProvider><SocialGeneratorPage /></AppProvider>} />
+        <Route path="/app/video-generator" element={<AppProvider><VideoGeneratorPage /></AppProvider>} />
         <Route path="/app/ads-generator" element={<AppProvider><AdsGeneratorPage /></AppProvider>} />
         <Route path="/app/email-campaign" element={<AppProvider><EmailCampaignPage /></AppProvider>} />
         <Route path="/app/compliance-gate" element={<AppProvider><ComplianceGatePage /></AppProvider>} />

--- a/src/pages/VideoGeneratorPage.css
+++ b/src/pages/VideoGeneratorPage.css
@@ -1,0 +1,147 @@
+.vg-wrap {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+}
+
+.vg-header { margin-bottom: 28px; }
+.vg-title-row { display: flex; align-items: center; gap: 10px; color: #3563FF; }
+.vg-title {
+  font-size: 26px;
+  font-weight: 800;
+  color: #0F172A;
+  margin: 0;
+}
+.vg-sub {
+  margin: 8px 0 0;
+  font-size: 15px;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.vg-form {
+  background: #FFFFFF;
+  border: 1px solid #E2E8F0;
+  border-radius: 14px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+}
+.vg-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: #0F172A;
+  margin-bottom: 8px;
+}
+.vg-select,
+.vg-textarea {
+  width: 100%;
+  border: 1px solid #E2E8F0;
+  border-radius: 10px;
+  background: #F8FAFC;
+  padding: 12px 14px;
+  font-size: 15px;
+  color: #0F172A;
+  margin-bottom: 20px;
+  font-family: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.vg-textarea { resize: vertical; line-height: 1.5; }
+.vg-select:focus,
+.vg-textarea:focus {
+  outline: none;
+  border-color: #3563FF;
+  box-shadow: 0 0 0 3px rgba(53, 99, 255, 0.12);
+}
+
+.vg-btn {
+  align-self: flex-start;
+  background: #3563FF;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 24px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.vg-btn:hover:not(:disabled) { background: #2c52e0; }
+.vg-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.vg-error {
+  margin-top: 14px;
+  color: #B91C1C;
+  font-size: 14px;
+  background: rgba(185, 28, 28, 0.06);
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+
+/* ── Job progress ── */
+.vg-job {
+  margin-top: 24px;
+  background: #FFFFFF;
+  border: 1px solid #E2E8F0;
+  border-radius: 14px;
+  padding: 24px;
+}
+.vg-stage { font-size: 15px; font-weight: 600; color: #0F172A; margin-bottom: 12px; }
+.vg-bar {
+  height: 10px;
+  background: #E2E8F0;
+  border-radius: 5px;
+  overflow: hidden;
+}
+.vg-bar-fill {
+  height: 100%;
+  background: #3563FF;
+  border-radius: 5px;
+  transition: width 0.6s ease;
+}
+.vg-pct { margin-top: 8px; font-size: 13px; color: #94A3B8; text-align: right; }
+
+.vg-result { display: flex; flex-direction: column; align-items: center; gap: 16px; }
+.vg-video {
+  width: 100%;
+  max-width: 720px;
+  border-radius: 12px;
+  background: #000;
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.12);
+}
+.vg-download {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #3563FF;
+  font-weight: 700;
+  font-size: 14px;
+  text-decoration: none;
+}
+.vg-download:hover { color: #2c52e0; }
+
+/* ── Recent ── */
+.vg-recent { margin-top: 36px; }
+.vg-recent-title { font-size: 16px; font-weight: 700; color: #0F172A; margin: 0 0 14px; }
+.vg-recent-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid #E2E8F0;
+  font-size: 14px;
+}
+.vg-badge {
+  text-transform: capitalize;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(53, 99, 255, 0.10);
+  color: #3563FF;
+}
+.vg-badge-done { background: rgba(20, 184, 166, 0.12); color: #0d9488; }
+.vg-badge-error { background: rgba(185, 28, 28, 0.10); color: #B91C1C; }
+.vg-recent-date { color: #64748b; }
+.vg-recent-link { margin-left: auto; color: #3563FF; font-weight: 700; text-decoration: none; }
+.vg-recent-err { color: #B91C1C; font-size: 13px; }

--- a/src/pages/VideoGeneratorPage.tsx
+++ b/src/pages/VideoGeneratorPage.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { AppShell } from '../layouts/AppShell';
+import { useApp } from '../context/AppContext';
+import './VideoGeneratorPage.css';
+
+// ─── Lucide-style icons (1.5 stroke, currentColor) ───
+const Film = ({ size = 16 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="2" y="2" width="20" height="20" rx="2.18"/><path d="M7 2v20M17 2v20M2 12h20M2 7h5M2 17h5M17 17h5M17 7h5"/>
+  </svg>
+);
+const Download = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+  </svg>
+);
+
+interface Brain { id: string; brandName: string; brandUrl: string; }
+type Status = 'queued' | 'storyboarding' | 'voicing' | 'rendering' | 'done' | 'error';
+interface VideoJob {
+  id: string;
+  status: Status;
+  progress: number | null;
+  outputUrl: string | null;
+  error: string | null;
+}
+interface RecentVideo { id: string; status: Status; output_url: string | null; error: string | null; created_at: string; }
+
+// Human-readable label + rough completion weight for the progress bar. The
+// Lambda render reports its own 0..1 progress; the earlier stages are coarse.
+const STAGE: Record<Status, { label: string; base: number }> = {
+  queued:        { label: 'Queued…',                 base: 0.02 },
+  storyboarding: { label: 'Writing the storyboard…', base: 0.10 },
+  voicing:       { label: 'Generating voiceover…',   base: 0.30 },
+  rendering:     { label: 'Rendering on Lambda…',    base: 0.50 },
+  done:          { label: 'Done',                     base: 1.00 },
+  error:         { label: 'Failed',                   base: 0.00 },
+};
+
+function VideoGeneratorContent() {
+  const { historyEntries, activeBrand, authToken } = useApp();
+  const [selectedBrainId, setSelectedBrainId] = useState('');
+  const [brief, setBrief] = useState('');
+  const [job, setJob] = useState<VideoJob | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [recent, setRecent] = useState<RecentVideo[]>([]);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  let brains: Brain[] = historyEntries.map(e => ({ id: e.id, brandName: e.brandName, brandUrl: e.brandUrl }));
+  if (activeBrand?.id && !brains.some(b => b.id === activeBrand.id)) {
+    brains.push({ id: activeBrand.id, brandName: activeBrand.brandName || activeBrand.brandUrl, brandUrl: activeBrand.brandUrl });
+  }
+
+  useEffect(() => {
+    if (activeBrand?.id && !selectedBrainId) setSelectedBrainId(activeBrand.id);
+  }, [activeBrand, selectedBrainId]);
+
+  const loadRecent = useCallback(() => {
+    if (!selectedBrainId || !authToken) { setRecent([]); return; }
+    fetch(`/api/video?brandProfileId=${selectedBrainId}`, { headers: { Authorization: `Bearer ${authToken}` } })
+      .then(r => r.json()).then(d => setRecent(d.videos || [])).catch(() => {});
+  }, [selectedBrainId, authToken]);
+
+  useEffect(() => { loadRecent(); }, [loadRecent]);
+
+  // Poll an in-flight job until it finishes.
+  useEffect(() => {
+    if (!job || job.status === 'done' || job.status === 'error') return;
+    pollRef.current = setInterval(async () => {
+      try {
+        const r = await fetch(`/api/video/${job.id}`, { headers: { Authorization: `Bearer ${authToken}` } });
+        const d: VideoJob = await r.json();
+        setJob(d);
+        if (d.status === 'done' || d.status === 'error') {
+          if (pollRef.current) clearInterval(pollRef.current);
+          setBusy(false);
+          loadRecent();
+        }
+      } catch { /* transient — keep polling */ }
+    }, 3000);
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [job?.id, job?.status, authToken, loadRecent]);
+
+  async function generate() {
+    if (!selectedBrainId || !brief.trim() || !authToken) return;
+    setBusy(true); setError(null); setJob(null);
+    try {
+      const r = await fetch('/api/video/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+        body: JSON.stringify({ brandProfileId: selectedBrainId, brief: brief.trim() }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.error || `Request failed (${r.status})`);
+      setJob({ id: d.id, status: d.status, progress: null, outputUrl: null, error: null });
+    } catch (e: any) {
+      setError(e.message); setBusy(false);
+    }
+  }
+
+  const pct = job ? Math.round(
+    (STAGE[job.status].base + (job.status === 'rendering' && job.progress ? job.progress * 0.5 : 0)) * 100
+  ) : 0;
+
+  return (
+    <div className="vg-wrap">
+      <div className="vg-header">
+        <div className="vg-title-row">
+          <Film size={22} />
+          <h1 className="vg-title">Video Generator</h1>
+        </div>
+        <p className="vg-sub">Turn a brief into a branded product reel — storyboard, voiceover, and render, all automatic.</p>
+      </div>
+
+      <div className="vg-form">
+        <label className="vg-label">Brand</label>
+        <select className="vg-select" value={selectedBrainId} onChange={e => setSelectedBrainId(e.target.value)}>
+          <option value="">Select a Brain…</option>
+          {brains.map(b => <option key={b.id} value={b.id}>{b.brandName} — {b.brandUrl}</option>)}
+        </select>
+
+        <label className="vg-label">Brief</label>
+        <textarea
+          className="vg-textarea"
+          placeholder="What's the video about? e.g. 'A 60-second reel introducing our GEO measurement product to B2B marketers — the problem, how the brand brain works, and a closing CTA.'"
+          value={brief}
+          onChange={e => setBrief(e.target.value)}
+          rows={5}
+        />
+
+        <button className="vg-btn" onClick={generate} disabled={busy || !selectedBrainId || !brief.trim()}>
+          {busy ? 'Generating…' : 'Generate video'}
+        </button>
+        {error && <div className="vg-error">{error}</div>}
+      </div>
+
+      {job && (
+        <div className="vg-job">
+          {job.status !== 'done' && job.status !== 'error' && (
+            <>
+              <div className="vg-stage">{STAGE[job.status].label}</div>
+              <div className="vg-bar"><div className="vg-bar-fill" style={{ width: `${pct}%` }} /></div>
+              <div className="vg-pct">{pct}%</div>
+            </>
+          )}
+          {job.status === 'error' && <div className="vg-error">Render failed: {job.error}</div>}
+          {job.status === 'done' && job.outputUrl && (
+            <div className="vg-result">
+              <video className="vg-video" src={job.outputUrl} controls />
+              <a className="vg-download" href={job.outputUrl} target="_blank" rel="noreferrer"><Download /> Download MP4</a>
+            </div>
+          )}
+        </div>
+      )}
+
+      {recent.length > 0 && (
+        <div className="vg-recent">
+          <h2 className="vg-recent-title">Recent</h2>
+          {recent.map(v => (
+            <div key={v.id} className="vg-recent-row">
+              <span className={`vg-badge vg-badge-${v.status}`}>{v.status}</span>
+              <span className="vg-recent-date">{new Date(v.created_at).toLocaleString()}</span>
+              {v.output_url && <a className="vg-recent-link" href={v.output_url} target="_blank" rel="noreferrer">View</a>}
+              {v.error && <span className="vg-recent-err">{v.error}</span>}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function VideoGeneratorPage() {
+  return <AppShell><VideoGeneratorContent /></AppShell>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,4 +103,4 @@ export interface HistoryEntry {
   factualGroundUpdatedAt?: string | null;
 }
 
-export type ViewType = 'new-analysis' | 'active-run' | 'brand-profile' | 'strategy' | 'brain-history' | 'geo-strategist' | 'strategy-intel' | 'authenticity-enricher' | 'content-generator' | 'campaign-generator' | 'social-generator' | 'ads-generator' | 'email-campaign' | 'compliance-gate' | 'integrations' | 'publishing-queue' | 'content-library' | 'content-import' | 'admin' | 'topic-queue' | 'performance' | 'brand-settings';
+export type ViewType = 'new-analysis' | 'active-run' | 'brand-profile' | 'strategy' | 'brain-history' | 'geo-strategist' | 'strategy-intel' | 'authenticity-enricher' | 'content-generator' | 'campaign-generator' | 'social-generator' | 'video-generator' | 'ads-generator' | 'email-campaign' | 'compliance-gate' | 'integrations' | 'publishing-queue' | 'content-library' | 'content-import' | 'admin' | 'topic-queue' | 'performance' | 'brand-settings';


### PR DESCRIPTION
## Why
The video pipeline backend shipped in #296 and is live in prod. This adds the UI so users can actually drive it.

## What
**`/app/video-generator`** — brand picker + brief textarea → `POST /api/video/generate`, then polls `GET /api/video/:id` every 3s through the **storyboard → voicing → rendering** stages with a progress bar (the Lambda render's own 0..1 progress feeds the back half of the bar). Finished MP4 renders inline with a download link. A **Recent** list pulls `GET /api/video?brandProfileId=` for prior renders.

- `src/pages/VideoGeneratorPage.tsx` + `.css` — mirrors `SocialGeneratorPage` conventions: `AppShell`, `useApp()` for `authToken` + `activeBrand`, `Bearer` fetch, brand-select markup, brand palette (`#3563FF` / `#0F172A`).
- Routing: `/app/video-generator` in `main.tsx`; nav entry + new `film` icon in `Sidebar` (both the items list and `NAV_ROUTES`); `'video-generator'` added to `ViewType`.

## Test plan
- `npx tsc --noEmit` clean.
- `vite build` clean (chunk-size warning is pre-existing).
- Backend already verified live (`POST /api/video/generate` → `401` authed in prod).
- No backend / route-inventory changes — snapshot untouched.

## Rollback
Pure additive frontend. Revert the merge; nothing else references the page or the new `ViewType`/icon.

## Note
End-to-end UI smoke test needs a signed-in session against prod (Clerk-gated), which I can't drive headless. The page is wired to the exact contract the backend serves; the data path is the same one proven in #296. Worth a quick manual click-through after merge + deploy.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_