### PR TITLE
docs: checkpoint — video creative direction (music, voice, themes, length)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,42 @@
+## 2026-06-09 (cont.) — Video creative direction: sound, visual themes, hard length control
+
+Same session continued. The video generator was structurally solid but creatively flat ("the creative is meh"). Fixed with one repeating pattern — **a curated, finite vocabulary the storyboard agent picks from (grounded in the brand brain), with UI pickers as the human veto** — applied to sound, then visuals, plus deterministic length control. PRs #318 (music + voice) and #319 (themes + length); the #318→#319 sequencing snafu noted below.
+
+### Sound (#318)
+- **6 music beds** generated via **fal.ai Stable Audio** (`fal-ai/stable-audio`, ~47s instrumentals, mood-tagged: uplift-tech / warm-editorial / bold-energy / calm-minimal / corporate-rise / night-luxe), transcoded to mp3, stored in the render bucket `forge-music/`, **presigned per render** like the VO clips.
+- Template loops the bed and **ducks it under the voiceover** — `musicVolumeAt(frame, scenes)` (pure, exported): 0.12 while VO speaks, 0.26 in tails/VO-less beats, 1s edge fades. Verified on a Lambda render via RMS on extracted segments: music-only opening −32.4 dBFS, VO scene +6.2 dB over it.
+- **6 cast TTS voices** (gpt-4o-mini-tts: ash/onyx/ballad/sage/nova/shimmer) with delivery characters; agent also writes a per-brand `voiceInstructions` line.
+
+### Visual themes (#319)
+- **4 template styles** in `DataReel`: `clean` (original light), `editorial` (serif headlines, lighter weight, slow elegant springs), `bold` (dark canvas, huge type — theme palette beats the brand bg, brand ACCENT survives), `kinetic` (springy fast entrances). A theme = palette + headline typography + motion physics + a global `scale` folded into the `k` unit. `useHeadline()` restyles big type only; `springCfg` drives every entrance; `opacity` clamped to [0,1] so kinetic's overshoot doesn't flash.
+- Color precedence locked: **defaults → brand colors → theme colors**, so `bold`'s dark canvas wins over a measured light brand bg while the brand's accent still threads through.
+- Verified via local stills on the Sommers palette: bold-dark vs editorial-serif-on-cream are genuinely different videos from the same scene JSON.
+
+### Hard length control (#319) — the 15s→45s bug
+- Root cause: scene durations derive from VO word counts (`framesForVoiceover`) and **nothing enforced a budget**, so "15 seconds" in a brief was decorative. Two layers:
+  1. **Prompt:** `LENGTH_BUDGETS` gives hard scene-count + VO word caps per target (15s: 3 scenes/≤9 words · 30s: 4/≤13 · 60s: 5-6/≤18).
+  2. **Deterministic:** `enforceDuration(scenes, target)` trims AFTER storyboarding and BEFORE paying for TTS — drops middle scenes (never hook/CTA) until the estimate fits target +15%. The model's counting is advisory; this is the backstop.
+- `normalizeTargetSeconds` validates the picker server-side (unknown → 30).
+
+### Direction architecture (both PRs)
+- `storyboardFromBrief` now takes `brandContext` (`brandContextFor(profileData)` — voiceProfile summary/visualStyle/positioning/tone) + `targetSeconds`, and returns `{ scenes, direction }` where direction = `{ musicBed, voice, theme, voiceInstructions, mood }`.
+- `resolveDirection(agentPick, overrides)` — user picks win, `'auto'` keeps the agent's choice, **unknown ids fall back to safe defaults** (a hallucinated bed/voice/theme can never break TTS or the render). `musicBed:'none'` = VO-only.
+- API: `POST /generate` accepts `{ voice, musicBed, theme, targetSeconds }`; `GET /api/video/options` serves the full vocabulary (registered before `/:id`); `direction` persisted on `generated_videos` (JSONB), returned by the poll, shown in the UI ("Direction: mood · style · voice · music").
+- UI: Length toggle (15/30/60s) + Style/Voice/Music pickers, all Auto-default.
+- `forge-reels` Lambda site redeployed twice (music-aware, then theme-aware); both backward-compatible (no props → silent + clean = prior behavior), so safe ahead of the merges.
+
+### Process notes
+- **#318 merged with only its first commit.** Brian merged #318 at 21:44 when it held just the music+voice commit; the themes+length commit was pushed to the branch ~18 min later and rode along to a closed PR → stranded. Caught when Brian asked "did you submit that PR?"; verified with `git merge-base --is-ancestor`; opened **#319** from the same branch (clean diff = just the round-2 commit since round 1 was already in development). Lesson: push all commits before a PR can be merged, or flag that more is landing.
+- Tests: `resolveDirection`/`brandContextFor`/theme-fallback/duration-enforcement → `test/video-direction.test.js`; suite 169 green; route snapshot +1 (`/api/video/options`).
+- AWS Lambda concurrency increase (5,000) still pending; `framesPerLambda: 400` still pinned.
+
+### What's next
+- **Per-brand direction locking** — persist a brand's chosen voice/bed/theme (`manual_overrides`-style) so it sticks across reels.
+- **Real app footage** — Playwright-captured product screens as a new scene archetype (the last big authenticity lever; everything's still code-drawn).
+- Pacing profiles + more scene archetypes (stat punch, quote/testimonial, before/after).
+- Wire "Publish" from the video page into the existing channel integrations.
+- Drop `framesPerLambda` after the AWS concurrency bump; async `/analyze` refactor (still backlogged).
+
 ## 2026-06-09 — AI Video Generation shipped end-to-end (Remotion Lambda + S3) + visual brand system + Sommers House arc
 
 The session that took video generation from "can Claude even make a video?" (yesterday's sandbox experiment) to a **production feature with real brand identity**. PRs #296→#314, all merged to prod same-day.

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,11 +10,29 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-09 (cont.) — Video creative direction: sound + visual themes + length control
+
+PRs #318 (music + voice) + #319 (visual themes + length). Full detail in `PLAN.md` (2026-06-09 cont.). The "meh creative" fix, one pattern: **curated finite vocabulary the agent picks from (grounded in the brand brain), UI pickers as the veto.**
+
+- **Sound (#318):** 6 fal.ai-generated music beds (`forge-music/` in the render bucket), looped + **ducked under VO** (`musicVolumeAt`); 6 cast `gpt-4o-mini-tts` voices with per-brand delivery instructions.
+- **Visual themes (#319):** 4 `DataReel` styles — `clean`/`editorial`/`bold`/`kinetic` (palette + headline type + motion physics + scale). Color precedence: defaults → brand → theme (so `bold`'s dark canvas wins, brand accent survives).
+- **Hard length (#319):** the 15s→45s bug — `LENGTH_BUDGETS` in the prompt + **`enforceDuration()` deterministic trim** (drops middle scenes, keeps hook/CTA, before TTS). UI Length toggle 15/30/60s.
+- **Direction plumbing:** `storyboardFromBrief` returns `{scenes, direction}` from `brandContextFor(profile)`; `resolveDirection` merges agent pick + UI overrides (`auto`/`none`, unknown→default); `GET /api/video/options` serves the vocabulary; `direction` persisted on `generated_videos`. UI Style/Voice/Music pickers, all Auto-default.
+- **`forge-reels` site redeployed** (theme + music aware; backward-compatible). **Process snag:** #318 merged with only its first commit; round 2 was stranded on the branch → reopened as #319. Push all commits before a PR can merge.
+
+#### What's next
+- **Per-brand direction locking** — persist chosen voice/bed/theme (`manual_overrides`-style) so it sticks across reels.
+- **Real app footage** (Playwright screens → screenshot scene archetype) — the last authenticity lever; everything's still code-drawn.
+- Pacing profiles + more archetypes; wire "Publish" → channel integrations.
+- Drop `framesPerLambda` after the AWS 5,000 concurrency bump; async `/analyze` refactor.
+
+---
+
 ### 2026-06-09 — AI Video Generation live end-to-end (Remotion Lambda + S3) + visual brand system
 
 PRs #296→#314, all in prod same-day. Full retrospective in `PLAN.md` (2026-06-09).
 
-**1. Video generation is a production feature.** Brief → storyboard agent (Sonnet) → per-scene TTS (`gpt-4o-mini-tts`/`ash` → S3 presigned) → H.264 render on **AWS Lambda** (never the web dyno). `remotion/` at repo root is the versioned template (`DataReel`: data-driven, 7 scene archetypes, `calculateMetadata` derives duration+canvas from props; redeploy via `npx remotion lambda sites create src/index.ts --site-name=forge-reels`). Backend `src/server/video.js` + async `routes/video.js` (`POST /api/video/generate` 202+poll, `generated_videos`). UI at `/app/video-generator` (#298) with **16:9 / 9:16 toggle** (#304 — template rescales by `k=width/designWidth`). Cost: ~$0.011/70s landscape, ~$0.002/15s portrait.
+**1. Video generation is a production feature.** Brief → storyboard agent (Sonnet) → per-scene TTS (`gpt-4o-mini-tts` → S3 presigned) → H.264 render on **AWS Lambda** (never the web dyno). `remotion/` at repo root is the versioned template (`DataReel`: data-driven, 7 scene archetypes, `calculateMetadata` derives duration+canvas from props; redeploy via `npx remotion lambda sites create src/index.ts --site-name=forge-reels`). Backend `src/server/video.js` + async `routes/video.js` (`POST /api/video/generate` 202+poll, `generated_videos`). UI at `/app/video-generator` (#298) with **16:9 / 9:16 toggle** (#304 — template rescales by `k=width/designWidth`). Cost: ~$0.011/70s landscape, ~$0.002/15s portrait.
 - **Env (Forge group):** `REMOTION_AWS_*` ×3, `REMOTION_LAMBDA_FUNCTION_NAME` (`remotion-render-4-0-474-mem3008mb-disk2048mb-240sec`), `REMOTION_LAMBDA_SERVE_URL` (`forge-reels` site).
 - **Gotchas baked into code:** AWS SDK reads `AWS_*` not `REMOTION_AWS_*` → mirrored at `video.js` load (#302). New-AWS-account concurrency cap 10 → `framesPerLambda: 400` pinned; **drop it when the requested 5,000 increase approves** (still pending).
 
@@ -27,9 +45,7 @@ PRs #296→#314, all in prod same-day. Full retrospective in `PLAN.md` (2026-06-
 **5. autoDeploy mystery (unresolved).** Production's toggle flips off around deploys. Ruled out: Blueprints (none; fossil `render.yaml` deleted), our code (read-only Render API), visible event log. Suspect: another holder of the shared `RENDER_API_KEY`. If it recurs → dashboard Activity feed names the actor; rotating the key isolates it.
 
 #### What's next
-- **Run the branded Sommers reel** (seeded, one click in the UI).
-- **Video generator round 2** (Brian queued the conversation): music bed + ducking, local Inter font, real app footage (Playwright), richer storyboards/archetypes, publish-to-channels wiring.
-- Drop `framesPerLambda` after the AWS concurrency increase approves.
+- **Run the branded Sommers reel** (seeded, one click in the UI). _(Round 2 — music/voice/themes/length — shipped; see the cont. block above.)_
 - Async `/analyze` refactor; BrandSettings UI for `settings.breadcrumb`; `/scan` lead capture.
 
 ---


### PR DESCRIPTION
## What
Docs checkpoint for the video creative-direction arc (PRs #318 music+voice, #319 visual themes + hard length enforcement) — both already merged.

- **`PLAN.md`** — new `2026-06-09 (cont.)` block: the curated-vocabulary pattern applied to sound (fal.ai music beds + `musicVolumeAt` ducking, cast TTS voices) and visuals (4 `DataReel` themes + color precedence), the 15s→45s length bug + `enforceDuration` deterministic backstop, the `resolveDirection`/`brandContextFor`/`/options` plumbing, verified mix/render numbers, and the #318→#319 sequencing snag (merged with only its first commit) + the lesson.
- **`WORKING-STATE.md`** — cont. block on top with the live pointers (per-brand direction locking, real app footage, `framesPerLambda` drop, async `/analyze`); trimmed the now-shipped "round 2" line from the prior block. 81 lines, under the ~100 budget.

Docs only — no code.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_