### PR TITLE
fix(video): real audio timing (no overlap), no duplicate copy, fit-to-frame

### DIFF
--- a/remotion/src/DataReel.tsx
+++ b/remotion/src/DataReel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   AbsoluteFill, Sequence, Audio, Img, staticFile,
   useCurrentFrame, useVideoConfig, interpolate, spring, Easing,
+  delayRender, continueRender,
 } from "remotion";
 import type {
   Brand, Scene, HookScene, TagsScene, OrbitScene,
@@ -110,17 +111,41 @@ const useRise = (delay = 0, dist = 50) => {
   return { opacity: Math.min(1, s), transform: `translateY(${interpolate(s, [0, 1], [dist * k, 0])}px)` };
 };
 
+// Scale scene content DOWN to fit the safe area, so a long headline or a deck
+// scene with many items can never render out of frame. Measures natural size
+// (scrollWidth/Height, unaffected by the transform) once and shrinks if needed;
+// delayRender holds the frame until the measurement lands on Lambda.
+const Fit: React.FC<{ children: React.ReactNode; pad: number }> = ({ children, pad }) => {
+  const { width, height } = useVideoConfig();
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [scale, setScale] = React.useState(1);
+  const [handle] = React.useState(() => delayRender("fit-measure"));
+  React.useEffect(() => {
+    const el = ref.current;
+    if (el) {
+      const s = Math.min(1, (width - pad * 2) / el.scrollWidth, (height - pad * 2) / el.scrollHeight);
+      if (s > 0 && s < 0.999) setScale(s);
+    }
+    continueRender(handle);
+  }, [handle, width, height, pad]);
+  return (
+    <div style={{ transform: `scale(${scale})`, transformOrigin: "center center", display: "flex", justifyContent: "center", alignItems: "center" }}>
+      <div ref={ref}>{children}</div>
+    </div>
+  );
+};
+
 const Stage: React.FC<{ children: React.ReactNode; audio?: string }> = ({ children, audio }) => {
   const { C, font, brand, L } = React.useContext(Ctx);
   const { k } = L;
   const src = audioSrc(audio);
   return (
-    <AbsoluteFill style={{ background: C.bg, fontFamily: font, justifyContent: "center", alignItems: "center", padding: 120 * k }}>
+    <AbsoluteFill style={{ background: C.bg, fontFamily: font, justifyContent: "center", alignItems: "center", padding: 120 * k, overflow: "hidden" }}>
       {src && <Audio src={src} />}
       <div style={{ position: "absolute", top: 64 * k, left: 90 * k, display: "flex", alignItems: "center", gap: 14 * k }}>
         <BrandMark size={36} /><span style={{ fontWeight: 700, fontSize: 32 * k, color: C.emphasis }}>{brand.name}</span>
       </div>
-      {children}
+      <Fit pad={120 * k}>{children}</Fit>
     </AbsoluteFill>
   );
 };

--- a/src/server/video.js
+++ b/src/server/video.js
@@ -249,6 +249,7 @@ Scene archetypes — a deck of distinct layouts. PICK THE BEST FIT PER BEAT and 
 Rules:
 - Always open with exactly one "hook" and close with exactly one "cta".
 - VARY the middle beats — reach for the deck above, not just tags/bars/orbit every time.
+- NO REPEATED COPY: every scene's headline/text must be DISTINCT. Never reuse the same phrase, sentence, or key line in two scenes. Each beat advances the story with new words; do not restate the hook later.
 - Copy is punchy and concrete. Headlines <= 8 words. NO em dashes.${screensRule}
 - Every scene MUST include a "voiceover" string: one spoken sentence (8-22 words) that matches the on-screen beat.
 - Output ONLY JSON: { "direction": {...}, "scenes": [ { "id":"kebab-name", "type":..., ...fields, "voiceover":"..." } ] }`;
@@ -470,7 +471,9 @@ async function ttsOpenAI(text, voice, instructions) {
     }),
   });
   if (!res.ok) throw new Error(`OpenAI TTS ${res.status}: ${(await res.text()).slice(0, 200)}`);
-  return Buffer.from(await res.arrayBuffer());
+  // seconds:null — OpenAI's mp3 isn't guaranteed CBR, so duration is estimated
+  // downstream from word count.
+  return { buf: Buffer.from(await res.arrayBuffer()), seconds: null };
 }
 
 async function ttsElevenLabs(text, voice) {
@@ -487,7 +490,10 @@ async function ttsElevenLabs(text, voice) {
     }),
   });
   if (!res.ok) throw new Error(`ElevenLabs ${res.status}: ${(await res.text()).slice(0, 200)}`);
-  return Buffer.from(await res.arrayBuffer());
+  const buf = Buffer.from(await res.arrayBuffer());
+  // mp3_44100_128 is constant 128 kbps → 16000 bytes/sec. Exact duration with
+  // no decoder, so scene timing matches the real read (no overlap/cutoff).
+  return { buf, seconds: buf.length / 16000 };
 }
 
 async function ttsToBuffer(text, voice, instructions) {
@@ -665,13 +671,20 @@ export async function synthesizeScenes(scenes, jobId, direction, opts = {}) {
     work = assignShotsToScreens(work, shotUrls, hostLabel(opts.siteUrl || ''));
   }
   const out = [];
+  const TAIL_FRAMES = 26; // ~0.85s breath after VO ends (aligns with music duck tail)
   for (let i = 0; i < work.length; i++) {
     const { voiceover, ...scene } = work[i];
-    scene.durationInFrames = scene.durationInFrames || framesForVoiceover(voiceover);
-    if (voiceover && process.env.OPENAI_API_KEY) {
+    if (voiceover && (process.env.OPENAI_API_KEY || process.env.ELEVENLABS_API_KEY)) {
       // Per-scene direction: brand voice + this scene's on-screen punch words.
-      const buf = await ttsToBuffer(voiceover, d.voice, voiceInstructionsForScene(d.voiceInstructions, work[i]));
+      const { buf, seconds } = await ttsToBuffer(voiceover, d.voice, voiceInstructionsForScene(d.voiceInstructions, work[i]));
+      // Scene length tracks the REAL audio (EL gives exact seconds; OpenAI falls
+      // back to the word-count estimate). +tail so the VO never bleeds into the
+      // next scene and there's a clean beat before the cut.
+      const voFrames = seconds ? Math.ceil(seconds * FPS) : framesForVoiceover(voiceover);
+      scene.durationInFrames = Math.max(scene.durationInFrames || 0, voFrames + TAIL_FRAMES);
       scene.audio = await uploadAndPresign(buf, `forge-audio/${jobId}/${scene.id || i}.mp3`);
+    } else {
+      scene.durationInFrames = scene.durationInFrames || framesForVoiceover(voiceover);
     }
     out.push(scene);
   }


### PR DESCRIPTION
## Three issues from the first real ElevenLabs reels

### 1. Voice overlapping between scenes
Scene length was **estimated** from word count (`framesForVoiceover`), but ElevenLabs reads at a different pace — so a scene could be shorter than its VO clip and the audio bled into the next scene. Now scene duration tracks the **real audio length**: `ttsElevenLabs` returns exact seconds (`mp3_44100_128` is 128 kbps CBR → `bytes / 16000`), OpenAI falls back to the estimate; `durationInFrames = ceil(seconds·fps) + ~0.85s tail`. VO can't overflow its scene anymore.

### 2. Two scenes with identical copy
Added a hard **NO-REPEATED-COPY** rule to the storyboard prompt — every scene's headline/text must be distinct; never restate the hook.

### 3. Rendering out of frame
New **`Fit`** wrapper in `Stage`: measures each scene's natural size (`scrollWidth/Height`, unaffected by the transform) and scales it down to the safe area; `delayRender` holds the frame until the measurement lands on Lambda. Plus `overflow:hidden` as a safety net. A long headline or a deck scene with many items can no longer render off-canvas — verified with a 6-item portrait checklist + long wrapping headline (still in chat).

## Test plan
- `remotion tsc` + `node --check` + lint clean; **191 tests**.
- `forge-reels` Lambda site **redeployed** with the `Fit` template (required — template change).

## Merge note
Stacks on **#332** (re-landed upload + tts-check); touches `video.js` (`synthesizeScenes`/tts fns) and `DataReel` (`Stage`). Merge #332 first, then this; trivial otherwise. After the whole stack lands, the site is already on the latest template (this PR's deploy), but a final `sites create` from `development` post-merge keeps it canonical.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_