### PR TITLE
fix(scrape): logo priority — real logo mark first, og:image last

### DIFF
--- a/src/server/scrape.js
+++ b/src/server/scrape.js
@@ -151,7 +151,7 @@ async function _tryScrapingBrowser(url, { timeout, caller, metadata }) {
 // the true accent color + logo. Heuristic but measured, not guessed:
 //   accent = most-weighted saturated color across CTAs/buttons (x3), header/nav
 //            backgrounds (x2), link text (x1); neutrals/near-black/white dropped.
-//   logo   = og:image -> rel=icon/apple-touch-icon -> header/nav/logo <img>.
+//   logo   = header/nav/logo <img> -> apple-touch-icon -> largest rel=icon -> og:image.
 // Returns { success, accentColor, bgColor, logoUrl }.
 export async function captureBrandVisual(url, { caller = 'context-hub', timeout = 30000, metadata = {} } = {}) {
   const browserAuth = process.env.BRIGHTDATA_BROWSER_AUTH;
@@ -208,16 +208,27 @@ export async function captureBrandVisual(url, { caller = 'context-hub', timeout 
       for (const [h, w] of Object.entries(cand)) if (w > best) { best = w; accent = h; }
       const bodyRgb = toRGB(getComputedStyle(document.body).backgroundColor);
       const abs = (u) => { try { return new URL(u, location.href).href; } catch { return null; } };
+      // Logo priority: an actual logo mark first. og:image LAST — it's usually a
+      // 1200x630 social share banner, not a logo (Duolingo's came back as the
+      // share card), and it looks squished in the reel lockup.
       let logo = null;
-      const og = document.querySelector('meta[property="og:image"]');
-      if (og && og.getAttribute('content')) logo = abs(og.getAttribute('content'));
+      const img = document.querySelector('header img,nav img,[class*="logo"] img,img[class*="logo"],img[alt*="logo" i]');
+      if (img) logo = abs(img.getAttribute('src') || img.getAttribute('data-src'));
       if (!logo) {
-        const ico = [...document.querySelectorAll('link[rel~="icon"],link[rel="apple-touch-icon"]')].pop();
-        if (ico) logo = abs(ico.getAttribute('href'));
+        const touch = document.querySelector('link[rel="apple-touch-icon"],link[rel="apple-touch-icon-precomposed"]');
+        if (touch) logo = abs(touch.getAttribute('href'));
       }
       if (!logo) {
-        const img = document.querySelector('header img,nav img,[class*="logo"] img,img[class*="logo"],img[alt*="logo" i]');
-        if (img) logo = abs(img.getAttribute('src'));
+        // Prefer the largest declared favicon (sizes attr), skip tiny .ico defaults.
+        const icons = [...document.querySelectorAll('link[rel~="icon"]')]
+          .map(l => ({ href: l.getAttribute('href'), size: parseInt((l.getAttribute('sizes') || '0').split('x')[0], 10) || 0 }))
+          .filter(i => i.href)
+          .sort((a, b) => b.size - a.size);
+        if (icons[0]) logo = abs(icons[0].href);
+      }
+      if (!logo) {
+        const og = document.querySelector('meta[property="og:image"]');
+        if (og && og.getAttribute('content')) logo = abs(og.getAttribute('content'));
       }
       return { accent, bg: bodyRgb ? hex(bodyRgb) : null, logo };
     });


### PR DESCRIPTION
## Why
Post-#308 validation **proved the visual capture works in prod** — the duolingo.com scan measured a genuine Duolingo green (`#a5ed6e`) and overwrote the guessed `accentColor`. One defect surfaced: `logoUrl` came back as the **og:image**, which is a 1200×630 social share *banner*, not a logo. Rendered into the reel's 36px-high lockup it reads as a squished thumbnail.

## What
Reorder logo selection so an actual mark wins:
1. `header`/`nav`/`[class*=logo]` `<img>` (the real logo, often the wordmark) — also reads `data-src` for lazy-loaded logos
2. `apple-touch-icon` (square, high-res)
3. Largest declared `rel=icon` by `sizes` attr (skips tiny default `.ico`)
4. `og:image` — last resort only

## Test plan
- `node --check` + lint clean.
- Post-merge: re-run the anonymous duolingo scan; `logoUrl` should resolve to their header logo or touch icon rather than the share card. I'll verify on deploy.

Ready (not draft) — small, scoped to the logo block inside `captureBrandVisual`, accent logic untouched.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_