### PR TITLE
fix(scrape): visual capture must not wait for networkidle2

### DIFF
--- a/src/server/scrape.js
+++ b/src/server/scrape.js
@@ -169,7 +169,13 @@ export async function captureBrandVisual(url, { caller = 'context-hub', timeout 
       if (['font', 'media'].includes(t)) req.abort();
       else req.continue();
     });
-    await page.goto(url, { waitUntil: 'networkidle2', timeout });
+    // domcontentloaded + a settle delay, NOT networkidle2: heavy sites (analytics,
+    // animations — e.g. duolingo.com) never go network-idle and time out the whole
+    // capture. Computed styles only need stylesheets applied, which happens well
+    // before idle. If even DCL times out, proceed anyway — whatever rendered is
+    // usually measurable; a hard failure surfaces at evaluate().
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout }).catch(() => {});
+    await new Promise((r) => setTimeout(r, 2500));
     const visual = await page.evaluate(() => {
       const toRGB = (s) => {
         const m = s && s.match(/rgba?\(([^)]+)\)/);


### PR DESCRIPTION
## Why
First prod exercise of #306's `captureBrandVisual` (anonymous test scan of duolingo.com) failed: **`Navigation timeout of 30000 ms exceeded`** (`scrape_log` row with `kind:'visual'`). Heavy sites with constant analytics/animation traffic never fire `networkidle2`, so the whole capture timed out. Everything else worked — the capture ran post-scrape, logged correctly, failed soft (profile completed), and the prompt fix is live (Duolingo's `accentColor` came back as the descriptor `"Vibrant feather green"`, no hallucinated hex).

## What
Computed styles only need stylesheets *applied*, which happens long before network idle. So:
- `waitUntil: 'networkidle2'` → `'domcontentloaded'` + a fixed **2.5s settle delay**
- Swallow the `goto` timeout: whatever rendered is usually measurable; a genuine hard failure (DNS, etc.) still surfaces at `evaluate()`

One-line-ish change scoped to `captureBrandVisual` — the content scrape's wait logic is untouched.

## Test plan
- `node --check` + lint clean.
- Post-merge validation: re-run the anonymous duolingo scan and confirm `profile_data.brandVisual.accentColor` lands near `#58cc02` (I'll do this as soon as it deploys).

Ready (not draft) — it's the last blocker on validating the visual pipeline end-to-end.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_