### PR TITLE
fix(video): constrain arc generator to the real production envelope

### DIFF
--- a/src/server/video.js
+++ b/src/server/video.js
@@ -380,17 +380,25 @@ function arcBrainContext(pd) {
 
 export async function videoArcs(brandName, profileData, count = 8) {
   const ctx = arcBrainContext(profileData);
-  const prompt = `You are a brand video strategist for "${brandName}". Propose ${count} DISTINCT short-form video concepts — a video content slate. Each is a self-contained reel with a DIFFERENT strategic angle (e.g. problem/solution, hard proof, founder POV, how-it-works, us-vs-them, customer story, a bold contrarian claim, behind-the-scenes, a single killer stat, a myth-bust). Do not repeat angles.
+  const prompt = `You are a brand video strategist for "${brandName}". Propose ${count} DISTINCT short-form video concepts — a video content slate. Each is a self-contained reel with a DIFFERENT strategic angle (e.g. problem/solution, hard proof, how-it-works, us-vs-them, a single killer stat, a myth-bust, a bold contrarian claim, an on-screen customer quote). Do not repeat angles.
 
 BRAND:
 ${ctx}
+
+PRODUCTION ENVELOPE — this is an automated motion-graphics generator. Every concept MUST be fully achievable with ONLY these elements:
+- Animated typographic + data scenes: bold headlines, stat callouts, bar/curve charts, process/timeline flows, comparison tables, feature grids, on-screen pull-quotes, logo rows, full-bleed statements.
+- A synthetic AI voiceover (text-to-speech) reading the script. There is NO human voice actor, NO recorded narration talent.
+- Optional product screenshots the user uploads (shown in browser chrome).
+- A music bed.
+
+There is NO live-action footage, NO real video, NO camera, NO people on screen, NO interviews, NO b-roll, NO drone/stock clips, NO screen-recorded demos, NO hands/product photography. If an angle would normally need filmed material, RECAST it as motion graphics: a "customer testimonial" becomes an on-screen pull-quote with the name/role as text; a "founder story" becomes animated statements + data, not a person talking; a "product demo" becomes uploaded screenshots + animated callouts. Do NOT propose "behind-the-scenes," "day in the life," "talking head," or anything that implies a shoot. Do NOT mention a human narrator, voice actor, or any visual the list above can't produce.
 
 For each concept return:
 - "title": a short internal name for the idea
 - "angle": one phrase naming the strategic angle
 - "length": 15, 30, or 60 (seconds) — whatever fits the idea
 - "orientation": "portrait" (social/IG/TikTok) or "landscape" (web/YouTube)
-- "brief": 1-2 sentences a video director can run with — what it says and its arc (hook -> body -> CTA). Concrete and on-brand. NO em dashes.
+- "brief": 1-2 sentences a video director can run with — what it says and its arc (hook -> body -> CTA), described in terms of animated text/data/screenshots only. Concrete and on-brand. NO em dashes.
 
 Output ONLY JSON: { "arcs": [ { "id":"kebab-name", "title", "angle", "length", "orientation", "brief" } ] }`;
   const msg = await anthropic.messages.create({


### PR DESCRIPTION
## Why
The video arc generator (`POST /api/video/arcs` → 8 concepts) pitched ideas the renderer **can't produce** — human voice actors, real video/footage, behind-the-scenes and talking-head shoots, screen-recorded demos. The resulting briefs either misled the user about what they'd get or got awkwardly force-fit into abstract motion-graphics scenes.

## What
The storyboard stage is already bounded by the 18 scene archetypes, so it can't emit impossible elements. The leak was upstream in `videoArcs`, whose prompt had **no capability envelope**. Added an explicit **PRODUCTION ENVELOPE** block that constrains every concept to what the system actually makes:
- animated typographic / data scenes (headlines, stats, charts, process/timeline, comparison, grids, on-screen pull-quotes, logo rows, statements)
- a **synthetic AI voiceover** (no human narrator / voice actor)
- optional user-uploaded product screenshots
- a music bed

And explicitly bans live action, people on screen, interviews, b-roll, stock/drone clips, screen-recorded demos. Filmed angles get **recast** as motion graphics: testimonial → on-screen pull-quote; founder story → animated statements + data; product demo → uploaded screenshots + callouts.

## Test plan
- `node --check` clean; existing video tests pass (28).
- Post-deploy: hit "Suggest video ideas" for a brand — briefs should no longer reference a narrator, footage, or a shoot.

## Rollback
Single-function prompt change; revert the commit.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_