### PR TITLE
feat(context-hub+video): measure real brand visuals during scrape + inject into reels

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,8 @@ export default [
         // there, so whitelist them rather than flag false positives.
         document: 'readonly',
         window: 'readonly',
+        getComputedStyle: 'readonly',
+        location: 'readonly',
       },
     },
     rules: {

--- a/remotion/src/DataReel.tsx
+++ b/remotion/src/DataReel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {
-  AbsoluteFill, Sequence, Audio, staticFile,
+  AbsoluteFill, Sequence, Audio, Img, staticFile,
   useCurrentFrame, useVideoConfig, interpolate, spring, Easing,
 } from "remotion";
 import type {
@@ -43,6 +43,17 @@ const Diamond: React.FC<{ size?: number }> = ({ size = 40 }) => {
   );
 };
 
+// Brand mark: the brand's real logo if we measured one; the Forge diamond only
+// for Forge itself; nothing for a third-party brand without a logo (better than
+// stamping Forge's diamond on someone else's reel).
+const BrandMark: React.FC<{ size?: number }> = ({ size = 36 }) => {
+  const { brand, L } = React.useContext(Ctx);
+  const { k } = L;
+  if (brand.logo) return <Img src={brand.logo} style={{ height: size * k, width: "auto", objectFit: "contain" }} />;
+  if (/forge/i.test(brand.name)) return <Diamond size={size} />;
+  return null;
+};
+
 const useRise = (delay = 0, dist = 50) => {
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
@@ -59,7 +70,7 @@ const Stage: React.FC<{ children: React.ReactNode; audio?: string }> = ({ childr
     <AbsoluteFill style={{ background: C.bg, fontFamily: font, justifyContent: "center", alignItems: "center", padding: 120 * k }}>
       {src && <Audio src={src} />}
       <div style={{ position: "absolute", top: 64 * k, left: 90 * k, display: "flex", alignItems: "center", gap: 14 * k }}>
-        <Diamond size={36} /><span style={{ fontWeight: 700, fontSize: 32 * k, color: C.emphasis }}>{brand.name}</span>
+        <BrandMark size={36} /><span style={{ fontWeight: 700, fontSize: 32 * k, color: C.emphasis }}>{brand.name}</span>
       </div>
       {children}
     </AbsoluteFill>
@@ -268,7 +279,7 @@ const CtaView: React.FC<{ s: CtaScene }> = ({ s }) => {
   return (
     <Stage audio={s.audio}>
       <div style={{ textAlign: "center", maxWidth: 1500 * k }}>
-        <div style={a}><Diamond size={96} /></div>
+        <div style={a}><BrandMark size={96} /></div>
         <div style={{ ...b, fontSize: 96 * k, fontWeight: 800, color: C.emphasis, margin: `${34 * k}px 0 ${26 * k}px` }}>{s.title}</div>
         {s.sub && <div style={{ ...b, fontSize: 50 * k, color: C.secondary, fontWeight: 500, marginBottom: 44 * k }}>{s.sub}</div>}
         <div style={{ ...c, fontSize: 46 * k, fontWeight: 700, color: "#fff", background: C.accent, borderRadius: 18 * k, padding: `${24 * k}px ${52 * k}px`, display: "inline-block" }}>{s.cta}</div>

--- a/remotion/src/types.ts
+++ b/remotion/src/types.ts
@@ -10,6 +10,9 @@ export type Brand = {
     emphasis: string; secondary: string; muted: string;
     error: string; success: string; border: string;
   }>;
+  // Measured logo URL (S3/og:image/favicon). When present it replaces the
+  // Forge diamond in the lockup + closing card.
+  logo?: string;
 };
 
 type SceneBase = {

--- a/src/server/routes/context-hub.js
+++ b/src/server/routes/context-hub.js
@@ -10,7 +10,7 @@ import { pool } from '../db.js';
 import { anthropic, dateContext } from '../llm.js';
 import { safeParseLLM } from '../llm-json.js';
 import { requireAuth, softAuth, verifyBrandAccess, SUPER_ADMIN_IDS } from '../auth.js';
-import { forgeScrape, getBrandPageContent, discoverSubpages } from '../scrape.js';
+import { forgeScrape, getBrandPageContent, discoverSubpages, captureBrandVisual } from '../scrape.js';
 import { quickStartTruncate } from '../text.js';
 
 const router = express.Router();
@@ -471,6 +471,20 @@ router.post('/analyze', softAuth, async (req, res) => {
       : '';
     if (!scraperSuccess) console.warn(`[Context Hub] ⚠️ SCRAPER FAILED for ${brandUrl} — Claude will guess from domain name + Sonar context only`);
 
+    // ── Visual capture — measure the brand's REAL accent color + logo ─────────
+    // The text scrape strips all color, so accentColor used to be hallucinated
+    // (anchored to Forge). Load the homepage in the headless browser and read
+    // computed CSS. Best-effort: failure never blocks the profile.
+    let brandVisual = null;
+    if (workingBaseUrl) {
+      brandVisual = await captureBrandVisual(workingBaseUrl, { caller: 'context-hub', metadata: { brandUrl } }).catch(() => null);
+      if (brandVisual?.success) {
+        console.log(`[Context Hub] Visual capture: accent=${brandVisual.accentColor || 'none'} logo=${brandVisual.logoUrl ? 'yes' : 'no'}`);
+      } else {
+        console.warn(`[Context Hub] Visual capture failed: ${brandVisual?.error || 'unknown'}`);
+      }
+    }
+
     // ── Tool 1.5: Perplexity Sonar — competitor + ICP discovery ───────────────
     // Grounded in the SCRAPED site content, not the domain. The domain is a
     // terrible primary signal: brands like "Sommers House" on a *.forge-os.ai /
@@ -581,7 +595,7 @@ Return ONLY valid JSON (no markdown, no explanation, no newlines inside string v
     "positioning": "string — one tight sentence: what they do, for whom, and why they win",
     "targetPersona": "string — primary buyer in plain language, e.g. \'VP of Marketing at mid-market SaaS\'",
     "visualStyle": "string — inferred from site aesthetic, e.g. \'dark editorial minimal\', \'bright human photography\', \'technical precision grids\', \'warm organic textures\'",
-    "accentColor": "string — dominant brand color as hex if detectable, otherwise descriptor e.g. \'#3563FF\' or \'deep indigo\'"
+    "accentColor": "string — a plain-language descriptor only (e.g. \'deep indigo\', \'warm terracotta\'). Do NOT output a hex code: the real brand hex is measured from the live site and injected separately. Never guess a hex from text."
   },
   "personas": [{
     "id": "string", "name": "string", "role": "string",
@@ -654,6 +668,23 @@ Requirements: 5 toneAttributes, 2-3 personas, 4-6 thirdPartySignals, 3-5 competi
     console.log(`[Context Hub] Complete — ${brandName} | Latency: ${latencyMs}ms | Competitors found: ${sonarCompetitors.length}`);
 
     profileData.scraperSuccess = scraperSuccess;
+
+    // ── Inject measured visuals — overrides Claude's guessed accentColor ──────
+    // accentColor/logo are now MEASURED from the live site, not inferred from
+    // text. Store the raw capture under brandVisual and overwrite the (guessed)
+    // voiceProfile.accentColor with the real hex so every downstream consumer
+    // (Video Generator brand injector, hero-image gen) gets the true color.
+    if (brandVisual?.success && (brandVisual.accentColor || brandVisual.logoUrl)) {
+      profileData.brandVisual = {
+        accentColor: brandVisual.accentColor || null,
+        bgColor: brandVisual.bgColor || null,
+        logoUrl: brandVisual.logoUrl || null,
+        capturedAt: new Date().toISOString(),
+      };
+      if (brandVisual.accentColor) {
+        profileData.voiceProfile = { ...(profileData.voiceProfile || {}), accentColor: brandVisual.accentColor };
+      }
+    }
 
     // ── Stamp server-side time on every signal ────────────────────────────
     // The schema asks the LLM for a 'lastChecked' ISO8601 date per signal, but

--- a/src/server/routes/video.js
+++ b/src/server/routes/video.js
@@ -7,7 +7,7 @@ import express from 'express';
 import { pool } from '../db.js';
 import { verifyBrandAccess } from '../auth.js';
 import {
-  videoConfigured, storyboardFromBrief, synthesizeScenes,
+  videoConfigured, buildBrand, storyboardFromBrief, synthesizeScenes,
   renderReel, getReelProgress,
 } from '../video.js';
 
@@ -41,16 +41,16 @@ async function setStatus(id, fields) {
 }
 
 // Background pipeline — not awaited by the request.
-async function runJob(id, brief, brandName, orientation) {
+async function runJob(id, brief, brand, orientation) {
   try {
     await setStatus(id, { status: 'storyboarding' });
-    const draft = await storyboardFromBrief({ brief, brandName });
+    const draft = await storyboardFromBrief({ brief, brandName: brand.name });
 
     await setStatus(id, { status: 'voicing', scenes: JSON.stringify(draft) });
     const scenes = await synthesizeScenes(draft, id);
 
     await setStatus(id, { status: 'rendering', scenes: JSON.stringify(scenes) });
-    const { renderId, bucketName } = await renderReel({ brand: { name: brandName }, scenes, orientation });
+    const { renderId, bucketName } = await renderReel({ brand, scenes, orientation });
     await setStatus(id, { render_id: renderId, bucket_name: bucketName });
   } catch (e) {
     console.error('[VIDEO] job failed:', id, e.message);
@@ -70,16 +70,17 @@ router.post('/generate', async (req, res) => {
     if (!videoConfigured()) return res.status(503).json({ error: 'Video rendering is not configured (REMOTION_* env vars missing)' });
 
     const r = await pool.query(
-      `SELECT brand_name FROM brand_profiles WHERE id = $1`, [brandProfileId]
+      `SELECT brand_name, profile_data, logo_url FROM brand_profiles WHERE id = $1`, [brandProfileId]
     );
-    const brandName = r.rows[0]?.brand_name || 'Forge Intelligence';
+    const row = r.rows[0] || {};
+    const brand = buildBrand(row.brand_name || 'Forge Intelligence', row.profile_data, row.logo_url);
 
     const ins = await pool.query(
       `INSERT INTO generated_videos (brand_profile_id, brief, status, orientation) VALUES ($1, $2, 'queued', $3) RETURNING id`,
       [brandProfileId, brief, orientation]
     );
     const id = ins.rows[0].id;
-    runJob(id, brief, brandName, orientation); // fire-and-forget
+    runJob(id, brief, brand, orientation); // fire-and-forget
     res.status(202).json({ id, status: 'queued' });
   } catch (e) {
     console.error('[VIDEO] generate error:', e.message);

--- a/src/server/scrape.js
+++ b/src/server/scrape.js
@@ -144,6 +144,89 @@ async function _tryScrapingBrowser(url, { timeout, caller, metadata }) {
   }
 }
 
+// ── captureBrandVisual — measure a brand's REAL visual identity ─────────────
+// The markdown scrape strips all color/imagery, so accentColor was being
+// hallucinated. This loads the homepage in the headless browser WITH stylesheets
+// (unlike _tryScrapingBrowser, which blocks them) and reads computed CSS to pull
+// the true accent color + logo. Heuristic but measured, not guessed:
+//   accent = most-weighted saturated color across CTAs/buttons (x3), header/nav
+//            backgrounds (x2), link text (x1); neutrals/near-black/white dropped.
+//   logo   = og:image -> rel=icon/apple-touch-icon -> header/nav/logo <img>.
+// Returns { success, accentColor, bgColor, logoUrl }.
+export async function captureBrandVisual(url, { caller = 'context-hub', timeout = 30000, metadata = {} } = {}) {
+  const browserAuth = process.env.BRIGHTDATA_BROWSER_AUTH;
+  const startTime = Date.now();
+  if (!browserAuth) return { success: false, error: 'BRIGHTDATA_BROWSER_AUTH missing' };
+  let browser = null;
+  try {
+    browser = await puppeteer.connect({ browserWSEndpoint: `wss://${browserAuth}@brd.superproxy.io:9222` });
+    const page = await browser.newPage();
+    page.setDefaultNavigationTimeout(timeout);
+    // Keep stylesheets (computed colors need them); drop only fonts/media for bandwidth.
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      const t = req.resourceType();
+      if (['font', 'media'].includes(t)) req.abort();
+      else req.continue();
+    });
+    await page.goto(url, { waitUntil: 'networkidle2', timeout });
+    const visual = await page.evaluate(() => {
+      const toRGB = (s) => {
+        const m = s && s.match(/rgba?\(([^)]+)\)/);
+        if (!m) return null;
+        const p = m[1].split(',').map(x => parseFloat(x));
+        if (p[3] !== undefined && p[3] < 0.5) return null; // transparent
+        return { r: p[0], g: p[1], b: p[2] };
+      };
+      const sl = ({ r, g, b }) => {
+        const mx = Math.max(r, g, b) / 255, mn = Math.min(r, g, b) / 255;
+        const l = (mx + mn) / 2;
+        const s = mx === mn ? 0 : (l > 0.5 ? (mx - mn) / (2 - mx - mn) : (mx - mn) / (mx + mn));
+        return { s, l };
+      };
+      const hex = ({ r, g, b }) => '#' + [r, g, b].map(v => Math.round(v).toString(16).padStart(2, '0')).join('');
+      const cand = {};
+      const add = (rgb, w) => {
+        if (!rgb) return;
+        const { s, l } = sl(rgb);
+        if (s < 0.18 || l < 0.08 || l > 0.92) return; // neutral / near-black / near-white
+        const h = hex(rgb);
+        cand[h] = (cand[h] || 0) + w;
+      };
+      document.querySelectorAll('button,[class*="btn"],[class*="Button"],[class*="cta"],[class*="Cta"]')
+        .forEach(el => add(toRGB(getComputedStyle(el).backgroundColor), 3));
+      document.querySelectorAll('header,nav,[class*="header"],[class*="nav"]')
+        .forEach(el => add(toRGB(getComputedStyle(el).backgroundColor), 2));
+      document.querySelectorAll('a').forEach(el => add(toRGB(getComputedStyle(el).color), 1));
+      let accent = null, best = 0;
+      for (const [h, w] of Object.entries(cand)) if (w > best) { best = w; accent = h; }
+      const bodyRgb = toRGB(getComputedStyle(document.body).backgroundColor);
+      const abs = (u) => { try { return new URL(u, location.href).href; } catch { return null; } };
+      let logo = null;
+      const og = document.querySelector('meta[property="og:image"]');
+      if (og && og.getAttribute('content')) logo = abs(og.getAttribute('content'));
+      if (!logo) {
+        const ico = [...document.querySelectorAll('link[rel~="icon"],link[rel="apple-touch-icon"]')].pop();
+        if (ico) logo = abs(ico.getAttribute('href'));
+      }
+      if (!logo) {
+        const img = document.querySelector('header img,nav img,[class*="logo"] img,img[class*="logo"],img[alt*="logo" i]');
+        if (img) logo = abs(img.getAttribute('src'));
+      }
+      return { accent, bg: bodyRgb ? hex(bodyRgb) : null, logo };
+    });
+    await browser.close();
+    browser = null;
+    const latencyMs = Date.now() - startTime;
+    await _logScrape({ url, source: 'brightdata_browser', status_code: 200, body_size: 0, latency_ms: latencyMs, success: true, caller, metadata: { ...(metadata ?? {}), kind: 'visual', visual } });
+    return { success: true, accentColor: visual.accent, bgColor: visual.bg, logoUrl: visual.logo, latencyMs };
+  } catch (e) {
+    if (browser) { try { await browser.close(); } catch {} }
+    await _logScrape({ url, source: 'brightdata_browser', success: false, latency_ms: Date.now() - startTime, caller, error: e.message, metadata: { ...(metadata ?? {}), kind: 'visual' } });
+    return { success: false, error: e.message };
+  }
+}
+
 export async function forgeScrape(url, opts = {}) {
   const {
     format = 'raw',           // 'raw' = HTML, 'markdown' = cleaned content

--- a/src/server/video.js
+++ b/src/server/video.js
@@ -41,6 +41,39 @@ export function videoConfigured() {
   );
 }
 
+// ── Visual brand injector ──────────────────────────────────────────────────
+// Build the reel's brand object from the Context Hub profile so it renders in
+// the brand's REAL colors/logo, not Forge's. Source: profileData.brandVisual
+// (measured from the live site by captureBrandVisual) with voiceProfile.accentColor
+// + logo_url as fallbacks. Only accent colors and logo are overridden; the reel
+// keeps its light background + dark body text so contrast is always safe.
+const HEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+function normHex(s) {
+  if (typeof s !== 'string') return null;
+  const v = s.trim();
+  if (!HEX.test(v)) return null; // descriptors ("deep indigo") are not usable as a hex
+  return v.length === 4 ? '#' + [...v.slice(1)].map(c => c + c).join('') : v.toLowerCase();
+}
+
+// Mix a hex toward white (amt 0..1) for the lighter companion shade (orbit gradient).
+function lighten(hex, amt) {
+  const n = parseInt(hex.slice(1), 16);
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  const mix = (c) => Math.round(c + (255 - c) * amt);
+  return '#' + [mix(r), mix(g), mix(b)].map(c => c.toString(16).padStart(2, '0')).join('');
+}
+
+export function buildBrand(brandName, profileData, logoUrl) {
+  const brand = { name: brandName };
+  const v = profileData?.brandVisual || {};
+  const accent = normHex(v.accentColor) || normHex(profileData?.voiceProfile?.accentColor);
+  if (accent) brand.colors = { accent, accent2: lighten(accent, 0.45) };
+  const logo = v.logoUrl || logoUrl;
+  if (typeof logo === 'string' && /^https?:\/\//.test(logo)) brand.logo = logo;
+  return brand;
+}
+
 // Lazy-load the heavy SDKs so they only resolve when video is actually used.
 async function lambdaClient() {
   return import('@remotion/lambda/client');

--- a/test/video-brand.test.js
+++ b/test/video-brand.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildBrand } from '../src/server/video.js';
+
+describe('buildBrand (visual injector)', () => {
+  it('uses a measured hex from brandVisual', () => {
+    const b = buildBrand('Acme', { brandVisual: { accentColor: '#16A34A' } });
+    expect(b.colors.accent).toBe('#16a34a');
+    expect(b.colors.accent2).toMatch(/^#[0-9a-f]{6}$/); // derived lighter shade
+    expect(b.colors.accent2).not.toBe('#16a34a');
+  });
+
+  it('prefers brandVisual.accentColor over voiceProfile.accentColor', () => {
+    const b = buildBrand('Acme', {
+      brandVisual: { accentColor: '#ff0000' },
+      voiceProfile: { accentColor: '#0000ff' },
+    });
+    expect(b.colors.accent).toBe('#ff0000');
+  });
+
+  it('falls back to voiceProfile.accentColor when brandVisual is absent', () => {
+    const b = buildBrand('Acme', { voiceProfile: { accentColor: '#123ABC' } });
+    expect(b.colors.accent).toBe('#123abc');
+  });
+
+  it('ignores descriptor (non-hex) accent colors — no color override', () => {
+    const b = buildBrand('Acme', { voiceProfile: { accentColor: 'deep indigo' } });
+    expect(b.colors).toBeUndefined();
+  });
+
+  it('expands 3-digit hex', () => {
+    const b = buildBrand('Acme', { brandVisual: { accentColor: '#0a0' } });
+    expect(b.colors.accent).toBe('#00aa00');
+  });
+
+  it('takes logo from brandVisual, then the logo_url column, http(s) only', () => {
+    expect(buildBrand('Acme', { brandVisual: { logoUrl: 'https://x/l.png' } }).logo).toBe('https://x/l.png');
+    expect(buildBrand('Acme', {}, 'https://cdn/logo.svg').logo).toBe('https://cdn/logo.svg');
+    expect(buildBrand('Acme', {}, '/relative/logo.png').logo).toBeUndefined();
+  });
+
+  it('always sets the name and never throws on empty profile', () => {
+    expect(buildBrand('Forge Intelligence', null, null)).toEqual({ name: 'Forge Intelligence' });
+  });
+});


### PR DESCRIPTION
## Why
First video render came out fully Forge-branded. Root cause (you called it): **the Context Hub does no visual inspection** — the scrape is text-only, so `voiceProfile.accentColor` was hallucinated by Claude, anchored to Forge (the prompt's own example hex was Forge blue, and the navy we saw is a Forge UI color). Injecting that would smear a fake/Forge color on every brand.

## What — measure real visuals, then inject them

**Capture** (`scrape.js` + `context-hub.js`):
- `captureBrandVisual(url)` — loads the homepage in the headless browser we already use, but **keeps stylesheets** (the content scrape blocks them) and reads **computed CSS**. Accent = most-weighted saturated color across CTAs/buttons (×3), header/nav backgrounds (×2), link text (×1); neutrals / near-black / near-white dropped. Logo = `og:image` → `rel=icon`/`apple-touch-icon` → header/nav/`[class*=logo]` `<img>`. **Measured, not guessed.**
- Context Hub calls it post-scrape (best-effort — failure never blocks the profile), stores `profileData.brandVisual` and **overwrites** the guessed `voiceProfile.accentColor` with the real hex. Prompt updated so Claude emits a descriptor, never a hex.

**Inject** (`video.js` + `DataReel`):
- `buildBrand()` → `{ name, colors:{accent,accent2}, logo }`, preferring `brandVisual.accentColor` then `voiceProfile`, with `logo_url` fallback; derives `accent2` by lightening; ignores non-hex descriptors.
- `routes/video` pulls `profile_data` + `logo_url` and threads the brand through the job.
- `DataReel` `BrandMark`: real **logo** (`<Img>`) if measured; the **Forge diamond only for Forge**; **nothing** for a third-party brand with no logo (stops stamping Forge's mark on someone else's reel). Accent colors already flowed via `brand.colors`.

## Verified
- Lambda render with a deliberately non-Forge brand (Acme, green): headline + bars + CTA recolor green, lockup shows the name with **no Forge diamond**, background/text contrast preserved (frame in chat).
- 7 `buildBrand` unit tests + 152-test suite green; `tsc`/`node --check` clean; lint clean (`getComputedStyle`/`location` whitelisted for the `page.evaluate` browser context, same as the existing `document`/`window`).
- **Browser extraction itself couldn't be exercised in the sandbox** (egress can't reach BrightData's browser endpoint). It follows the exact proven `_tryScrapingBrowser` pattern that already runs in prod — validate by re-scanning a brand after deploy and checking `profile_data.brandVisual`.

## Deploy notes
- The `forge-reels` Lambda site is **already redeployed** with the new template. It's backward-compatible: old backend (brand = name only) → no colors override + no mark for non-Forge, no crash.
- Populating real colors requires a **Context Hub re-scan per brand** after this merges.

## Rollback
Revert the merge. `brandVisual` is additive; with it gone, reels fall back to Forge defaults (current behavior). The redeployed site stays backward-compatible regardless.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_