### PR TITLE
fix(video): two prod blockers — brand_name column + AWS credential resolution

### DIFF
--- a/src/server/routes/video.js
+++ b/src/server/routes/video.js
@@ -66,9 +66,9 @@ router.post('/generate', async (req, res) => {
     if (!videoConfigured()) return res.status(503).json({ error: 'Video rendering is not configured (REMOTION_* env vars missing)' });
 
     const r = await pool.query(
-      `SELECT name FROM brand_profiles WHERE id = $1`, [brandProfileId]
+      `SELECT brand_name FROM brand_profiles WHERE id = $1`, [brandProfileId]
     );
-    const brandName = r.rows[0]?.name || 'Forge Intelligence';
+    const brandName = r.rows[0]?.brand_name || 'Forge Intelligence';
 
     const ins = await pool.query(
       `INSERT INTO generated_videos (brand_profile_id, brief, status) VALUES ($1, $2, 'queued') RETURNING id`,


### PR DESCRIPTION
## Why
Two bugs were stopping video generation in prod, surfaced live while demoing:

1. `POST /api/video/generate` → `column "name" does not exist`. The handler queried `SELECT name`; `brand_profiles` has `brand_name`. Failed instantly, before any work.
2. After that's fixed, the render job fails with **`Could not load credentials from any providers`**. Remotion's programmatic Lambda client + the AWS SDK (S3 upload/presign and `renderMediaOnLambda`) resolve credentials via the SDK **default chain** — the `AWS_*` env names — **not** the `REMOTION_AWS_*` names the Remotion CLI reads. Render only carries `REMOTION_AWS_*`, so the SDK found nothing. (My sandbox renders only worked because I also exported `AWS_ACCESS_KEY_ID`.)

## What
1. Query `brand_name` (+ read `brand_name`); still falls back to `'Forge Intelligence'`.
2. At `video.js` module load, mirror `REMOTION_AWS_ACCESS_KEY_ID/SECRET[/REGION]` → `AWS_*` **without clobbering** any real `AWS_*` already set. Fixes both the Lambda render and the S3 TTS upload.

## Test plan
- `node --check` clean on `video.js` + `routes/video.js`.
- #1 is the exact prod error. #2 matches the SDK credential-chain error; the same creds were already proven working against this account/function (the `REMOTION_AWS_*` values are valid — they just weren't under the names the SDK reads).

Ready (not draft) — urgent unblock for the active demo. One merge fixes generation end-to-end (landscape). 9:16 portrait + UI toggle follow in a separate PR.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7