### PR TITLE
feat(video): reel canvas takes the brand's measured background color

### DIFF
--- a/src/server/video.js
+++ b/src/server/video.js
@@ -64,11 +64,25 @@ function lighten(hex, amt) {
   return '#' + [mix(r), mix(g), mix(b)].map(c => c.toString(16).padStart(2, '0')).join('');
 }
 
+// Perceived lightness 0..1 (rec601 luma) — guards the bg override.
+function lightness(hex) {
+  const n = parseInt(hex.slice(1), 16);
+  return ((n >> 16 & 255) * 0.299 + (n >> 8 & 255) * 0.587 + (n & 255) * 0.114) / 255;
+}
+
 export function buildBrand(brandName, profileData, logoUrl) {
   const brand = { name: brandName };
   const v = profileData?.brandVisual || {};
   const accent = normHex(v.accentColor) || normHex(profileData?.voiceProfile?.accentColor);
   if (accent) brand.colors = { accent, accent2: lighten(accent, 0.45) };
+  // Canvas takes the brand's measured page background ONLY when it's clearly
+  // light — the reel's text/cards are designed for a light canvas, so a dark
+  // site bg (or a mid-tone) would break contrast. Dark-mode reels are a
+  // template variant, not a color swap.
+  const bg = normHex(v.bgColor);
+  if (bg && lightness(bg) >= 0.88) {
+    brand.colors = { ...(brand.colors || {}), bg };
+  }
   const logo = v.logoUrl || logoUrl;
   if (typeof logo === 'string' && /^https?:\/\//.test(logo)) brand.logo = logo;
   return brand;

--- a/test/video-brand.test.js
+++ b/test/video-brand.test.js
@@ -42,3 +42,27 @@ describe('buildBrand (visual injector)', () => {
     expect(buildBrand('Forge Intelligence', null, null)).toEqual({ name: 'Forge Intelligence' });
   });
 });
+
+describe('buildBrand bg override', () => {
+  it('applies a clearly light measured bg (Sommers cream)', () => {
+    const b = buildBrand('Sommers House', { brandVisual: { accentColor: '#2e5c3b', bgColor: '#fbf8f1' } });
+    expect(b.colors.bg).toBe('#fbf8f1');
+    expect(b.colors.accent).toBe('#2e5c3b');
+  });
+
+  it('rejects a dark site bg (contrast guard)', () => {
+    const b = buildBrand('DarkCo', { brandVisual: { accentColor: '#ff4400', bgColor: '#111122' } });
+    expect(b.colors.bg).toBeUndefined();
+    expect(b.colors.accent).toBe('#ff4400'); // accent still applies
+  });
+
+  it('rejects a mid-tone bg', () => {
+    const b = buildBrand('MidCo', { brandVisual: { bgColor: '#888888' } });
+    expect(b.colors).toBeUndefined();
+  });
+
+  it('applies bg even when no accent was measured', () => {
+    const b = buildBrand('PaleCo', { brandVisual: { bgColor: '#ffffff' } });
+    expect(b.colors.bg).toBe('#ffffff');
+  });
+});


### PR DESCRIPTION
## Why
The visual injector (#306) overrides accents + logo but leaves the reel on Forge's lavender canvas. Sommers House measured a warm cream page background (`#fbf8f1`) that should carry into the reel.

## What
`buildBrand` now passes `brandVisual.bgColor` through as `colors.bg` — **with a contrast guard**: only applied when the measured background is clearly light (rec601 luma ≥ 0.88). The reel's dark text and white cards are designed for a light canvas; a dark or mid-tone site background would break them (that's a future dark-mode template variant, not a color swap). Accent + logo still apply regardless of the bg decision.

The `DataReel` template already accepts `colors.bg`, so **no Lambda site redeploy is needed** — this is backend-only.

## Test plan
- 4 new tests: light bg applied (Sommers cream), dark bg rejected (accent still applies), mid-tone rejected, bg-without-accent applied. 11/11 in `video-brand.test.js`.
- `node --check` + lint clean.
- Post-deploy: regenerate the Sommers reel — canvas should come out cream under the forest-green accent.

Ready (not draft) — small, scoped to `buildBrand`.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_