### PR TITLE
feat(video): expressive voiceover — openai.fm-style structured delivery direction

### DIFF
--- a/src/server/video.js
+++ b/src/server/video.js
@@ -118,7 +118,9 @@ export const MUSIC_BEDS = {
 };
 
 // OpenAI gpt-4o-mini-tts voices, curated with delivery characters the agent
-// can match to the brand's tone.
+// can match to the brand's tone. Expressiveness comes from the `instructions`
+// (see voiceInstructions / the directionGuide spec), not the voice id alone —
+// this is the same steerable model openai.fm demos.
 export const VOICES = {
   ash:     { desc: 'confident, brisk, modern — default tech/product energy' },
   onyx:    { desc: 'deep, measured, authoritative — premium and serious' },
@@ -126,6 +128,8 @@ export const VOICES = {
   sage:    { desc: 'warm, calm, reassuring — human and trustworthy' },
   nova:    { desc: 'bright, friendly, upbeat — consumer warmth' },
   shimmer: { desc: 'energetic, crisp, lively — launch-day excitement' },
+  coral:   { desc: 'warm, expressive, characterful — conversational and human' },
+  verse:   { desc: 'dynamic, narrative, emotive — storytelling range' },
 };
 
 // Visual themes — implemented in the Remotion template (remotion/src/DataReel.tsx
@@ -137,9 +141,17 @@ export const THEMES = {
   kinetic:   { desc: 'springy, fast, punchy entrances — launch-day energy' },
 };
 
+// Rich, structured default delivery (openai.fm style) — multi-dimensional
+// direction is what makes gpt-4o-mini-tts sound human instead of robotic.
+const DEFAULT_VOICE_INSTRUCTIONS = `Voice Affect: Confident, modern, and genuinely engaged — like a smart founder who believes what they're saying.
+Tone: Warm and conversational, never an announcer or a robot.
+Pacing: Natural and varied — quicker through setup, slowing to land the key phrase. Avoid a flat, even cadence.
+Emotion: Real conviction and a little energy.
+Pauses: Brief, natural breaths between sentences; a beat before the payoff line.`;
+
 const DEFAULT_DIRECTION = {
   voice: 'ash',
-  voiceInstructions: 'Brisk, confident, modern brand voice. Natural energy, not robotic.',
+  voiceInstructions: DEFAULT_VOICE_INSTRUCTIONS,
   musicBed: 'uplift-tech',
   theme: 'clean',
   mood: 'modern tech optimism',
@@ -237,9 +249,18 @@ Include in the output JSON:
   "musicBed": "<bed id>",
   "voice": "<voice id>",
   "theme": "<theme id>",
-  "voiceInstructions": "one sentence directing the voice actor's delivery for THIS brand (pace, warmth, attitude)",
+  "voiceInstructions": "<see spec below>",
   "mood": "2-4 word creative mood"
-}`;
+}
+
+voiceInstructions is the single biggest lever on whether the voiceover sounds human or robotic. Do NOT write one flat sentence. Write a SHORT, MULTI-LINE delivery direction for a real voice actor, tuned to THIS brand, using these labeled lines (omit any that don't apply):
+Voice Affect: <the persona behind the mic — e.g. "a calm luxury creative director", "a sharp, excited founder">
+Tone: <warm/commanding/playful/intimate — and what to AVOID, e.g. "never an announcer">
+Pacing: <fast/slow/varied; tell it where to speed up and where to slow down and land a line>
+Emotion: <the feeling to convey>
+Emphasis: <which words/phrases to stress>
+Pauses: <where to breathe or hold a beat>
+Keep it punchy (5-7 short lines). Match it to the brand: a luxury brand = unhurried, intimate, composed; a launch = fast, bright, energetic.`;
 }
 
 function lengthGuide(targetSeconds) {

--- a/test/video-direction.test.js
+++ b/test/video-direction.test.js
@@ -98,3 +98,19 @@ describe('duration enforcement', () => {
     expect(estimateSeconds(out)).toBeLessThanOrEqual(30 * 1.15);
   });
 });
+
+describe('expressive voice instructions', () => {
+  it('default voiceInstructions are structured/multi-line (openai.fm style), not a thin sentence', () => {
+    const d = resolveDirection(null, null);
+    expect(d.voiceInstructions).toMatch(/Voice Affect:/);
+    expect(d.voiceInstructions.split('\n').length).toBeGreaterThanOrEqual(4);
+  });
+  it('expressive voices are in the roster', () => {
+    expect(VOICES.coral).toBeTruthy();
+    expect(VOICES.verse).toBeTruthy();
+  });
+  it('a blank agent voiceInstruction falls back to the rich default', () => {
+    const d = resolveDirection({ voiceInstructions: '   ' }, {});
+    expect(d.voiceInstructions).toMatch(/Voice Affect:/);
+  });
+});


### PR DESCRIPTION
## Why
Brian: "The voice is still really robotic" (re: openai.fm). Diagnosis: **we already use the same steerable model openai.fm demos — `gpt-4o-mini-tts` — but fed it one thin generic instruction**, so we got one thin generic read. openai.fm's expressiveness is entirely in the **`instructions`** (structured: affect / tone / pacing / emotion / pauses), not a different engine. A/B clips on the same voice+line are in chat — the structured direction has real cadence, emphasis, and held pauses.

## What
- **Storyboard agent writes structured delivery direction per brand.** `voiceInstructions` is now a SHORT multi-line directive (Voice Affect / Tone / Pacing / Emotion / Emphasis / Pauses) instead of one sentence — the `directionGuide` spells out the spec and tells the agent to tune cadence to the brand (luxury = unhurried/intimate; launch = fast/bright). This is flagged in-prompt as "the single biggest lever on whether the VO sounds human or robotic."
- **Rich default** (`DEFAULT_VOICE_INSTRUCTIONS`) — the fallback and what an empty agent value resolves to, so even the default read has cadence.
- **Two expressive voices added:** `coral` (warm, characterful) and `verse` (narrative, emotive).

## Test plan
- A/B verified by ear (chat): thin vs structured on `ballad`.
- 3 new tests (default is structured/multi-line, coral+verse present, blank → rich default); suite **172 green**; lint clean.
- **Backend-only** (TTS generation). The deployed `forge-reels` template just plays the per-scene audio — **no Lambda site redeploy**, no schema change. `/api/video/options` now lists the two new voices.

## Rollback
Revert the merge — instructions go back to the thin sentence; nothing else affected.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_