### PR TITLE
feat(video): visual themes + hard length enforcement (round 2, follow-up to #318)

### DIFF
--- a/remotion/src/DataReel.tsx
+++ b/remotion/src/DataReel.tsx
@@ -5,7 +5,7 @@ import {
 } from "remotion";
 import type {
   Brand, Scene, HookScene, TagsScene, OrbitScene,
-  PipelineScene, BarsScene, CurveScene, CtaScene, VideoProps,
+  PipelineScene, BarsScene, CurveScene, CtaScene, VideoProps, ThemeId,
 } from "./types";
 
 // Forge defaults — any brand.colors key overrides these.
@@ -18,16 +18,61 @@ type Palette = typeof DEFAULT_COLORS;
 
 const DEFAULT_FONT = '-apple-system, "Helvetica Neue", "Segoe UI", Roboto, Arial, sans-serif';
 
+// ── Visual themes ───────────────────────────────────────────────────────────
+// Template-level styles. `colors` are applied AFTER the brand's colors, so a
+// dark theme's canvas wins over a measured light brand bg (the brand's ACCENT
+// still applies — themes don't define accents). `scale` folds into the global
+// k unit; `springCfg` drives every entrance; `headlineFont` restyles the big
+// type only.
+type Theme = {
+  colors?: Partial<Palette>;
+  headlineFont?: string;
+  headlineWeight?: number;
+  scale: number;
+  springCfg: { damping: number; stiffness?: number; mass?: number };
+};
+const THEMES: Record<ThemeId, Theme> = {
+  // The original light product look.
+  clean: { scale: 1, springCfg: { damping: 200 } },
+  // Luxury magazine: serif headlines, lighter weight, slower glide.
+  editorial: {
+    headlineFont: 'Georgia, "Times New Roman", "Palatino Linotype", serif',
+    headlineWeight: 600,
+    scale: 0.96,
+    springCfg: { damping: 200, stiffness: 45, mass: 1.2 },
+  },
+  // Dark canvas, huge type, high contrast. Theme canvas beats brand bg; brand
+  // accent survives.
+  bold: {
+    colors: {
+      bg: "#0B1220", card: "#141D2E", emphasis: "#F8FAFC",
+      secondary: "#A6B3C8", muted: "#64748B", border: "#1F2A3D",
+    },
+    headlineWeight: 800,
+    scale: 1.1,
+    springCfg: { damping: 200 },
+  },
+  // Springy, fast, punchy entrances.
+  kinetic: { scale: 1.04, springCfg: { damping: 14, stiffness: 160, mass: 0.7 } },
+};
+
 // Sizes below are authored against a landscape design width. `k` rescales every
 // dimension to the actual canvas so the SAME layout works at 1920x1080 and
 // 1080x1920 — portrait just gets a tighter unit and the flex rows wrap.
 type Layout = { k: number; portrait: boolean };
-const Ctx = React.createContext<{ C: Palette; font: string; brand: Brand; L: Layout }>({
+const Ctx = React.createContext<{ C: Palette; font: string; brand: Brand; L: Layout; T: Theme }>({
   C: DEFAULT_COLORS, font: DEFAULT_FONT, brand: { name: "Forge Intelligence" },
-  L: { k: 1, portrait: false },
+  L: { k: 1, portrait: false }, T: THEMES.clean,
 });
 
 const useL = () => React.useContext(Ctx).L;
+const useT = () => React.useContext(Ctx).T;
+
+// Headline style fragment shared by every big-type element.
+const useHeadline = () => {
+  const T = useT();
+  return { fontFamily: T.headlineFont, fontWeight: T.headlineWeight ?? 800 } as const;
+};
 
 // audio: full URL (S3) used as-is, bare filename resolved locally.
 const audioSrc = (a?: string) =>
@@ -58,8 +103,9 @@ const useRise = (delay = 0, dist = 50) => {
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
   const { k } = useL();
-  const s = spring({ frame: frame - delay, fps, config: { damping: 200 } });
-  return { opacity: s, transform: `translateY(${interpolate(s, [0, 1], [dist * k, 0])}px)` };
+  const T = useT();
+  const s = spring({ frame: frame - delay, fps, config: T.springCfg });
+  return { opacity: Math.min(1, s), transform: `translateY(${interpolate(s, [0, 1], [dist * k, 0])}px)` };
 };
 
 const Stage: React.FC<{ children: React.ReactNode; audio?: string }> = ({ children, audio }) => {
@@ -80,6 +126,7 @@ const Stage: React.FC<{ children: React.ReactNode; audio?: string }> = ({ childr
 const HookView: React.FC<{ s: HookScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
   const { k } = useL();
+  const hl = useHeadline();
   const a = useRise(0), b = useRise(14);
   return (
     <Stage audio={s.audio}>
@@ -87,7 +134,7 @@ const HookView: React.FC<{ s: HookScene }> = ({ s }) => {
         {s.eyebrow && (
           <div style={{ ...a, fontSize: 28 * k, letterSpacing: 6 * k, color: C.accent, fontWeight: 700, marginBottom: 28 * k }}>{s.eyebrow}</div>
         )}
-        <div style={{ ...a, fontSize: 110 * k, fontWeight: 800, color: C.emphasis, lineHeight: 1.05 }}>
+        <div style={{ ...a, ...hl, fontSize: 110 * k, color: C.emphasis, lineHeight: 1.05 }}>
           {s.headline}
           {s.emphasis && <><br /><span style={{ color: C.error }}>{s.emphasis}</span></>}
         </div>
@@ -100,11 +147,12 @@ const HookView: React.FC<{ s: HookScene }> = ({ s }) => {
 const TagsView: React.FC<{ s: TagsScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
   const { k } = useL();
+  const hl = useHeadline();
   const head = useRise(0);
   return (
     <Stage audio={s.audio}>
       <div style={{ textAlign: "center", maxWidth: 1500 * k }}>
-        <div style={{ ...head, fontSize: 80 * k, fontWeight: 800, color: C.emphasis, lineHeight: 1.1 }}>{s.headline}</div>
+        <div style={{ ...head, ...hl, fontSize: 80 * k, color: C.emphasis, lineHeight: 1.1 }}>{s.headline}</div>
         <div style={{ display: "flex", gap: 22 * k, justifyContent: "center", flexWrap: "wrap", marginTop: 56 * k }}>
           {s.tags.map((t, i) => {
             const r = useRise(30 + i * 14);
@@ -121,9 +169,10 @@ const TagsView: React.FC<{ s: TagsScene }> = ({ s }) => {
 const OrbitView: React.FC<{ s: OrbitScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
   const { k, portrait } = useL();
+  const T = useT();
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
-  const core = spring({ frame, fps, config: { damping: 200 } });
+  const core = spring({ frame, fps, config: T.springCfg });
   const sub = useRise(70);
   const radius = (portrait ? 300 : 330) * k; // tighter ring in portrait so chips don't clip
   return (
@@ -140,12 +189,12 @@ const OrbitView: React.FC<{ s: OrbitScene }> = ({ s }) => {
         </div>
         {s.facets.map((f, i) => {
           const ang = (i / s.facets.length) * Math.PI * 2 - Math.PI / 2;
-          const appear = spring({ frame: frame - 24 - i * 10, fps, config: { damping: 200 } });
+          const appear = spring({ frame: frame - 24 - i * 10, fps, config: T.springCfg });
           const x = Math.cos(ang) * radius, y = Math.sin(ang) * radius * 0.62;
           return (
             <div key={f} style={{
               position: "absolute", left: `calc(50% + ${x}px)`, top: `calc(50% + ${y}px)`,
-              transform: `translate(-50%,-50%) scale(${appear})`, opacity: appear,
+              transform: `translate(-50%,-50%) scale(${appear})`, opacity: Math.min(1, appear),
               background: C.card, border: `2px solid ${C.accent}`, color: C.accent, fontWeight: 700,
               fontSize: 34 * k, padding: `${16 * k}px ${30 * k}px`, borderRadius: 999, whiteSpace: "nowrap",
               boxShadow: `0 ${8 * k}px ${30 * k}px rgba(53,99,255,0.15)`,
@@ -165,6 +214,8 @@ const OrbitView: React.FC<{ s: OrbitScene }> = ({ s }) => {
 const PipelineView: React.FC<{ s: PipelineScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
   const { k, portrait } = useL();
+  const T = useT();
+  const hl = useHeadline();
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
   const head = useRise(0);
@@ -172,17 +223,17 @@ const PipelineView: React.FC<{ s: PipelineScene }> = ({ s }) => {
   return (
     <Stage audio={s.audio}>
       <div style={{ width: (portrait ? 920 : 1640) * k, textAlign: "center" }}>
-        <div style={{ ...head, fontSize: 70 * k, fontWeight: 800, color: C.emphasis, marginBottom: 70 * k }}>
+        <div style={{ ...head, ...hl, fontSize: 70 * k, color: C.emphasis, marginBottom: 70 * k }}>
           {s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}
         </div>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "center", flexWrap: "wrap", gap: portrait ? 14 * k : 0, rowGap: 18 * k }}>
           {s.stages.map((st, i) => {
-            const lit = spring({ frame: frame - 20 - i * 16, fps, config: { damping: 200 } });
+            const lit = spring({ frame: frame - 20 - i * 16, fps, config: T.springCfg });
             const isLast = s.highlightLast !== false && i === s.stages.length - 1;
             return (
               <React.Fragment key={st}>
                 <div style={{
-                  transform: `scale(${interpolate(lit, [0, 1], [0.7, 1])})`, opacity: lit,
+                  transform: `scale(${interpolate(lit, [0, 1], [0.7, 1])})`, opacity: Math.min(1, lit),
                   width: node, height: node, borderRadius: 24 * k, flexShrink: 0,
                   background: isLast ? C.accent : C.card, color: isLast ? "#fff" : C.emphasis,
                   border: `2px solid ${isLast ? C.accent : C.border}`,
@@ -191,7 +242,7 @@ const PipelineView: React.FC<{ s: PipelineScene }> = ({ s }) => {
                   boxShadow: isLast ? `0 0 ${50 * k}px rgba(53,99,255,0.4)` : `0 ${6 * k}px ${20 * k}px rgba(15,23,42,0.06)`,
                 }}>{st}</div>
                 {!portrait && i < s.stages.length - 1 && (
-                  <div style={{ width: 44 * k, height: 4 * k, background: C.border, flexShrink: 0, opacity: lit, borderRadius: 2 }} />
+                  <div style={{ width: 44 * k, height: 4 * k, background: C.border, flexShrink: 0, opacity: Math.min(1, lit), borderRadius: 2 }} />
                 )}
               </React.Fragment>
             );
@@ -211,7 +262,7 @@ const BarRow: React.FC<{ label: string; pct: number; delay: number }> = ({ label
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 28 * k, marginBottom: 22 * k }}>
       <span style={{ width: 380 * k, fontSize: 38 * k, fontWeight: 600, color: C.emphasis }}>{label}</span>
-      <div style={{ flex: 1, height: 30 * k, background: "#dfe5f5", borderRadius: 15 * k, overflow: "hidden" }}>
+      <div style={{ flex: 1, height: 30 * k, background: C.border, borderRadius: 15 * k, overflow: "hidden" }}>
         <div style={{ width: `${Math.max(w, zero ? 1.2 : w)}%`, height: "100%", background: zero ? C.error : C.accent, borderRadius: 15 * k }} />
       </div>
       <span style={{ width: 100 * k, textAlign: "right", fontSize: 38 * k, fontWeight: 700, color: zero ? C.error : C.emphasis }}>{Math.round(w)}%</span>
@@ -222,11 +273,12 @@ const BarRow: React.FC<{ label: string; pct: number; delay: number }> = ({ label
 const BarsView: React.FC<{ s: BarsScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
   const { k } = useL();
+  const hl = useHeadline();
   const head = useRise(0);
   return (
     <Stage audio={s.audio}>
       <div style={{ width: 1500 * k }}>
-        <div style={{ ...head, fontSize: 64 * k, fontWeight: 800, color: C.emphasis, marginBottom: 48 * k, textAlign: "center" }}>
+        <div style={{ ...head, ...hl, fontSize: 64 * k, color: C.emphasis, marginBottom: 48 * k, textAlign: "center" }}>
           {s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}
         </div>
         {s.bars.map((b, i) => <BarRow key={b.label} label={b.label} pct={b.pct} delay={40 + i * 12} />)}
@@ -249,6 +301,7 @@ const BarsView: React.FC<{ s: BarsScene }> = ({ s }) => {
 const CurveView: React.FC<{ s: CurveScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
   const { k } = useL();
+  const hl = useHeadline();
   const frame = useCurrentFrame();
   const head = useRise(0);
   const progress = interpolate(frame, [20, 130], [0, 1], { extrapolateRight: "clamp", easing: Easing.out(Easing.cubic) });
@@ -258,7 +311,7 @@ const CurveView: React.FC<{ s: CurveScene }> = ({ s }) => {
   return (
     <Stage audio={s.audio}>
       <div style={{ width: W, textAlign: "center" }}>
-        <div style={{ ...head, fontSize: 76 * k, fontWeight: 800, color: C.emphasis, marginBottom: 50 * k }}>
+        <div style={{ ...head, ...hl, fontSize: 76 * k, color: C.emphasis, marginBottom: 50 * k }}>
           {s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}
         </div>
         <svg width={W} height={H} style={{ overflow: "visible" }}>
@@ -275,12 +328,13 @@ const CurveView: React.FC<{ s: CurveScene }> = ({ s }) => {
 const CtaView: React.FC<{ s: CtaScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
   const { k } = useL();
+  const hl = useHeadline();
   const a = useRise(0), b = useRise(14), c = useRise(30);
   return (
     <Stage audio={s.audio}>
       <div style={{ textAlign: "center", maxWidth: 1500 * k }}>
         <div style={a}><BrandMark size={96} /></div>
-        <div style={{ ...b, fontSize: 96 * k, fontWeight: 800, color: C.emphasis, margin: `${34 * k}px 0 ${26 * k}px` }}>{s.title}</div>
+        <div style={{ ...b, ...hl, fontSize: 96 * k, color: C.emphasis, margin: `${34 * k}px 0 ${26 * k}px` }}>{s.title}</div>
         {s.sub && <div style={{ ...b, fontSize: 50 * k, color: C.secondary, fontWeight: 500, marginBottom: 44 * k }}>{s.sub}</div>}
         <div style={{ ...c, fontSize: 46 * k, fontWeight: 700, color: "#fff", background: C.accent, borderRadius: 18 * k, padding: `${24 * k}px ${52 * k}px`, display: "inline-block" }}>{s.cta}</div>
       </div>
@@ -334,18 +388,23 @@ export const musicVolumeAt = (frame: number, scenes: Scene[]) => {
   return level * fadeIn * fadeOut;
 };
 
-export const DataReel: React.FC<VideoProps> = ({ brand, scenes, fontFamily, music }) => {
-  const C: Palette = { ...DEFAULT_COLORS, ...(brand.colors || {}) };
+export const DataReel: React.FC<VideoProps> = ({ brand, scenes, fontFamily, music, theme }) => {
+  const T = THEMES[theme ?? "clean"] ?? THEMES.clean;
+  // Precedence: defaults -> brand colors -> theme colors. The theme's canvas
+  // (e.g. bold's dark bg) must beat a measured light brand bg, but the brand's
+  // ACCENT survives because themes don't define accents.
+  const C: Palette = { ...DEFAULT_COLORS, ...(brand.colors || {}), ...(T.colors || {}) };
   const font = fontFamily || DEFAULT_FONT;
   const { width, height } = useVideoConfig();
   const portrait = height > width;
   // Author against ~1740 wide in portrait (so 1080 content fits with margin) and
   // 1920 in landscape; k rescales every dimension to the real canvas width.
-  const k = width / (portrait ? 1740 : 1920);
+  // Theme scale folds into the unit so the whole layout breathes with it.
+  const k = (width / (portrait ? 1740 : 1920)) * T.scale;
   const L: Layout = { k, portrait };
   let offset = 0;
   return (
-    <Ctx.Provider value={{ C, font, brand, L }}>
+    <Ctx.Provider value={{ C, font, brand, L, T }}>
       <AbsoluteFill style={{ background: C.bg }}>
         {music?.src && (
           <Audio

--- a/remotion/src/types.ts
+++ b/remotion/src/types.ts
@@ -85,6 +85,11 @@ export type Scene =
 // landscape = 1920x1080 (16:9), portrait = 1080x1920 (9:16, IG reel).
 export type Orientation = "landscape" | "portrait";
 
+// Visual themes — template-level styles (palette, typography, motion physics).
+// clean = the original light look; editorial = serif luxury; bold = dark canvas,
+// huge type; kinetic = springy and fast.
+export type ThemeId = "clean" | "editorial" | "bold" | "kinetic";
+
 // Background music bed. src is a presigned S3 URL to a curated instrumental
 // (~47s, looped). The template ducks it under the per-scene voiceover.
 export type Music = {
@@ -97,4 +102,5 @@ export type VideoProps = {
   fontFamily?: string;
   orientation?: Orientation;
   music?: Music | null;
+  theme?: ThemeId;
 };

--- a/src/pages/VideoGeneratorPage.tsx
+++ b/src/pages/VideoGeneratorPage.tsx
@@ -23,7 +23,7 @@ interface VideoJob {
   progress: number | null;
   outputUrl: string | null;
   error: string | null;
-  direction?: { voice?: string; musicBed?: string; mood?: string } | null;
+  direction?: { voice?: string; musicBed?: string; theme?: string; mood?: string } | null;
 }
 interface RecentVideo { id: string; status: Status; output_url: string | null; error: string | null; created_at: string; }
 interface DirectionOption { id: string; desc: string; }
@@ -46,8 +46,12 @@ function VideoGeneratorContent() {
   const [orientation, setOrientation] = useState<'landscape' | 'portrait'>('landscape');
   const [voice, setVoice] = useState('auto');
   const [musicBed, setMusicBed] = useState('auto');
+  const [theme, setTheme] = useState('auto');
+  const [targetSeconds, setTargetSeconds] = useState(30);
   const [voiceOptions, setVoiceOptions] = useState<DirectionOption[]>([]);
   const [bedOptions, setBedOptions] = useState<DirectionOption[]>([]);
+  const [themeOptions, setThemeOptions] = useState<DirectionOption[]>([]);
+  const [lengthOptions, setLengthOptions] = useState<number[]>([15, 30, 60]);
   const [job, setJob] = useState<VideoJob | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +72,11 @@ function VideoGeneratorContent() {
     if (!authToken) return;
     fetch('/api/video/options', { headers: { Authorization: `Bearer ${authToken}` } })
       .then(r => r.json())
-      .then(d => { setVoiceOptions(d.voices || []); setBedOptions(d.musicBeds || []); })
+      .then(d => {
+        setVoiceOptions(d.voices || []); setBedOptions(d.musicBeds || []);
+        setThemeOptions(d.themes || []);
+        if (Array.isArray(d.lengths) && d.lengths.length) setLengthOptions(d.lengths);
+      })
       .catch(() => {});
   }, [authToken]);
 
@@ -105,7 +113,7 @@ function VideoGeneratorContent() {
       const r = await fetch('/api/video/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
-        body: JSON.stringify({ brandProfileId: selectedBrainId, brief: brief.trim(), orientation, voice, musicBed }),
+        body: JSON.stringify({ brandProfileId: selectedBrainId, brief: brief.trim(), orientation, voice, musicBed, theme, targetSeconds }),
       });
       const d = await r.json();
       if (!r.ok) throw new Error(d.error || `Request failed (${r.status})`);
@@ -165,8 +173,29 @@ function VideoGeneratorContent() {
           </button>
         </div>
 
+        <label className="vg-label">Length</label>
+        <div className="vg-toggle">
+          {lengthOptions.map(l => (
+            <button
+              key={l}
+              type="button"
+              className={`vg-toggle-opt ${targetSeconds === l ? 'active' : ''}`}
+              onClick={() => setTargetSeconds(l)}
+            >
+              {l}s
+            </button>
+          ))}
+        </div>
+
         <label className="vg-label">Creative direction</label>
         <div className="vg-direction">
+          <div className="vg-direction-field">
+            <span className="vg-direction-name">Style</span>
+            <select className="vg-select vg-select-sm" value={theme} onChange={e => setTheme(e.target.value)}>
+              <option value="auto">Auto — brand brain decides</option>
+              {themeOptions.map(t => <option key={t.id} value={t.id}>{t.id} — {t.desc}</option>)}
+            </select>
+          </div>
           <div className="vg-direction-field">
             <span className="vg-direction-name">Voice</span>
             <select className="vg-select vg-select-sm" value={voice} onChange={e => setVoice(e.target.value)}>
@@ -201,7 +230,7 @@ function VideoGeneratorContent() {
           )}
           {job.direction && (job.direction.voice || job.direction.musicBed) && (
             <div className="vg-direction-note">
-              Direction: {[job.direction.mood, job.direction.voice && `voice ${job.direction.voice}`, job.direction.musicBed && `music ${job.direction.musicBed}`].filter(Boolean).join(' · ')}
+              Direction: {[job.direction.mood, job.direction.theme && `style ${job.direction.theme}`, job.direction.voice && `voice ${job.direction.voice}`, job.direction.musicBed && `music ${job.direction.musicBed}`].filter(Boolean).join(' · ')}
             </div>
           )}
           {job.status === 'error' && <div className="vg-error">Render failed: {job.error}</div>}

--- a/src/server/routes/video.js
+++ b/src/server/routes/video.js
@@ -8,8 +8,8 @@ import { pool } from '../db.js';
 import { verifyBrandAccess } from '../auth.js';
 import {
   videoConfigured, buildBrand, brandContextFor, storyboardFromBrief,
-  resolveDirection, presignMusicBed, synthesizeScenes,
-  renderReel, getReelProgress, VOICES, MUSIC_BEDS,
+  resolveDirection, presignMusicBed, synthesizeScenes, normalizeTargetSeconds,
+  renderReel, getReelProgress, VOICES, MUSIC_BEDS, THEMES, LENGTH_BUDGETS,
 } from '../video.js';
 
 async function ensureVideosTable() {
@@ -43,10 +43,10 @@ async function setStatus(id, fields) {
 }
 
 // Background pipeline — not awaited by the request.
-async function runJob(id, brief, brand, orientation, brandContext, directionOverrides) {
+async function runJob(id, brief, brand, orientation, brandContext, directionOverrides, targetSeconds) {
   try {
     await setStatus(id, { status: 'storyboarding' });
-    const { scenes: draft, direction: agentPick } = await storyboardFromBrief({ brief, brandName: brand.name, brandContext });
+    const { scenes: draft, direction: agentPick } = await storyboardFromBrief({ brief, brandName: brand.name, brandContext, targetSeconds });
 
     // Agent proposes the creative direction from the brand brain; user
     // overrides win; unknown ids fall back to safe defaults.
@@ -59,6 +59,7 @@ async function runJob(id, brief, brand, orientation, brandContext, directionOver
     const { renderId, bucketName } = await renderReel({
       brand, scenes, orientation,
       music: musicSrc ? { src: musicSrc } : null,
+      theme: direction.theme,
     });
     await setStatus(id, { render_id: renderId, bucket_name: bucketName });
   } catch (e) {
@@ -88,14 +89,16 @@ router.post('/generate', async (req, res) => {
     const directionOverrides = {
       voice: typeof req.body?.voice === 'string' ? req.body.voice : 'auto',
       musicBed: typeof req.body?.musicBed === 'string' ? req.body.musicBed : 'auto',
+      theme: typeof req.body?.theme === 'string' ? req.body.theme : 'auto',
     };
+    const targetSeconds = normalizeTargetSeconds(req.body?.targetSeconds);
 
     const ins = await pool.query(
       `INSERT INTO generated_videos (brand_profile_id, brief, status, orientation) VALUES ($1, $2, 'queued', $3) RETURNING id`,
       [brandProfileId, brief, orientation]
     );
     const id = ins.rows[0].id;
-    runJob(id, brief, brand, orientation, brandContext, directionOverrides); // fire-and-forget
+    runJob(id, brief, brand, orientation, brandContext, directionOverrides, targetSeconds); // fire-and-forget
     res.status(202).json({ id, status: 'queued' });
   } catch (e) {
     console.error('[VIDEO] generate error:', e.message);
@@ -109,6 +112,8 @@ router.get('/options', (_req, res) => {
   res.json({
     voices: Object.entries(VOICES).map(([id, v]) => ({ id, desc: v.desc })),
     musicBeds: Object.entries(MUSIC_BEDS).map(([id, b]) => ({ id, desc: b.desc })),
+    themes: Object.entries(THEMES).map(([id, t]) => ({ id, desc: t.desc })),
+    lengths: Object.keys(LENGTH_BUDGETS).map(Number),
   });
 });
 

--- a/src/server/video.js
+++ b/src/server/video.js
@@ -128,10 +128,20 @@ export const VOICES = {
   shimmer: { desc: 'energetic, crisp, lively — launch-day excitement' },
 };
 
+// Visual themes — implemented in the Remotion template (remotion/src/DataReel.tsx
+// THEMES map: palette, typography, motion physics).
+export const THEMES = {
+  clean:     { desc: 'light, modern product look — crisp sans, smooth motion (the default)' },
+  editorial: { desc: 'luxury magazine — serif headlines, lighter weight, slow elegant glide' },
+  bold:      { desc: 'dark canvas, huge type, high contrast — confident and dramatic' },
+  kinetic:   { desc: 'springy, fast, punchy entrances — launch-day energy' },
+};
+
 const DEFAULT_DIRECTION = {
   voice: 'ash',
   voiceInstructions: 'Brisk, confident, modern brand voice. Natural energy, not robotic.',
   musicBed: 'uplift-tech',
+  theme: 'clean',
   mood: 'modern tech optimism',
 };
 
@@ -143,12 +153,46 @@ export function resolveDirection(agentPick, overrides) {
   const o = overrides || {};
   if (o.voice && o.voice !== 'auto') d.voice = o.voice;
   if (o.musicBed && o.musicBed !== 'auto') d.musicBed = o.musicBed;
+  if (o.theme && o.theme !== 'auto') d.theme = o.theme;
   if (!VOICES[d.voice]) d.voice = DEFAULT_DIRECTION.voice;
   if (d.musicBed !== 'none' && !MUSIC_BEDS[d.musicBed]) d.musicBed = DEFAULT_DIRECTION.musicBed;
+  if (!THEMES[d.theme]) d.theme = DEFAULT_DIRECTION.theme;
   if (typeof d.voiceInstructions !== 'string' || !d.voiceInstructions.trim()) {
     d.voiceInstructions = DEFAULT_DIRECTION.voiceInstructions;
   }
   return d;
+}
+
+// ── Duration budget ─────────────────────────────────────────────────────────
+// Scene durations derive from VO word counts (framesForVoiceover), so "make it
+// 15 seconds" in a brief was decorative — the agent wrote 5-7 scenes and blew
+// the budget every time. Two layers:
+//   1) the prompt gets a hard scene-count + VO word budget for the target
+//   2) enforceDuration() deterministically trims AFTER storyboarding (and
+//      before paying for TTS): drop middle scenes (never the hook or CTA)
+//      until the estimate fits target + 15% slack.
+export const LENGTH_BUDGETS = {
+  15: { scenes: '3 (hook, ONE middle beat, cta)', maxVoWords: 9 },
+  30: { scenes: '4', maxVoWords: 13 },
+  60: { scenes: '5-6', maxVoWords: 18 },
+};
+
+export function normalizeTargetSeconds(v) {
+  const n = Number(v);
+  return LENGTH_BUDGETS[n] ? n : 30;
+}
+
+export function estimateSeconds(scenes) {
+  return scenes.reduce((a, s) => a + (s.durationInFrames || framesForVoiceover(s.voiceover)), 0) / FPS;
+}
+
+export function enforceDuration(scenes, targetSeconds) {
+  const cap = targetSeconds * 1.15;
+  const out = [...scenes];
+  while (out.length > 3 && estimateSeconds(out) > cap) {
+    out.splice(Math.floor(out.length / 2), 1); // drop a middle beat, keep hook + cta
+  }
+  return out;
 }
 
 // ── Storyboard agent ──────────────────────────────────────────────────────
@@ -175,8 +219,9 @@ Rules:
 function directionGuide() {
   const beds = Object.entries(MUSIC_BEDS).map(([id, b]) => `  - "${id}": ${b.desc}`).join('\n');
   const voices = Object.entries(VOICES).map(([id, v]) => `  - "${id}": ${v.desc}`).join('\n');
+  const themes = Object.entries(THEMES).map(([id, t]) => `  - "${id}": ${t.desc}`).join('\n');
   return `
-Creative direction — pick ONE music bed and ONE voice that match this brand's personality (use the BRAND PROFILE below; e.g. a luxury editorial brand wants ballad/onyx + warm-editorial or night-luxe, not the default tech treatment):
+Creative direction — pick ONE music bed, ONE voice, and ONE visual theme that match this brand's personality (use the BRAND PROFILE below; e.g. a luxury editorial brand wants ballad/onyx + warm-editorial/night-luxe + the editorial theme, not the default tech treatment):
 
 Music beds:
 ${beds}
@@ -184,31 +229,46 @@ ${beds}
 Voices:
 ${voices}
 
+Visual themes:
+${themes}
+
 Include in the output JSON:
 "direction": {
   "musicBed": "<bed id>",
   "voice": "<voice id>",
+  "theme": "<theme id>",
   "voiceInstructions": "one sentence directing the voice actor's delivery for THIS brand (pace, warmth, attitude)",
   "mood": "2-4 word creative mood"
 }`;
 }
 
-export async function storyboardFromBrief({ brief, brandName, brandContext = '' }) {
+function lengthGuide(targetSeconds) {
+  const b = LENGTH_BUDGETS[targetSeconds];
+  return `
+HARD LENGTH BUDGET — the video must run ~${targetSeconds} seconds. Scene durations are computed from voiceover length, so the ONLY way to hit the budget is:
+- Use exactly ${b.scenes} scenes. No more.
+- Every voiceover is AT MOST ${b.maxVoWords} words. Count them.
+Scenes beyond the budget get cut in post (middle scenes dropped), so do not write extra scenes hoping they survive.`;
+}
+
+export async function storyboardFromBrief({ brief, brandName, brandContext = '', targetSeconds = 30 }) {
   const contextBlock = brandContext ? `\n\nBRAND PROFILE (ground the creative direction in this):\n${brandContext}` : '';
   const msg = await anthropic.messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 2500,
     messages: [{
       role: 'user',
-      content: `You are a brand video director for "${brandName}". Turn this brief into a short product reel storyboard.\n\nBRIEF:\n${brief}${contextBlock}\n\n${SCENE_GUIDE}\n${directionGuide()}`,
+      content: `You are a brand video director for "${brandName}". Turn this brief into a short product reel storyboard.\n\nBRIEF:\n${brief}${contextBlock}\n${lengthGuide(targetSeconds)}\n\n${SCENE_GUIDE}\n${directionGuide()}`,
     }],
   });
   const text = msg?.content?.[0]?.text || '';
   const parsed = safeParseLLM(text);
-  const scenes = parsed?.scenes;
+  let scenes = parsed?.scenes;
   if (!Array.isArray(scenes) || scenes.length === 0) {
     throw new Error('Storyboard agent returned no scenes');
   }
+  // Deterministic backstop — the model's word counting is advisory; this isn't.
+  scenes = enforceDuration(scenes, targetSeconds);
   return { scenes, direction: parsed?.direction || null };
 }
 
@@ -287,7 +347,7 @@ export async function presignMusicBed(bedId) {
 }
 
 // ── Lambda render ─────────────────────────────────────────────────────────
-export async function renderReel({ brand, scenes, orientation, music }) {
+export async function renderReel({ brand, scenes, orientation, music, theme }) {
   const { renderMediaOnLambda } = await lambdaClient();
   // orientation flows into inputProps; the site's calculateMetadata maps it to
   // 1080x1920 (portrait) or 1920x1080 (landscape).
@@ -297,7 +357,7 @@ export async function renderReel({ brand, scenes, orientation, music }) {
     functionName: process.env.REMOTION_LAMBDA_FUNCTION_NAME,
     serveUrl: process.env.REMOTION_LAMBDA_SERVE_URL,
     composition: 'DataReel',
-    inputProps: { brand, scenes, orientation: o, ...(music ? { music } : {}) },
+    inputProps: { brand, scenes, orientation: o, ...(music ? { music } : {}), ...(theme ? { theme } : {}) },
     codec: 'h264',
     framesPerLambda: FRAMES_PER_LAMBDA,
     privacy: 'public',

--- a/test/video-direction.test.js
+++ b/test/video-direction.test.js
@@ -56,3 +56,45 @@ describe('brandContextFor', () => {
     expect(brandContextFor({})).toBe('');
   });
 });
+
+import { enforceDuration, estimateSeconds, normalizeTargetSeconds, THEMES } from '../src/server/video.js';
+
+describe('theme resolution', () => {
+  it('agent theme survives; override wins; hallucination falls back', () => {
+    expect(resolveDirection({ theme: 'editorial' }, {}).theme).toBe('editorial');
+    expect(resolveDirection({ theme: 'editorial' }, { theme: 'bold' }).theme).toBe('bold');
+    expect(THEMES[resolveDirection({ theme: 'vaporwave' }, {}).theme]).toBeTruthy();
+  });
+});
+
+describe('duration enforcement', () => {
+  const scene = (id, words) => ({ id, type: 'tags', headline: 'x', tags: ['a'], voiceover: Array(words).fill('word').join(' ') });
+
+  it('normalizeTargetSeconds only allows known budgets', () => {
+    expect(normalizeTargetSeconds(15)).toBe(15);
+    expect(normalizeTargetSeconds('60')).toBe(60);
+    expect(normalizeTargetSeconds(45)).toBe(30);
+    expect(normalizeTargetSeconds(undefined)).toBe(30);
+  });
+
+  it('trims an over-budget storyboard down to target (drops middles, keeps hook+cta)', () => {
+    // 7 scenes x 20 words ≈ 7 x 9.5s ≈ 66s — way over a 15s target
+    const scenes = [scene('hook', 20), scene('a', 20), scene('b', 20), scene('c', 20), scene('d', 20), scene('e', 20), scene('cta', 20)];
+    const out = enforceDuration(scenes, 15);
+    expect(out[0].id).toBe('hook');
+    expect(out[out.length - 1].id).toBe('cta');
+    expect(out.length).toBe(3); // floor — never trims below hook + 1 + cta
+  });
+
+  it('leaves a within-budget storyboard untouched', () => {
+    const scenes = [scene('hook', 8), scene('mid', 8), scene('cta', 8)];
+    expect(enforceDuration(scenes, 15)).toHaveLength(3);
+    expect(estimateSeconds(scenes)).toBeLessThan(15 * 1.15);
+  });
+
+  it('a 30s storyboard lands near 30s after trim', () => {
+    const scenes = [scene('hook', 13), scene('a', 13), scene('b', 13), scene('c', 13), scene('d', 13), scene('cta', 13)];
+    const out = enforceDuration(scenes, 30);
+    expect(estimateSeconds(out)).toBeLessThanOrEqual(30 * 1.15);
+  });
+});


### PR DESCRIPTION
## Why
**Follow-up to #318** — which merged round 1 (music + voice) but closed *before* this commit was pushed, so the round-2 work never landed. This PR carries just that commit (`1673ab5`).

Addresses Brian's round-2 feedback: "the visuals are exactly the same though and kind of flat… maybe we just offer templates? Start with 3-4 styles?" + "the LLM is completely ignoring time limits. I asked for two 15sec videos and they were both around 45sec."

## What

### Visual themes (the "flat / same every time" fix)
- **4 template styles** in `DataReel`: `clean` (original) · `editorial` (serif headlines, lighter weight, slow elegant glide) · `bold` (dark canvas, huge type — theme palette beats brand bg, brand **accent** survives) · `kinetic` (springy fast entrances). A theme = palette + headline typography + motion physics + global scale (folded into the `k` unit).
- Agent picks the theme from the brand's `visualStyle`; **Style picker** (Auto default) forces it; unknown ids fall back to `clean`. Verified: same scene renders genuinely different as bold-dark vs editorial-serif-on-cream (stills posted in chat).

### Hard length enforcement (the 15s→45s bug)
- Root cause: scene durations derive from VO word counts; nothing enforced a budget, so "15 seconds" was decorative.
- **Layer 1 (prompt):** `LENGTH_BUDGETS` — hard scene-count + VO word caps per target (15s: 3 scenes/≤9 words · 30s: 4/≤13 · 60s: 5-6/≤18).
- **Layer 2 (deterministic):** `enforceDuration()` trims after storyboarding, **before paying for TTS** — drops middle scenes (never hook/CTA) until the estimate fits target +15%. The model's word-counting is advisory; this isn't.
- **Length toggle (15s/30s/60s)** in the UI; `normalizeTargetSeconds` validates server-side (unknown → 30).

### Plumbing
- `resolveDirection` extended for `theme`; `direction.theme` persisted + surfaced in the job note; `GET /api/video/options` now returns themes + lengths.

## Deploy notes
- `forge-reels` site is **already redeployed** with the theme-aware template (backward-compatible: no `theme` prop → `clean` = exact prior look). So this PR is backend/UI catching up to the already-live template.

## Test plan
- 5 new tests on top of #318's 8 (theme fallback/override, `normalizeTargetSeconds`, over-budget trim preserving hook+cta, within-budget untouched, 30s lands ≤ +15%). Full suite **169 green**; route snapshot already +1 from #318; `tsc` + remotion `tsc` + lint clean.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_