### PR TITLE
docs: checkpoint — video timing/fit + per-brand pronunciation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,24 @@
+## 2026-06-10 — Video QA pass: real audio timing, fit-to-frame, per-brand pronunciation
+
+Three fixes off Brian's QA of generated reels, all merged to `development`.
+
+### Timing + fit-to-frame (#334)
+- **VO no longer overlaps the next scene.** `synthesizeScenes` now sets `scene.durationInFrames = max(existing, voFrames + TAIL_FRAMES)` where `voFrames` comes from the REAL audio length: ElevenLabs returns exact seconds (`buf.length/16000`), OpenAI falls back to `framesForVoiceover` (word-count). `TAIL_FRAMES = 26` (~0.85s) gives a clean beat before the cut and aligns with the music duck tail.
+- **No duplicate copy** — added a "NO REPEATED COPY across scenes" rule to the storyboard prompt (Brian saw two scenes with identical lines).
+- **Out-of-frame text fixed** — new `Fit` component in `DataReel.tsx` measures `scrollWidth/Height` via `delayRender`/`continueRender` and scales content down to the safe area; `overflow:hidden` on the Stage. Verified with a 6-item portrait checklist render.
+
+### Per-brand pronunciation (#336)
+- Root cause: prompt edits to fix "SYSOI" were ignored because the brief is *interpreted* by the storyboard model, but the voiceover string is read near-literally by TTS — so the fix has to live at the spoken-text layer.
+- `applyPronunciations(text, dict)` — whole-word, case-insensitive substitution, bounded on word chars (won't touch substrings; survives punctuation/string edges). Applied to `voiceover` **right before `ttsToBuffer`** so **on-screen text keeps the real spelling**.
+- Sources merge in order: per-brand `profile_data.pronunciations` (via `pronunciationsFor()`, sanitized, capped 30) → optional per-render request override, surfaced as the **"Pronounce names like"** UI field (`SYSOI=Sis-Oy, GEO=jee-oh`).
+- **Seeded SYSOI's 3 brand profiles** `{ "SYSOI": "Sis-Oy" }` via relay (`||` merge; Brian picked spelling "Sis-Oy" from a 6-variant ElevenLabs A/B).
+- Tests: `applyPronunciations` (whole-word/punctuation/substring/empty) + `pronunciationsFor`. Full suite 197 pass.
+
+### Deploy pending
+- `DataReel.tsx` changed (Fit) → the live `forge-reels` Lambda site needs `cd remotion && npm run deploy-site` (requires `REMOTION_AWS_*`, Render-side — not available in the sandbox). Pronunciation is server-side only, no deploy needed.
+
+---
+
 ## 2026-06-09 (cont. 2) — Video generator → production-grade (creative, voice, screens, deck, arcs)
 
 The long arc that turned the video generator from "it renders" into a real product. Same governing pattern throughout: **a curated, finite vocabulary the storyboard agent picks from (grounded in the brand brain), with the human holding a veto via UI pickers.** Merge state at session end below — a stack of PRs, some merged, four still open.

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,6 +10,19 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-10 — Video: real timing, fit-to-frame, per-brand pronunciation
+
+All merged to `development`. Three voice/render-quality fixes from Brian's QA pass:
+- **#334 timing + fit** — scene length now tracks the REAL audio (ElevenLabs returns exact seconds; OpenAI falls back to word-count estimate) + a ~0.85s tail, so VO no longer overlaps into the next scene. "No repeated copy" prompt rule. New `Fit` component in `DataReel.tsx` measures content and scales down to the safe area → kills out-of-frame text.
+- **#336 pronunciation** — `applyPronunciations(text, dict)` rewrites tricky brand names in the **spoken VO only** (on-screen text keeps real spelling); whole-word, case-insensitive, substring-safe. Sources merge: per-brand `profile_data.pronunciations` → optional per-render override (new "Pronounce names like" UI field). **SYSOI's 3 profiles seeded** `{ "SYSOI": "Sis-Oy" }`.
+
+#### What's next (video) — DEPLOY PENDING
+- **⚠️ Run `cd remotion && npm run deploy-site` (needs `REMOTION_AWS_*` env — Render side, not the sandbox).** #334 changed the `DataReel.tsx` template (Fit component); the live `forge-reels` Lambda site won't have it until this redeploy. Pronunciation (#336) is server-side only and needs no deploy.
+- Then verify ElevenLabs on Render: hit `dev.forgeintelligence.ai/api/video/tts-check` signed in, confirm the `elevenlabs` block (EL works vs. datacenter-IP blocked → silent OpenAI fallback).
+- Drop `framesPerLambda: 400` once the AWS **5,000 concurrency** increase approves.
+
+---
+
 ### 2026-06-09 (cont. 2) — Video generator → production-grade
 
 The video generator went from "it renders" to a real product. One pattern throughout: **curated finite vocabulary the storyboard agent picks from (grounded in the brand brain), human veto via UI pickers.** Full detail in `PLAN.md` (2026-06-09 cont. 2). Architecture: brief → `storyboardFromBrief` (Claude) → `synthesizeScenes` (TTS → S3 presigned) → `renderReel` on **AWS Lambda** (`forge-reels` site). Backend `src/server/video.js` + `routes/video.js`; template `remotion/src/DataReel.tsx` (redeploy: `cd remotion && npm run deploy-site`).


### PR DESCRIPTION
## Why
End-of-session doc protocol: record the 2026-06-10 video QA pass in both the archive (`PLAN.md`) and the live pointer (`WORKING-STATE.md`).

## What
- `PLAN.md` — full entry for #334 (real audio timing, no-overlap, no-duplicate-copy, `Fit` component) and #336 (per-brand pronunciation: `applyPronunciations`, `pronunciationsFor`, SYSOI seeded `Sis-Oy`).
- `WORKING-STATE.md` — new top session block; flags the **pending `forge-reels` site redeploy** for #334's `DataReel.tsx` Fit change (needs `REMOTION_AWS_*`, Render-side).

Docs only — no code.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_