### PR TITLE
feat(video): "video arcs" — 8 brand-grounded video concepts, one click

### DIFF
--- a/src/pages/VideoGeneratorPage.css
+++ b/src/pages/VideoGeneratorPage.css
@@ -215,3 +215,25 @@
   font-size: 13px;
   color: #64748b;
 }
+
+/* ── Video idea arcs ── */
+.vg-arcs-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+.vg-arcs-btn {
+  border: 1px solid #3563FF; background: rgba(53,99,255,0.06); color: #3563FF;
+  font-size: 13px; font-weight: 700; padding: 8px 14px; border-radius: 8px; cursor: pointer;
+  white-space: nowrap; transition: background 0.15s;
+}
+.vg-arcs-btn:hover:not(:disabled) { background: rgba(53,99,255,0.12); }
+.vg-arcs-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.vg-arcs { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 22px; }
+@media (max-width: 640px) { .vg-arcs { grid-template-columns: 1fr; } }
+.vg-arc {
+  text-align: left; background: #F8FAFC; border: 1px solid #E2E8F0; border-radius: 10px;
+  padding: 14px 16px; cursor: pointer; transition: border-color 0.15s, box-shadow 0.15s; font: inherit;
+}
+.vg-arc:hover { border-color: #3563FF; box-shadow: 0 0 0 3px rgba(53,99,255,0.10); }
+.vg-arc-top { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.vg-arc-title { font-size: 14px; font-weight: 700; color: #0F172A; }
+.vg-arc-meta { font-size: 11px; font-weight: 700; color: #94A3B8; white-space: nowrap; }
+.vg-arc-angle { font-size: 11px; font-weight: 700; color: #3563FF; text-transform: uppercase; letter-spacing: 0.4px; margin-top: 4px; }
+.vg-arc-brief { font-size: 13px; color: #475569; line-height: 1.45; margin-top: 8px; }

--- a/src/pages/VideoGeneratorPage.tsx
+++ b/src/pages/VideoGeneratorPage.tsx
@@ -27,6 +27,7 @@ interface VideoJob {
 }
 interface RecentVideo { id: string; status: Status; output_url: string | null; error: string | null; created_at: string; }
 interface DirectionOption { id: string; desc: string; }
+interface VideoArc { id: string; title: string; angle: string; brief: string; length: number; orientation: 'landscape' | 'portrait'; }
 
 // Human-readable label + rough completion weight for the progress bar. The
 // Lambda render reports its own 0..1 progress; the earlier stages are coarse.
@@ -43,6 +44,8 @@ function VideoGeneratorContent() {
   const { historyEntries, activeBrand, authToken } = useApp();
   const [selectedBrainId, setSelectedBrainId] = useState('');
   const [brief, setBrief] = useState('');
+  const [arcs, setArcs] = useState<VideoArc[]>([]);
+  const [arcsLoading, setArcsLoading] = useState(false);
   const [orientation, setOrientation] = useState<'landscape' | 'portrait'>('landscape');
   const [voice, setVoice] = useState('auto');
   const [musicBed, setMusicBed] = useState('auto');
@@ -106,6 +109,31 @@ function VideoGeneratorContent() {
     return () => { if (pollRef.current) clearInterval(pollRef.current); };
   }, [job?.id, job?.status, authToken, loadRecent]);
 
+  async function suggestArcs() {
+    if (!selectedBrainId || !authToken) return;
+    setArcsLoading(true); setError(null);
+    try {
+      const r = await fetch('/api/video/arcs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+        body: JSON.stringify({ brandProfileId: selectedBrainId }),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.error || 'Could not generate ideas');
+      setArcs(d.arcs || []);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setArcsLoading(false);
+    }
+  }
+
+  function useArc(a: VideoArc) {
+    setBrief(a.brief);
+    setTargetSeconds(a.length);
+    setOrientation(a.orientation);
+  }
+
   async function generate() {
     if (!selectedBrainId || !brief.trim() || !authToken) return;
     setBusy(true); setError(null); setJob(null);
@@ -143,6 +171,27 @@ function VideoGeneratorContent() {
           <option value="">Select a Brain…</option>
           {brains.map(b => <option key={b.id} value={b.id}>{b.brandName} — {b.brandUrl}</option>)}
         </select>
+
+        <div className="vg-arcs-head">
+          <label className="vg-label" style={{ marginBottom: 0 }}>Need ideas? <span className="vg-optional">8 video concepts from the brand brain</span></label>
+          <button type="button" className="vg-arcs-btn" onClick={suggestArcs} disabled={arcsLoading || !selectedBrainId}>
+            {arcsLoading ? 'Thinking…' : arcs.length ? 'Regenerate ideas' : 'Suggest video ideas'}
+          </button>
+        </div>
+        {arcs.length > 0 && (
+          <div className="vg-arcs">
+            {arcs.map(a => (
+              <button type="button" key={a.id} className="vg-arc" onClick={() => useArc(a)} title="Use this idea">
+                <div className="vg-arc-top">
+                  <span className="vg-arc-title">{a.title}</span>
+                  <span className="vg-arc-meta">{a.length}s · {a.orientation === 'portrait' ? '9:16' : '16:9'}</span>
+                </div>
+                {a.angle && <div className="vg-arc-angle">{a.angle}</div>}
+                <div className="vg-arc-brief">{a.brief}</div>
+              </button>
+            ))}
+          </div>
+        )}
 
         <label className="vg-label">Brief</label>
         <textarea

--- a/src/server/routes/video.js
+++ b/src/server/routes/video.js
@@ -9,7 +9,7 @@ import { verifyBrandAccess } from '../auth.js';
 import {
   videoConfigured, buildBrand, brandContextFor, storyboardFromBrief,
   resolveDirection, presignMusicBed, synthesizeScenes, normalizeTargetSeconds,
-  renderReel, getReelProgress, VOICES, MUSIC_BEDS, THEMES, LENGTH_BUDGETS,
+  renderReel, getReelProgress, videoArcs, VOICES, MUSIC_BEDS, THEMES, LENGTH_BUDGETS,
 } from '../video.js';
 
 async function ensureVideosTable() {
@@ -104,6 +104,24 @@ router.post('/generate', async (req, res) => {
     res.status(202).json({ id, status: 'queued' });
   } catch (e) {
     console.error('[VIDEO] generate error:', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// POST /api/video/arcs — a slate of 8 video concepts for the brand (the "knock
+// out 8 arcs" feature). Each arc is a ready-to-run brief + length + orientation.
+// Registered before /:id so the param route doesn't capture it.
+router.post('/arcs', async (req, res) => {
+  try {
+    const { brandProfileId } = req.body || {};
+    if (!brandProfileId) return res.status(400).json({ error: 'brandProfileId required' });
+    if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
+    const r = await pool.query(`SELECT brand_name, profile_data FROM brand_profiles WHERE id = $1`, [brandProfileId]);
+    const row = r.rows[0] || {};
+    const arcs = await videoArcs(row.brand_name || 'this brand', row.profile_data, 8);
+    res.json({ arcs });
+  } catch (e) {
+    console.error('[VIDEO] arcs error:', e.message);
     res.status(500).json({ error: e.message });
   }
 });

--- a/src/server/video.js
+++ b/src/server/video.js
@@ -324,6 +324,56 @@ export function brandContextFor(profileData) {
   return parts.join('\n').slice(0, 2000);
 }
 
+// ── Video arcs (a slate of video concepts) ──────────────────────────────────
+// Like the Social Generator's campaign arcs, but for video: one click yields N
+// distinct reel ideas, each a ready-to-run brief the user can generate in a tap.
+// Grounded in the whole brain (positioning, buyer, personas, whitespace, the
+// existing campaignArcs as seeds), not just the voice.
+function arcBrainContext(pd) {
+  const bp = pd?.businessProfile || {};
+  const parts = [brandContextFor(pd)];
+  if (bp.whatTheyDo) parts.push(`What they do: ${bp.whatTheyDo}`);
+  if (bp.targetBuyer) parts.push(`Buyer: ${bp.targetBuyer}`);
+  if (Array.isArray(pd?.personas) && pd.personas.length) parts.push(`Personas: ${pd.personas.map(p => p.name).filter(Boolean).join(', ')}`);
+  if (Array.isArray(pd?.competitiveGaps) && pd.competitiveGaps.length) parts.push(`Whitespace topics: ${pd.competitiveGaps.map(g => g.topic).filter(Boolean).slice(0, 5).join('; ')}`);
+  if (Array.isArray(pd?.strategicMoats) && pd.strategicMoats.length) parts.push(`Moats (what they deliberately don't do): ${pd.strategicMoats.map(m => m.capability).filter(Boolean).join('; ')}`);
+  if (Array.isArray(pd?.campaignArcs) && pd.campaignArcs.length) parts.push(`Existing campaign arcs (seed thinking, do not just copy): ${pd.campaignArcs.map(a => a.title).filter(Boolean).join('; ')}`);
+  return parts.filter(Boolean).join('\n').slice(0, 3000);
+}
+
+export async function videoArcs(brandName, profileData, count = 8) {
+  const ctx = arcBrainContext(profileData);
+  const prompt = `You are a brand video strategist for "${brandName}". Propose ${count} DISTINCT short-form video concepts — a video content slate. Each is a self-contained reel with a DIFFERENT strategic angle (e.g. problem/solution, hard proof, founder POV, how-it-works, us-vs-them, customer story, a bold contrarian claim, behind-the-scenes, a single killer stat, a myth-bust). Do not repeat angles.
+
+BRAND:
+${ctx}
+
+For each concept return:
+- "title": a short internal name for the idea
+- "angle": one phrase naming the strategic angle
+- "length": 15, 30, or 60 (seconds) — whatever fits the idea
+- "orientation": "portrait" (social/IG/TikTok) or "landscape" (web/YouTube)
+- "brief": 1-2 sentences a video director can run with — what it says and its arc (hook -> body -> CTA). Concrete and on-brand. NO em dashes.
+
+Output ONLY JSON: { "arcs": [ { "id":"kebab-name", "title", "angle", "length", "orientation", "brief" } ] }`;
+  const msg = await anthropic.messages.create({
+    model: 'claude-sonnet-4-6', max_tokens: 3000,
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const parsed = safeParseLLM(msg?.content?.[0]?.text || '');
+  const raw = Array.isArray(parsed?.arcs) ? parsed.arcs : [];
+  const arcs = raw.slice(0, count).map((a, i) => ({
+    id: typeof a.id === 'string' && a.id ? a.id : `arc-${i + 1}`,
+    title: String(a.title || `Idea ${i + 1}`).slice(0, 90),
+    angle: String(a.angle || '').slice(0, 140),
+    brief: String(a.brief || '').slice(0, 700),
+    length: [15, 30, 60].includes(Number(a.length)) ? Number(a.length) : 30,
+    orientation: a.orientation === 'portrait' ? 'portrait' : 'landscape',
+  })).filter((a) => a.brief);
+  if (!arcs.length) throw new Error('Video arc generator returned no usable arcs');
+  return arcs;
+}
+
 // ── Per-scene TTS -> S3 (presigned URL) ───────────────────────────────────
 // Estimate spoken length from word count (~2.3 words/sec) so the scene is never
 // shorter than its audio; add a short tail. Avoids needing ffprobe on the dyno.

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -208,6 +208,7 @@
   "POST /api/topic-ideas",
   "POST /api/topic-ideas/bulk",
   "POST /api/utils/shorten-url",
+  "POST /api/video/arcs",
   "POST /api/video/generate",
   "POST /api/waitlist",
   "POST /api/webflow/select-target",


### PR DESCRIPTION
## Why
Brian: "The pipeline creates campaign arcs for the social generator. Can we have it knock out like 8 arcs for videos?" Same idea, for video: one click → 8 distinct video concepts from the brand brain, each a ready-to-run brief.

## What
- **`videoArcs(brandName, profileData, 8)`** (`video.js`) — Claude (sonnet) grounded in the *whole* brain via `arcBrainContext()`: positioning, buyer, personas, whitespace gaps, moats, and the existing `campaignArcs` as seeds. Each arc = `{ id, title, angle, length (15/30/60), orientation, brief }`, normalized + validated server-side (bad length/orientation → safe defaults; empty briefs dropped).
- **`POST /api/video/arcs`** `{ brandProfileId }` — auth + brand-scoped, registered before `/:id`. Route snapshot +1.
- **UI** — "Suggest video ideas" button + an 8-card grid (title · angle · length/aspect · brief). Click a card → fills the brief **and** sets length + orientation, so it's one tap from idea → Generate. "Regenerate ideas" for a fresh slate.

## Verified live (Sommers' real brain)
8 on-strategy, non-repeating concepts — *The Room Is Lying* (contrarian), *One Number* (killer stat), *Why I Walk Away* (founder POV), *The Operator Model* (how-it-works), *They Already Had a Vendor* (customer story), *Built for the Brief* (problem/solution), *Vendor or Operator* (us-vs-them), *Events Are Not Top of Funnel* (myth-bust) — each with correct length/orientation and a director-ready brief. (Output in chat.)

## Test plan
- `node --check` + `tsc` + lint clean; 181-test suite green; route snapshot +1.
- Backend (new route + LLM helper) + additive UI. No template change, no redeploy.

## Merge note
Built on `development`; touches `video.js`/`routes/video.js`/`VideoGeneratorPage` like the other open video PRs but in distinct regions — trivial merges. Part of the same video stack (#326/#327/#328); ping me to reconcile the order + a final site deploy.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_