### PR TITLE
feat(video): +11 scene archetypes — wider deck, less recycling

### DIFF
--- a/remotion/src/DataReel.tsx
+++ b/remotion/src/DataReel.tsx
@@ -6,6 +6,8 @@ import {
 import type {
   Brand, Scene, HookScene, TagsScene, OrbitScene,
   PipelineScene, BarsScene, CurveScene, CtaScene, ScreensScene, VideoProps, ThemeId,
+  BigStatScene, StatTrioScene, QuoteScene, ComparisonScene, StepsScene,
+  GridScene, TimelineScene, StatementScene, LogosScene, ChecklistScene, SplitScene,
 } from "./types";
 
 // Forge defaults — any brand.colors key overrides these.
@@ -423,6 +425,243 @@ const CtaView: React.FC<{ s: CtaScene }> = ({ s }) => {
   );
 };
 
+// ── Expanded deck ───────────────────────────────────────────────────────────
+const BigStatView: React.FC<{ s: BigStatScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k } = useL(); const hl = useHeadline();
+  const a = useRise(0), b = useRise(14);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ textAlign: "center", maxWidth: 1500 * k }}>
+        <div style={{ ...a, ...hl, fontSize: 300 * k, lineHeight: 1, color: C.accent }}>{s.stat.value}</div>
+        <div style={{ ...b, fontSize: 54 * k, fontWeight: 700, color: C.emphasis, marginTop: 18 * k }}>{s.stat.label}</div>
+        {s.sub && <div style={{ ...b, fontSize: 38 * k, color: C.secondary, marginTop: 16 * k, fontWeight: 500 }}>{s.sub}</div>}
+      </div>
+    </Stage>
+  );
+};
+
+const StatTrioView: React.FC<{ s: StatTrioScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k } = useL(); const hl = useHeadline();
+  const head = useRise(0);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ textAlign: "center", maxWidth: 1640 * k }}>
+        {s.headline && <div style={{ ...head, ...hl, fontSize: 60 * k, color: C.emphasis, marginBottom: 64 * k }}>{s.headline}</div>}
+        <div style={{ display: "flex", gap: 64 * k, justifyContent: "center", flexWrap: "wrap" }}>
+          {s.stats.map((st, i) => {
+            const r = useRise(20 + i * 16);
+            return (
+              <div key={i} style={{ ...r, textAlign: "center" }}>
+                <div style={{ ...hl, fontSize: 130 * k, lineHeight: 1, color: C.accent }}>{st.value}</div>
+                <div style={{ fontSize: 30 * k, fontWeight: 600, color: C.secondary, marginTop: 14 * k }}>{st.label}</div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Stage>
+  );
+};
+
+const QuoteView: React.FC<{ s: QuoteScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k } = useL(); const hl = useHeadline();
+  const a = useRise(0), b = useRise(16);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ textAlign: "center", maxWidth: 1500 * k }}>
+        <div style={{ ...a, fontSize: 180 * k, lineHeight: 0.6, color: C.accent, fontWeight: 800, fontFamily: 'Georgia, "Times New Roman", serif' }}>&ldquo;</div>
+        <div style={{ ...a, ...hl, fontSize: 60 * k, color: C.emphasis, lineHeight: 1.28, fontWeight: 600, marginTop: 12 * k }}>{s.quote}</div>
+        {s.attribution && (
+          <div style={{ ...b, marginTop: 40 * k }}>
+            <div style={{ fontSize: 34 * k, fontWeight: 700, color: C.emphasis }}>{s.attribution.name}</div>
+            {s.attribution.role && <div style={{ fontSize: 28 * k, color: C.secondary, marginTop: 6 * k }}>{s.attribution.role}</div>}
+          </div>
+        )}
+      </div>
+    </Stage>
+  );
+};
+
+const ComparisonView: React.FC<{ s: ComparisonScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k, portrait } = useL(); const hl = useHeadline();
+  const head = useRise(0);
+  const Col: React.FC<{ data: { label: string; items: string[] }; on: boolean; mark: string; delay: number }> = ({ data, on, mark, delay }) => (
+    <div style={{ flex: 1, background: C.card, border: `2px solid ${on ? C.accent : C.border}`, borderRadius: 20 * k, padding: `${34 * k}px ${38 * k}px` }}>
+      <div style={{ fontSize: 34 * k, fontWeight: 800, color: on ? C.accent : C.muted, marginBottom: 26 * k }}>{data.label}</div>
+      {data.items.map((it, i) => {
+        const r = useRise(delay + i * 10);
+        return (
+          <div key={i} style={{ ...r, display: "flex", gap: 14 * k, alignItems: "flex-start", marginBottom: 16 * k, fontSize: 30 * k, color: C.emphasis, fontWeight: 500 }}>
+            <span style={{ color: on ? C.accent : C.muted, fontWeight: 800, flexShrink: 0 }}>{mark}</span>{it}
+          </div>
+        );
+      })}
+    </div>
+  );
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ width: 1500 * k }}>
+        {s.headline && <div style={{ ...head, ...hl, fontSize: 64 * k, color: C.emphasis, textAlign: "center", marginBottom: 48 * k }}>{s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}</div>}
+        <div style={{ display: "flex", flexDirection: portrait ? "column" : "row", gap: 32 * k, alignItems: "stretch" }}>
+          <Col data={s.left} on={false} mark="✕" delay={30} />
+          <Col data={s.right} on mark="✓" delay={45} />
+        </div>
+      </div>
+    </Stage>
+  );
+};
+
+const StepsView: React.FC<{ s: StepsScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k } = useL(); const hl = useHeadline();
+  const head = useRise(0);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ width: 1300 * k }}>
+        {s.headline && <div style={{ ...head, ...hl, fontSize: 64 * k, color: C.emphasis, textAlign: "center", marginBottom: 54 * k }}>{s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}</div>}
+        {s.steps.map((st, i) => {
+          const r = useRise(20 + i * 16);
+          return (
+            <div key={i} style={{ ...r, display: "flex", gap: 28 * k, alignItems: "center", marginBottom: 30 * k }}>
+              <div style={{ flexShrink: 0, width: 72 * k, height: 72 * k, borderRadius: "50%", background: C.accent, color: "#fff", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 36 * k, fontWeight: 800 }}>{i + 1}</div>
+              <div>
+                <div style={{ fontSize: 40 * k, fontWeight: 700, color: C.emphasis }}>{st.title}</div>
+                {st.detail && <div style={{ fontSize: 30 * k, color: C.secondary, marginTop: 6 * k }}>{st.detail}</div>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Stage>
+  );
+};
+
+const GridView: React.FC<{ s: GridScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k } = useL(); const hl = useHeadline();
+  const head = useRise(0);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ width: 1500 * k }}>
+        {s.headline && <div style={{ ...head, ...hl, fontSize: 60 * k, color: C.emphasis, textAlign: "center", marginBottom: 50 * k }}>{s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}</div>}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 28 * k, justifyContent: "center" }}>
+          {s.items.map((it, i) => {
+            const r = useRise(20 + i * 12);
+            return (
+              <div key={i} style={{ ...r, flex: "1 1 44%", minWidth: 0, background: C.card, border: `2px solid ${C.border}`, borderRadius: 18 * k, padding: `${30 * k}px ${34 * k}px` }}>
+                <div style={{ width: 18 * k, height: 18 * k, borderRadius: 6 * k, background: C.accent, marginBottom: 20 * k }} />
+                <div style={{ fontSize: 36 * k, fontWeight: 700, color: C.emphasis }}>{it.title}</div>
+                {it.detail && <div style={{ fontSize: 28 * k, color: C.secondary, marginTop: 10 * k, lineHeight: 1.35 }}>{it.detail}</div>}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Stage>
+  );
+};
+
+const TimelineView: React.FC<{ s: TimelineScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k, portrait } = useL(); const hl = useHeadline();
+  const head = useRise(0);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ width: (portrait ? 920 : 1640) * k, textAlign: "center" }}>
+        {s.headline && <div style={{ ...head, ...hl, fontSize: 62 * k, color: C.emphasis, marginBottom: 70 * k }}>{s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}</div>}
+        <div style={{ display: "flex", flexWrap: portrait ? "wrap" : "nowrap", alignItems: "flex-start", justifyContent: "center", gap: portrait ? 24 * k : 0 }}>
+          {s.milestones.map((m, i) => {
+            const r = useRise(20 + i * 14); const last = i === s.milestones.length - 1;
+            return (
+              <React.Fragment key={i}>
+                <div style={{ ...r, display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, width: portrait ? "auto" : 220 * k }}>
+                  <div style={{ width: 28 * k, height: 28 * k, borderRadius: "50%", background: C.accent }} />
+                  {m.when && <div style={{ fontSize: 26 * k, fontWeight: 700, color: C.accent, marginTop: 16 * k }}>{m.when}</div>}
+                  <div style={{ fontSize: 30 * k, fontWeight: 600, color: C.emphasis, marginTop: 8 * k, maxWidth: 200 * k }}>{m.label}</div>
+                </div>
+                {!portrait && !last && <div style={{ height: 4 * k, background: C.border, flex: 1, marginTop: 12 * k, minWidth: 40 * k }} />}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      </div>
+    </Stage>
+  );
+};
+
+const StatementView: React.FC<{ s: StatementScene }> = ({ s }) => {
+  const { C, font } = React.useContext(Ctx); const { k } = useL(); const hl = useHeadline();
+  const src = audioSrc(s.audio); const a = useRise(0);
+  // Full-bleed accent gradient, white type — a single dramatic beat that breaks
+  // the light-canvas rhythm. Ignores theme bg on purpose.
+  return (
+    <AbsoluteFill style={{ background: `linear-gradient(135deg, ${C.accent}, ${C.accent2})`, fontFamily: font, justifyContent: "center", alignItems: "center", padding: 120 * k }}>
+      {src && <Audio src={src} />}
+      <div style={{ ...a, ...hl, fontSize: 120 * k, color: "#fff", textAlign: "center", lineHeight: 1.05, maxWidth: 1500 * k }}>
+        {s.headline}{s.emphasis && <><br /><span style={{ opacity: 0.82 }}>{s.emphasis}</span></>}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+const LogosView: React.FC<{ s: LogosScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k } = useL();
+  const head = useRise(0);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ textAlign: "center", maxWidth: 1640 * k }}>
+        <div style={{ ...head, fontSize: 28 * k, letterSpacing: 4 * k, color: C.muted, fontWeight: 700, textTransform: "uppercase", marginBottom: 46 * k }}>{s.label || "Trusted by"}</div>
+        <div style={{ display: "flex", gap: 56 * k, justifyContent: "center", flexWrap: "wrap", alignItems: "center" }}>
+          {s.names.map((n, i) => {
+            const r = useRise(20 + i * 10);
+            return <span key={i} style={{ ...r, fontSize: 50 * k, fontWeight: 800, color: C.secondary }}>{n}</span>;
+          })}
+        </div>
+      </div>
+    </Stage>
+  );
+};
+
+const ChecklistView: React.FC<{ s: ChecklistScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k } = useL(); const hl = useHeadline();
+  const head = useRise(0);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ maxWidth: 1200 * k }}>
+        {s.headline && <div style={{ ...head, ...hl, fontSize: 64 * k, color: C.emphasis, textAlign: "center", marginBottom: 50 * k }}>{s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}</div>}
+        {s.items.map((it, i) => {
+          const r = useRise(20 + i * 12);
+          return (
+            <div key={i} style={{ ...r, display: "flex", gap: 22 * k, alignItems: "center", marginBottom: 26 * k, fontSize: 42 * k, color: C.emphasis, fontWeight: 600 }}>
+              <span style={{ flexShrink: 0, width: 52 * k, height: 52 * k, borderRadius: "50%", background: C.accent, color: "#fff", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 28 * k, fontWeight: 800 }}>✓</span>
+              {it}
+            </div>
+          );
+        })}
+      </div>
+    </Stage>
+  );
+};
+
+const SplitView: React.FC<{ s: SplitScene }> = ({ s }) => {
+  const { C } = React.useContext(Ctx); const { k, portrait } = useL(); const hl = useHeadline();
+  const a = useRise(0);
+  return (
+    <Stage audio={s.audio}>
+      <div style={{ display: "flex", flexDirection: portrait ? "column" : "row", gap: 60 * k, alignItems: portrait ? "flex-start" : "center", width: 1640 * k }}>
+        <div style={{ ...a, ...hl, flex: 1, fontSize: 84 * k, color: C.emphasis, lineHeight: 1.08 }}>{s.headline} {s.headlineEmphasis && <span style={{ color: C.accent }}>{s.headlineEmphasis}</span>}</div>
+        <div style={{ flex: 1 }}>
+          {s.points.map((p, i) => {
+            const r = useRise(20 + i * 14);
+            return (
+              <div key={i} style={{ ...r, display: "flex", gap: 18 * k, alignItems: "flex-start", marginBottom: 24 * k, fontSize: 36 * k, color: C.secondary, fontWeight: 500 }}>
+                <span style={{ color: C.accent, fontWeight: 800, flexShrink: 0 }}>—</span>{p}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Stage>
+  );
+};
+
 const renderScene = (s: Scene) => {
   switch (s.type) {
     case "hook": return <HookView s={s} />;
@@ -433,6 +672,17 @@ const renderScene = (s: Scene) => {
     case "curve": return <CurveView s={s} />;
     case "screens": return <ScreensView s={s} />;
     case "cta": return <CtaView s={s} />;
+    case "bigstat": return <BigStatView s={s} />;
+    case "stattrio": return <StatTrioView s={s} />;
+    case "quote": return <QuoteView s={s} />;
+    case "comparison": return <ComparisonView s={s} />;
+    case "steps": return <StepsView s={s} />;
+    case "grid": return <GridView s={s} />;
+    case "timeline": return <TimelineView s={s} />;
+    case "statement": return <StatementView s={s} />;
+    case "logos": return <LogosView s={s} />;
+    case "checklist": return <ChecklistView s={s} />;
+    case "split": return <SplitView s={s} />;
   }
 };
 

--- a/remotion/src/types.ts
+++ b/remotion/src/types.ts
@@ -93,9 +93,76 @@ export type ScreensScene = SceneBase & {
   urlLabel?: string;    // address-bar text, e.g. "acme.com"
 };
 
+// ── Expanded scene deck (more variety, less recycling) ──────────────────────
+export type BigStatScene = SceneBase & {
+  type: "bigstat";
+  stat: { value: string; label: string };
+  sub?: string;
+};
+export type StatTrioScene = SceneBase & {
+  type: "stattrio";
+  headline?: string;
+  stats: { value: string; label: string }[]; // 2-3
+};
+export type QuoteScene = SceneBase & {
+  type: "quote";
+  quote: string;
+  attribution?: { name: string; role?: string };
+};
+export type ComparisonScene = SceneBase & {
+  type: "comparison";
+  headline?: string;
+  headlineEmphasis?: string;
+  left: { label: string; items: string[] };   // the old/their way (✕)
+  right: { label: string; items: string[] };   // your way (✓, accent)
+};
+export type StepsScene = SceneBase & {
+  type: "steps";
+  headline?: string;
+  headlineEmphasis?: string;
+  steps: { title: string; detail?: string }[]; // numbered 1..n
+};
+export type GridScene = SceneBase & {
+  type: "grid";
+  headline?: string;
+  headlineEmphasis?: string;
+  items: { title: string; detail?: string }[]; // 2-4 feature cells
+};
+export type TimelineScene = SceneBase & {
+  type: "timeline";
+  headline?: string;
+  headlineEmphasis?: string;
+  milestones: { label: string; when?: string }[];
+};
+export type StatementScene = SceneBase & {
+  type: "statement";
+  headline: string;     // full-bleed accent gradient, white type — one bold beat
+  emphasis?: string;
+};
+export type LogosScene = SceneBase & {
+  type: "logos";
+  label?: string;       // e.g. "Trusted by"
+  names: string[];      // client/brand names rendered as a wordmark row
+};
+export type ChecklistScene = SceneBase & {
+  type: "checklist";
+  headline?: string;
+  headlineEmphasis?: string;
+  items: string[];      // accent-checked list (deliverables / what you get)
+};
+export type SplitScene = SceneBase & {
+  type: "split";
+  headline: string;     // asymmetric: big headline left, supporting points right
+  headlineEmphasis?: string;
+  points: string[];
+};
+
 export type Scene =
   | HookScene | TagsScene | OrbitScene | PipelineScene
-  | BarsScene | CurveScene | CtaScene | ScreensScene;
+  | BarsScene | CurveScene | CtaScene | ScreensScene
+  | BigStatScene | StatTrioScene | QuoteScene | ComparisonScene
+  | StepsScene | GridScene | TimelineScene | StatementScene
+  | LogosScene | ChecklistScene | SplitScene;
 
 // landscape = 1920x1080 (16:9), portrait = 1080x1920 (9:16, IG reel).
 export type Orientation = "landscape" | "portrait";

--- a/src/server/video.js
+++ b/src/server/video.js
@@ -224,17 +224,29 @@ function buildSceneGuide(allowScreens) {
     ? `\n- When the brief is about a real product WITH a website, PREFER one "screens" beat over an abstract scene (orbit/bars/curve) for the "here's the product" moment — real UI sells harder than a diagram. Use at most 2 "screens" scenes.`
     : '';
   return `
-Scene archetypes (pick the right one per beat, 5-7 scenes total):
-- hook:     { type:"hook", eyebrow?, headline, emphasis?, sub? }  — opening punch. emphasis renders as a colored 2nd line.
-- tags:     { type:"tags", headline, tags:[3-4 short words] }     — a claim + chips.
-- orbit:    { type:"orbit", centerLabel (use \\n for 2 lines), facets:[3-4], caption?, captionEmphasis? } — a hub concept with orbiting ideas.
-- pipeline: { type:"pipeline", headline, headlineEmphasis?, stages:[5-8 short labels] } — a process/flow.
-- bars:     { type:"bars", headline, headlineEmphasis?, bars:[{label,pct}], footnoteLabel?, footnoteChips?:[] } — a metric/comparison. pct 0-100.
-- curve:    { type:"curve", headline, headlineEmphasis?, flatLabel? } — a "compounds over time" idea.${screensLine}
-- cta:      { type:"cta", title, sub?, cta } — the closing call to action.
+Scene archetypes — a deck of distinct layouts. PICK THE BEST FIT PER BEAT and VARY them: do NOT reuse the same archetype twice in one video unless truly necessary. Match the layout to what the line is doing (a number wants bigstat, a process wants steps/pipeline/timeline, a contrast wants comparison, social proof wants quote/logos).
+- hook:       { type:"hook", eyebrow?, headline, emphasis?, sub? }  — opening punch. emphasis renders as a colored 2nd line.
+- tags:       { type:"tags", headline, tags:[3-4 short words] }     — a claim + chips.
+- orbit:      { type:"orbit", centerLabel (use \\n for 2 lines), facets:[3-4], caption?, captionEmphasis? } — a hub concept with orbiting ideas.
+- pipeline:   { type:"pipeline", headline, headlineEmphasis?, stages:[5-8 short labels] } — a horizontal process/flow.
+- bars:       { type:"bars", headline, headlineEmphasis?, bars:[{label,pct}], footnoteLabel?, footnoteChips?:[] } — metric comparison. pct 0-100.
+- curve:      { type:"curve", headline, headlineEmphasis?, flatLabel? } — a "compounds over time" idea.
+- bigstat:    { type:"bigstat", stat:{value,label}, sub? } — ONE giant hero number (e.g. value:"92%").
+- stattrio:   { type:"stattrio", headline?, stats:[{value,label}] (2-3) } — three proof numbers in a row.
+- quote:      { type:"quote", quote, attribution?:{name,role} } — a testimonial / pull-quote.
+- comparison: { type:"comparison", headline?, headlineEmphasis?, left:{label,items:[]}, right:{label,items:[]} } — old way (✕) vs your way (✓).
+- steps:      { type:"steps", headline?, headlineEmphasis?, steps:[{title,detail?}] } — numbered how-it-works (1..n).
+- grid:       { type:"grid", headline?, headlineEmphasis?, items:[{title,detail?}] (2-4) } — a feature grid.
+- timeline:   { type:"timeline", headline?, headlineEmphasis?, milestones:[{label,when?}] } — milestones over time.
+- statement:  { type:"statement", headline, emphasis? } — a full-bleed bold statement on the brand color (one dramatic beat).
+- logos:      { type:"logos", label?, names:[] } — social proof: a row of client/customer names.
+- checklist:  { type:"checklist", headline?, headlineEmphasis?, items:[] } — what you get / deliverables, accent checks.
+- split:      { type:"split", headline, headlineEmphasis?, points:[] } — big headline + supporting points beside it.${screensLine}
+- cta:        { type:"cta", title, sub?, cta } — the closing call to action.
 
 Rules:
 - Always open with exactly one "hook" and close with exactly one "cta".
+- VARY the middle beats — reach for the deck above, not just tags/bars/orbit every time.
 - Copy is punchy and concrete. Headlines <= 8 words. NO em dashes.${screensRule}
 - Every scene MUST include a "voiceover" string: one spoken sentence (8-22 words) that matches the on-screen beat.
 - Output ONLY JSON: { "direction": {...}, "scenes": [ { "id":"kebab-name", "type":..., ...fields, "voiceover":"..." } ] }`;


### PR DESCRIPTION
## Why
Brian: "I feel like they're just recycled over and over." Correct — the agent only had **7 fixed layouts**, so on short reels you'd see the same orbit/bars/tags every time. This widens the deck to **18 archetypes** so different briefs yield genuinely different videos — staying template-based (brand-safe, fast, ~$0.01), not generative.

## What — 11 new archetypes
`bigstat` (one hero number) · `stattrio` (three proof numbers) · `quote` (testimonial) · `comparison` (old-way ✕ vs your-way ✓ columns) · `steps` (numbered how-it-works) · `grid` (2-4 feature cells) · `timeline` (milestones) · `statement` (full-bleed accent-gradient beat — deliberately breaks the light-canvas rhythm) · `logos` (client-name social proof) · `checklist` (accent-checked deliverables) · `split` (big headline + points).

- **types.ts** — 11 discriminated-union members.
- **DataReel.tsx** — 11 `View` components + `renderScene` cases. All use the existing idioms: palette colors, **brand accent** on emphasis/checks/marks, **theme** headline font + motion, `k` scaling, portrait reflow.
- **video.js `buildSceneGuide`** — teaches the agent the full deck, with per-archetype "when to use" hints and an explicit **"VARY the middle beats, don't reuse the same archetype"** rule.

Stills (Sommers palette) in chat: comparison / stattrio / steps — distinct layouts, brand-correct.

## Test plan
- `remotion tsc` + `node --check` + lint clean.
- `forge-reels` Lambda site **already redeployed** with all 11 views (required before the agent can emit them; backward-compatible — unknown types can't occur since the agent only knows what `buildSceneGuide` lists).

## Merge order
Built on `development` (which has #324 screens + #322 voice). Touches `DataReel.tsx` (renderScene switch, new views) and `video.js buildSceneGuide` — different regions from the still-open **#326** (voice/ElevenLabs, `ttsToBuffer`) and **#327** (hook red, `HookView`). Trivial 3-way merges; I'll resolve whichever lands later. **Site is redeployed, so merge this before #327 re-deploys an older template** — or just ping me and I'll re-deploy after the dust settles.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_