### PR TITLE
feat(video): per-brand pronunciation dictionary for voiceover

### DIFF
--- a/src/pages/VideoGeneratorPage.tsx
+++ b/src/pages/VideoGeneratorPage.tsx
@@ -51,6 +51,7 @@ function VideoGeneratorContent() {
   const [musicBed, setMusicBed] = useState('auto');
   const [theme, setTheme] = useState('auto');
   const [targetSeconds, setTargetSeconds] = useState(30);
+  const [sayItLike, setSayItLike] = useState('');
   const [voiceOptions, setVoiceOptions] = useState<DirectionOption[]>([]);
   const [bedOptions, setBedOptions] = useState<DirectionOption[]>([]);
   const [themeOptions, setThemeOptions] = useState<DirectionOption[]>([]);
@@ -136,14 +137,26 @@ function VideoGeneratorContent() {
     setOrientation(a.orientation);
   }
 
+  // Parse "Word=Say it, Other=Say it" into a { word: respelling } override map.
+  function parseSayItLike(s: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const pair of s.split(',')) {
+      const [word, ...rest] = pair.split('=');
+      const w = (word || '').trim(), say = rest.join('=').trim();
+      if (w && say) out[w] = say;
+    }
+    return out;
+  }
+
   async function generate() {
     if (!selectedBrainId || !brief.trim() || !authToken) return;
     setBusy(true); setError(null); setJob(null);
     try {
+      const pronunciations = parseSayItLike(sayItLike);
       const r = await fetch('/api/video/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
-        body: JSON.stringify({ brandProfileId: selectedBrainId, brief: brief.trim(), orientation, voice, musicBed, theme, targetSeconds, screenshotKeys: shots.map(s => s.key) }),
+        body: JSON.stringify({ brandProfileId: selectedBrainId, brief: brief.trim(), orientation, voice, musicBed, theme, targetSeconds, screenshotKeys: shots.map(s => s.key), ...(Object.keys(pronunciations).length ? { pronunciations } : {}) }),
       });
       const d = await r.json();
       if (!r.ok) throw new Error(d.error || `Request failed (${r.status})`);
@@ -309,6 +322,14 @@ function VideoGeneratorContent() {
           )}
         </div>
         {shots.length > 0 && <div className="vg-shots-note">A "product" scene will showcase these in browser chrome.</div>}
+
+        <label className="vg-label">Pronounce names like <span className="vg-optional">optional — fixes how the voice says tricky names, e.g. SYSOI=Sis-Oy</span></label>
+        <input
+          className="vg-select"
+          placeholder="SYSOI=Sis-Oy, GEO=jee-oh"
+          value={sayItLike}
+          onChange={e => setSayItLike(e.target.value)}
+        />
 
         <button className="vg-btn" onClick={generate} disabled={busy || !selectedBrainId || !brief.trim()}>
           {busy ? 'Generating…' : 'Generate video'}

