### PR TITLE
fix(ui): recover from dropped /analyze connections instead of hanging

### DIFF
--- a/src/components/views/BrandProfile.tsx
+++ b/src/components/views/BrandProfile.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@clerk/clerk-react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../../context/AppContext';
 import { BuildWithPartnerButton } from '../BuildWithPartnerButton';
+import { baselineVersionFor, withDeadline, isConnectionDeath, recoverAnalyze } from '../../lib/analyzeRecovery';
 import './BrandProfile.css';
 
 // Lucide-style icons
@@ -83,22 +84,31 @@ export function BrandProfile() {
   const handleReanalyze = useCallback(async () => {
     if (!brandProfile?.brandUrl || reanalyzing) return;
     setReanalyzing(true);
+    // The scan holds one connection open 3-4 min; if it drops, the server still
+    // finishes — recover via version-bump polling instead of spinning forever
+    // (see src/lib/analyzeRecovery.ts).
+    const baselineVersion = await baselineVersionFor(brandProfile.brandUrl);
     try {
       const token = await getToken();
-      const r = await fetch('/api/context-hub/analyze', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...(token ? { 'Authorization': `Bearer ${token}` } : {}) },
-        body: JSON.stringify({
-          brandUrl: brandProfile.brandUrl,
-          competitorUrls: [],
-          audienceNotes: '',
-          strategicNotes: '',
-          checkBrainFirst: false,
-          saveToBrain: true,
-        }),
-      });
-      const d = await r.json();
-      if (d.success && d.data) {
+      let d: any;
+      try {
+        d = await withDeadline(fetch('/api/context-hub/analyze', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...(token ? { 'Authorization': `Bearer ${token}` } : {}) },
+          body: JSON.stringify({
+            brandUrl: brandProfile.brandUrl,
+            competitorUrls: [],
+            audienceNotes: '',
+            strategicNotes: '',
+            checkBrainFirst: false,
+            saveToBrain: true,
+          }),
+        }).then(r => r.json()));
+      } catch (err) {
+        if (!isConnectionDeath(err)) throw err;
+        d = await recoverAnalyze(brandProfile.brandUrl, baselineVersion);
+      }
+      if (d?.success && d.data) {
         setBrandProfile(d.data);
       }
     } catch (e) { console.error('Re-analyze failed:', e); }

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState, useEffect, useCallback, useRef, Re
 import { ViewType, BrandProfile, AnalysisInput, ProcessingStage, HistoryEntry } from '../types';
 import { initialProcessingStages, sampleAnalysisInput } from '../data/mockData';
 import { humanize, AlertSeverity } from '../lib/humanizeError';