--- a/src/server/routes/video.js
+++ b/src/server/routes/video.js
@@ -10,7 +10,7 @@ import {
   videoConfigured, buildBrand, brandContextFor, storyboardFromBrief,
   resolveDirection, presignMusicBed, synthesizeScenes, normalizeTargetSeconds,
   renderReel, getReelProgress, videoArcs, presignShotKeys, MAX_USER_SHOTS,
-  ttsHealth, VOICES, MUSIC_BEDS, THEMES, LENGTH_BUDGETS,
+  ttsHealth, pronunciationsFor, VOICES, MUSIC_BEDS, THEMES, LENGTH_BUDGETS,
 } from '../video.js';
 
 async function ensureVideosTable() {
@@ -44,7 +44,7 @@ async function setStatus(id, fields) {
 }
 
 // Background pipeline — not awaited by the request.
-async function runJob(id, brief, brand, orientation, brandContext, directionOverrides, targetSeconds, siteUrl, uploadedShots) {
+async function runJob(id, brief, brand, orientation, brandContext, directionOverrides, targetSeconds, siteUrl, uploadedShots, pronunciations) {
   try {
     const hasUploads = Array.isArray(uploadedShots) && uploadedShots.length > 0;
     await setStatus(id, { status: 'storyboarding' });
@@ -57,7 +57,7 @@ async function runJob(id, brief, brand, orientation, brandContext, directionOver
     // uploadedShots (user's product screenshots) are the primary source for
     // "screens" beats; siteUrl auto-capture is the fallback (gated by
     // VIDEO_SCREENS_ENABLED).
-    const scenes = await synthesizeScenes(draft, id, direction, { siteUrl, orientation, uploadedShots });
+    const scenes = await synthesizeScenes(draft, id, direction, { siteUrl, orientation, uploadedShots, pronunciations });
 
     const musicSrc = direction.musicBed === 'none' ? null : await presignMusicBed(direction.musicBed);
     await setStatus(id, { status: 'rendering', scenes: JSON.stringify(scenes) });
@@ -90,6 +90,12 @@ router.post('/generate', async (req, res) => {
     const row = r.rows[0] || {};
     const brand = buildBrand(row.brand_name || 'Forge Intelligence', row.profile_data, row.logo_url);
     const brandContext = brandContextFor(row.profile_data);
+    // Per-brand "say-it-like" dictionary (e.g. SYSOI -> Sis-Oy), merged with any
+    // one-off overrides from the request. Rewrites the spoken VO only.
+    const pronunciations = {
+      ...(pronunciationsFor(row.profile_data) || {}),
+      ...(req.body?.pronunciations && typeof req.body.pronunciations === 'object' ? req.body.pronunciations : {}),
+    };
     // UI pickers: { voice, musicBed } with 'auto' (or absence) = brain decides.
     const directionOverrides = {
       voice: typeof req.body?.voice === 'string' ? req.body.voice : 'auto',
@@ -107,7 +113,7 @@ router.post('/generate', async (req, res) => {
       [brandProfileId, brief, orientation]
     );
     const id = ins.rows[0].id;
-    runJob(id, brief, brand, orientation, brandContext, directionOverrides, targetSeconds, row.brand_url, uploadedShots); // fire-and-forget
+    runJob(id, brief, brand, orientation, brandContext, directionOverrides, targetSeconds, row.brand_url, uploadedShots, pronunciations); // fire-and-forget
     res.status(202).json({ id, status: 'queued' });
   } catch (e) {
     console.error('[VIDEO] generate error:', e.message);

--- a/src/server/video.js
+++ b/src/server/video.js
@@ -346,6 +346,21 @@ export function brandContextFor(profileData) {
   return parts.join('\n').slice(0, 2000);
 }
 
+// Brand pronunciation dictionary stored on the profile. Returns a clean
+// { word: respelling } map (or null) for applyPronunciations. Caps entries so
+// a malformed/huge map can't blow up the VO loop.
+export function pronunciationsFor(profileData) {
+  const raw = profileData?.pronunciations;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const out = {};
+  for (const [k, v] of Object.entries(raw).slice(0, 30)) {
+    const word = String(k || '').trim().slice(0, 60);
+    const say = String(v || '').trim().slice(0, 120);
+    if (word && say) out[word] = say;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
 // ── Video arcs (a slate of video concepts) ──────────────────────────────────
 // Like the Social Generator's campaign arcs, but for video: one click yields N
 // distinct reel ideas, each a ready-to-run brief the user can generate in a tap.
@@ -403,6 +418,27 @@ export function framesForVoiceover(vo) {
   const words = String(vo || '').trim().split(/\s+/).filter(Boolean).length;
   const seconds = Math.max(2.2, words / 2.3 + 0.8);
   return Math.round(seconds * FPS);
+}
+
+// Per-brand pronunciation dictionary. The storyboard/brief model and the TTS
+// engine read the voiceover text near-literally, so a brand name with an
+// unobvious pronunciation (e.g. "SYSOI" = "Sis-Oy") gets spelled out or
+// mangled. Fix: rewrite the word ONLY in the spoken text (the on-screen text
+// keeps the real spelling) using a brand-supplied phonetic respelling.
+// dict: { "SYSOI": "Sis-Oy", ... }. Match is whole-word, case-insensitive.
+export function applyPronunciations(text, dict) {
+  if (!text || !dict || typeof dict !== 'object') return text;
+  let out = String(text);
+  for (const [word, say] of Object.entries(dict)) {
+    const key = String(word || '').trim();
+    const repl = String(say || '').trim();
+    if (!key || !repl) continue;
+    // \b is unreliable next to non-ASCII / punctuation; bound on word chars.
+    const esc = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`(^|[^A-Za-z0-9])(${esc})(?![A-Za-z0-9])`, 'gi');
+    out = out.replace(re, (_m, pre) => `${pre}${repl}`);
+  }
+  return out;
 }
 
 // The on-screen emphasis words ARE the buzzwords to punch. Pull them per scene
@@ -671,12 +707,15 @@ export async function synthesizeScenes(scenes, jobId, direction, opts = {}) {
     work = assignShotsToScreens(work, shotUrls, hostLabel(opts.siteUrl || ''));
   }
   const out = [];
+  const pron = opts.pronunciations && typeof opts.pronunciations === 'object' ? opts.pronunciations : null;
   const TAIL_FRAMES = 26; // ~0.85s breath after VO ends (aligns with music duck tail)
   for (let i = 0; i < work.length; i++) {
     const { voiceover, ...scene } = work[i];
     if (voiceover && (process.env.OPENAI_API_KEY || process.env.ELEVENLABS_API_KEY)) {
+      // Respell tricky brand names in the SPOKEN text only (on-screen unchanged).
+      const spoken = applyPronunciations(voiceover, pron);
       // Per-scene direction: brand voice + this scene's on-screen punch words.
-      const { buf, seconds } = await ttsToBuffer(voiceover, d.voice, voiceInstructionsForScene(d.voiceInstructions, work[i]));
+      const { buf, seconds } = await ttsToBuffer(spoken, d.voice, voiceInstructionsForScene(d.voiceInstructions, work[i]));
       // Scene length tracks the REAL audio (EL gives exact seconds; OpenAI falls
       // back to the word-count estimate). +tail so the VO never bleeds into the
       // next scene and there's a clean beat before the cut.

--- a/test/video-direction.test.js
+++ b/test/video-direction.test.js
@@ -1,5 +1,40 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { resolveDirection, MUSIC_BEDS, VOICES, brandContextFor } from '../src/server/video.js';
+import { resolveDirection, MUSIC_BEDS, VOICES, brandContextFor, applyPronunciations, pronunciationsFor } from '../src/server/video.js';
+
+describe('applyPronunciations', () => {
+  const dict = { SYSOI: 'Sis-Oy' };
+
+  it('respells a whole-word match, case-insensitively', () => {
+    expect(applyPronunciations('Welcome to SYSOI today', dict)).toBe('Welcome to Sis-Oy today');
+    expect(applyPronunciations('welcome to sysoi.', dict)).toBe('welcome to Sis-Oy.');
+  });
+
+  it('does not touch substrings inside other words', () => {
+    expect(applyPronunciations('SYSOImania is not a word', dict)).toBe('SYSOImania is not a word');
+  });
+
+  it('handles punctuation and start/end of string', () => {
+    expect(applyPronunciations('SYSOI!', dict)).toBe('Sis-Oy!');
+    expect(applyPronunciations('It is "SYSOI", yes', dict)).toBe('It is "Sis-Oy", yes');
+  });
+
+  it('passes text through untouched with no/empty dict', () => {
+    expect(applyPronunciations('SYSOI', null)).toBe('SYSOI');
+    expect(applyPronunciations('SYSOI', {})).toBe('SYSOI');
+    expect(applyPronunciations('', dict)).toBe('');
+  });
+});
+
+describe('pronunciationsFor', () => {
+  it('reads + sanitizes the profile map', () => {
+    expect(pronunciationsFor({ pronunciations: { SYSOI: 'Sis-Oy', '': 'x', y: '' } })).toEqual({ SYSOI: 'Sis-Oy' });
+  });
+  it('returns null for missing/invalid', () => {
+    expect(pronunciationsFor(null)).toBe(null);
+    expect(pronunciationsFor({})).toBe(null);
+    expect(pronunciationsFor({ pronunciations: [] })).toBe(null);
+  });
+});
 
 describe('resolveDirection', () => {
   it('keeps the agent pick when no overrides', () => {


### PR DESCRIPTION
## Why
SYSOI is pronounced "Sis-Oy" but the voice actor spells it out or says "Sis-eo". Prompt edits were ignored — the brief is *interpreted* by the storyboard model, but the voiceover string is read near-literally by TTS, so the fix has to live at the spoken-text layer, not the prompt.

## What
- **`applyPronunciations(text, dict)`** — whole-word, case-insensitive substitution. Bounds on word chars so it never touches substrings inside other words (`SYSOImania` stays put) and survives punctuation / start-of-string.
- Applied to the `voiceover` string **right before TTS** in `synthesizeScenes` — **on-screen text keeps the real spelling**, only the spoken audio changes.
- Sources, merged in order:
  1. `profile_data.pronunciations` (per-brand, persistent) via `pronunciationsFor()` — sanitized, capped at 30 entries.
  2. optional per-render override from the request (`pronunciations`), surfaced as a **"Pronounce names like"** UI field (`SYSOI=Sis-Oy, GEO=jee-oh`).
- **Seeded SYSOI's three brand profiles** with `{ "SYSOI": "Sis-Oy" }` (Brian picked spelling variant "Sis-Oy" from the A/B set).

## Test plan
- New unit tests: `applyPronunciations` (whole-word, punctuation, substring safety, empty dict) + `pronunciationsFor` sanitization. Full suite **197 pass**.
- `node --check` + `tsc --noEmit` clean; route snapshot unchanged (no new routes).
- Post-deploy: generate a SYSOI reel on dev — voice should say "Sis-Oy", on-screen text still reads "SYSOI".

## Rollback
Self-contained; revert the commit. The seeded `pronunciations` key is additive (`||` merge) and harmless if the code is absent.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_