+import { baselineVersionFor, withDeadline, isConnectionDeath, recoverAnalyze } from '../lib/analyzeRecovery';
 
 export interface Alert {
   id: string;
@@ -301,6 +302,11 @@ export function AppProvider({ children }: { children: ReactNode }) {
     const stages = initialProcessingStages.map(s => ({ ...s, status: 'pending' as const }));
     setProcessingStages(stages);
 
+    // Connection-drop resilience (see src/lib/analyzeRecovery.ts): snapshot the
+    // brand's current version; if the analyze fetch dies or zombies, recover the
+    // completed brain by polling for the version bump instead of hanging.
+    const baselineVersion = await baselineVersionFor(effectiveUrl);
+
     // Fire API call immediately — runs concurrently with the stage animation
     const analyzePromise = fetch('/api/context-hub/analyze', {
       method: 'POST',
@@ -357,7 +363,18 @@ export function AppProvider({ children }: { children: ReactNode }) {
     driveStages();
 
     try {
-      const data = await analyzePromise;
+      let data: any;
+      try {
+        data = await withDeadline(analyzePromise);
+      } catch (err) {
+        // Recover ONLY from network-level death — the server is most likely
+        // still working and will save the brain. Real server errors (409
+        // domain-claimed, !success payloads) re-throw below.
+        if (!isConnectionDeath(err)) throw err;
+        const recovered = await recoverAnalyze(effectiveUrl, baselineVersion);
+        if (!recovered) throw new Error('Analysis connection lost and recovery timed out — refresh to check Brain History');
+        data = recovered;
+      }
       cancelled = true;
       if (!data.success) throw new Error(data.error);
 

--- a/src/lib/analyzeRecovery.ts
+++ b/src/lib/analyzeRecovery.ts
@@ -1,0 +1,61 @@
+// Connection-drop recovery for /api/context-hub/analyze.
+//
+// /analyze is a single synchronous request that holds the connection open for
+// the full 3-4 minute scan. If the connection dies mid-flight (proxy idle
+// timeout, tab throttling, network blip) the SERVER finishes and saves fine,
+// but the browser's fetch never settles — the UI spins forever. These helpers
+// let every analyze call site (a) put a hard deadline on the fetch and
+// (b) recover the completed brain by polling the open history endpoint for a
+// version bump, then loading /brand/:id (same payload shape as analyze).
+
+export const ANALYZE_DEADLINE_MS = 8 * 60_000; // >> any real scan (3-4 min)
+
+// Snapshot the brand's current max version so recovery can detect the bump.
+export async function baselineVersionFor(brandUrl: string): Promise<number> {
+  try {
+    const h = await fetch(`/api/context-hub/history/${encodeURIComponent(brandUrl)}`).then(r => r.json());
+    if (h?.success && Array.isArray(h.data) && h.data.length) {
+      return Math.max(...h.data.map((r: any) => r.version || 0));
+    }
+  } catch { /* best-effort */ }
+  return 0;
+}
+
+// Race the analyze fetch against a deadline; a fetch whose connection has
+// silently died never settles on its own.
+export function withDeadline<T>(p: Promise<T>, ms = ANALYZE_DEADLINE_MS): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, rej) => setTimeout(() => rej(new Error('analyze-connection-lost')), ms)),
+  ]);
+}
+
+// True only for network-level death (dropped connection / our deadline) —
+// real server errors (409 domain-claimed, !success payloads) must NOT recover.
+export function isConnectionDeath(err: unknown): boolean {
+  return err instanceof Error &&
+    (err.message === 'analyze-connection-lost' ||
+     err.name === 'TypeError' ||
+     /failed to fetch|load failed|network/i.test(err.message));
+}
+
+// Poll history for a version newer than baseline; on bump, load the full brain.
+// Returns the analyze-shaped response ({ success, data }) or null on timeout.
+export async function recoverAnalyze(brandUrl: string, baselineVersion: number): Promise<any | null> {
+  const POLL_MS = 10_000;
+  const MAX_MS = 6 * 60_000;
+  const deadline = Date.now() + MAX_MS;
+  while (Date.now() < deadline) {
+    try {
+      const h = await fetch(`/api/context-hub/history/${encodeURIComponent(brandUrl)}`).then(r => r.json());
+      const rows: any[] = h?.success && Array.isArray(h.data) ? h.data : [];
+      const fresh = rows.find(r => (r.version || 0) > baselineVersion && r.is_active !== false);
+      if (fresh?.id) {
+        const b = await fetch(`/api/context-hub/brand/${fresh.id}`).then(r => r.json());
+        if (b?.success && b.data) return b;
+      }
+    } catch { /* transient — keep polling */ }
+    await new Promise(r => setTimeout(r, POLL_MS));
+  }
+  return null;
+}

--- a/src/pages/ContextAgentPage.tsx
+++ b/src/pages/ContextAgentPage.tsx
@@ -8,6 +8,7 @@ import { Strategy } from '../components/views/Strategy';
 import { BrainHistory } from '../components/views/BrainHistory';
 import { initialProcessingStages } from '../data/mockData';
 import { ProcessingStage } from '../types';
+import { baselineVersionFor, withDeadline, isConnectionDeath, recoverAnalyze } from '../lib/analyzeRecovery';
 
 function ContextAgentPage() {
   const { currentView, setCurrentView, setIsProcessing, setProcessingStages, setBrandProfile, setAnalysisInput, activeBrand } = useApp();
@@ -46,20 +47,30 @@ function ContextAgentPage() {
 
     driveStages();
 
-    // Domain is the session key — no session ID needed
-    fetch('/api/context-hub/analyze', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        brandUrl: onboardUrl,
-        competitorUrls: [],
-        audienceNotes: '',
-        strategicNotes: '',
-        checkBrainFirst: true,
-        saveToBrain: true,
-      }),
-    })
-      .then(r => r.json())
+    // Domain is the session key — no session ID needed.
+    // withDeadline + recoverAnalyze: if the 3-4 min connection drops, the server
+    // still finishes — recover via version-bump polling instead of spinning
+    // forever (see src/lib/analyzeRecovery.ts).
+    baselineVersionFor(onboardUrl)
+      .then(baselineVersion =>
+        withDeadline(fetch('/api/context-hub/analyze', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            brandUrl: onboardUrl,
+            competitorUrls: [],
+            audienceNotes: '',
+            strategicNotes: '',
+            checkBrainFirst: true,
+            saveToBrain: true,
+          }),
+        }).then(r => r.json())).catch(async (err) => {
+          if (!isConnectionDeath(err)) throw err;
+          const recovered = await recoverAnalyze(onboardUrl, baselineVersion);
+          if (!recovered) throw new Error('Analysis connection lost and recovery timed out — refresh to check Brain History');
+          return recovered;
+        })
+      )
       .then(d => {
         cancelled = true;
         if (d.success && d.data) {


### PR DESCRIPTION
## Why
Brian's Sommers v5 re-scan: UI spun forever while Render logs showed the scan completing; a browser refresh showed the finished brain. Root cause: **`/api/context-hub/analyze` is one synchronous HTTP request held open for the full 3–4 minute scan.** If the connection dies mid-flight (proxy idle timeout, tab throttling, network blip), the server finishes and saves fine, but the browser's `fetch` never settles → the UI hangs until manual refresh.

## What
New `src/lib/analyzeRecovery.ts`, wired into all three scan-shaped call sites:

- `baselineVersionFor(url)` — snapshot the brand's max version before scanning (open `/history/:url` endpoint)
- `withDeadline(p)` — 8-min race so a zombie connection can't hang forever (real scans run 3–4 min)
- `isConnectionDeath(err)` — recovery triggers **only** on network-level death; real server errors (409 domain-claimed, `!success` payloads) still surface as errors
- `recoverAnalyze(url, baseline)` — poll history every 10s (up to 6 min) for the version bump, then load `/brand/:id`, which returns the exact same payload shape as analyze

**Call sites:** `AppContext.startAnalysis` (New Analysis flow), `BrandProfile.handleReanalyze` (the re-scan path that bit tonight — its old catch just logged and could leave `reanalyzing` stuck), `ContextAgentPage` landing-onboard flow. Quick Start synthesis left alone (no scrape — fast path, different payload).

## Not in scope
The *proper* fix is converting `/analyze` to the async ack+poll pattern like video gen — that touches the core Stage 1 flow and deserves daylight. This PR makes the current architecture self-heal client-side. Backlogged.

## Test plan
- `tsc --noEmit` + `vite build` clean.
- Behavior change is confined to the two failure modes that previously hung or failed silently; the happy path is untouched (fetch resolves → identical flow).
- Live repro of a dropped connection is impractical to stage; the recovery path reuses two open endpoints already exercised in prod (`/history/:url`, `/brand/:id`).

Ready (not draft) per Brian — wanted on production now.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_