### PR TITLE
chore: Claude Code web session bootstrap (hooks + capability gate)

### DIFF
--- a/.claude/hooks/pre-tool-gate.sh
+++ b/.claude/hooks/pre-tool-gate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse gate — DENIES file edits and git commit/push until the capability
+# preflight has passed THIS session. Reads-and-tests stay allowed (so preflight
+# itself can run). exit 2 = block; stderr is fed back to the model.
+set -uo pipefail
+INPUT="$(cat)"
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+OK="$ROOT/.claude/.state/preflight-ok"
+
+read -r TOOL SESSION CMD <<<"$(printf '%s' "$INPUT" | node -e '
+let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{let j={};try{j=JSON.parse(d)}catch{}
+const c=(((j.tool_input||{}).command)||"").replace(/\s+/g," ").slice(0,160);
+process.stdout.write((j.tool_name||"-")+" "+(j.session_id||"-")+" "+c)})')"
+
+mut=false
+case "$TOOL" in
+  Edit|Write|MultiEdit|NotebookEdit) mut=true ;;
+  Bash) printf '%s' "$CMD" | grep -qE 'git[[:space:]]+(commit|push)|npm[[:space:]]+publish' && mut=true ;;
+esac
+
+if [ "$mut" = true ]; then
+  if [ ! -f "$OK" ] || [ "$(cat "$OK" 2>/dev/null)" != "$SESSION" ]; then
+    {
+      echo "⛔ PREFLIGHT GATE — edits/commits are blocked until the capability check passes this session."
+      echo "   Run:  bash .claude/hooks/preflight.sh"
+      echo "   Then resolve any ‼️ items (or surface them to the user). This is the deliberate stop that"
+      echo "   prevents discovering a missing tool/secret/MCP deep into the work."
+    } >&2
+    exit 2
+  fi
+fi
+exit 0

--- a/.claude/hooks/preflight.mjs
+++ b/.claude/hooks/preflight.mjs
@@ -1,0 +1,40 @@
+// Capability preflight. Checks the shell-verifiable items in capabilities.json
+// (cli.required + env.required block the gate; env.watched are surfaced but
+// never block), prints a ✅/‼️/○ report, and opens or closes the edit/commit
+// gate by writing/removing .claude/.state/preflight-ok. The MCP list is verified
+// by the MODEL (a shell can't see MCP connections).
+import { readFileSync, writeFileSync, existsSync, mkdirSync, rmSync } from "fs";
+import { execSync } from "child_process";
+import { join } from "path";
+
+const ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const STATE = join(ROOT, ".claude", ".state");
+mkdirSync(STATE, { recursive: true });
+const session = existsSync(join(STATE, "session-id")) ? readFileSync(join(STATE, "session-id"), "utf8").trim() : "manual";
+
+const cap = JSON.parse(readFileSync(join(ROOT, "capabilities.json"), "utf8"));
+const has = (cmd) => { try { execSync(`command -v ${cmd}`, { stdio: "ignore", shell: "/bin/bash" }); return true; } catch { return false; } };
+const tick = (ok) => (ok ? "✅" : "‼️");
+
+let requiredOk = true;
+const out = ["── PREFLIGHT · capability check ──"];
+
+for (const c of cap.cli?.required ?? []) { const ok = has(c); if (!ok) requiredOk = false; out.push(`${tick(ok)} cli  ${c}${ok ? "" : "   (REQUIRED — missing)"}`); }
+for (const o of cap.cli?.optional ?? []) { const ok = has(o.name); out.push(`${ok ? "✅" : "○ "} cli  ${o.name}${ok ? "" : "   — " + o.why}`); }
+for (const e of cap.env?.required ?? []) { const ok = !!process.env[e.name]; if (!ok) requiredOk = false; out.push(`${tick(ok)} env  ${e.name}${ok ? "" : "   (REQUIRED — add to env secrets + restart)"}`); }
+
+// Watched secrets never block the gate, but a missing one is loud — these are
+// the keys that get wiped on container resets (ElevenLabs/OpenAI/relay/Remotion).
+let missingWatched = 0;
+for (const w of cap.env?.watched ?? []) { const ok = !!process.env[w.name]; if (!ok) missingWatched++; out.push(`${ok ? "✅" : "○ "} env  ${w.name}${ok ? "" : "   — MISSING (watched): " + w.why}`); }
+
+const required = cap.mcp?.required ?? [];
+const direct = (cap.mcp?.directMcps ?? []).map((m) => m.name);
+out.push(`◐  mcp  VERIFY against your tools — required: ${required.join(", ") || "(none)"}  ·  direct: ${direct.join(", ") || "(none)"}`);
+
+const okFile = join(STATE, "preflight-ok");
+if (requiredOk) { writeFileSync(okFile, session); out.push(`→ required capabilities present · edit/commit gate OPEN${missingWatched ? ` · ‼️ ${missingWatched} watched secret(s) missing — surface to the user` : ""}`); }
+else { if (existsSync(okFile)) rmSync(okFile); out.push("→ a REQUIRED capability is missing · edit/commit gate CLOSED until fixed"); }
+
+console.log(out.join("\n"));
+process.exit(requiredOk ? 0 : 1);

--- a/.claude/hooks/preflight.sh
+++ b/.claude/hooks/preflight.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Thin wrapper so hooks/docs can call a stable path. Runs the capability check.
+set -uo pipefail
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+exec node "$ROOT/.claude/hooks/preflight.mjs"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SessionStart — installs deps (web runtime only), records the session id,
+# force-feeds a briefing into context (git state, recent commits, the live
+# WORKING-STATE pointer), and runs the capability preflight (which opens the
+# edit gate when required caps are present).
+#
+# Forge-Intelligence: base branch is `development` (Render's dev service deploys
+# from it); single npm package at the repo root.
+set -uo pipefail
+BASE_BRANCH="${BASE_BRANCH:-development}"
+
+INPUT="$(cat)"
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+mkdir -p "$ROOT/.claude/.state"
+SID=$(printf '%s' "$INPUT" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{let j={};try{j=JSON.parse(d)}catch{}process.stdout.write(j.session_id||"")})')
+[ -n "$SID" ] && echo "$SID" > "$ROOT/.claude/.state/session-id"
+
+# Only install in the remote/web runtime (locally you manage your own deps).
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  ( cd "$ROOT" && [ -f package.json ] && npm install --no-audit --no-fund >/dev/null 2>&1 || true )
+fi
+
+cd "$ROOT" 2>/dev/null || true
+git fetch origin "$BASE_BRANCH" >/dev/null 2>&1 || true
+echo "════════════ session brief ════════════"
+echo "branch: $(git branch --show-current 2>/dev/null)  ·  behind origin/$BASE_BRANCH by $(git rev-list --count HEAD..origin/$BASE_BRANCH 2>/dev/null || echo '?') commit(s)"
+echo "recent commits:"; git log --oneline -6 2>/dev/null | sed 's/^/  /'
+echo "uncommitted: $(git status --porcelain 2>/dev/null | wc -l | tr -d ' ') file(s)"
+# Live pointer: print the newest WORKING-STATE session block (### heading) so a
+# cold session lands on "where we are right now" without opening the file.
+if [ -f "$ROOT/WORKING-STATE.md" ]; then
+  echo "WORKING-STATE (newest block):"
+  awk '/^### /{c++} c==1{print "  "$0} c==2{exit}' "$ROOT/WORKING-STATE.md"
+fi
+echo
+node "$ROOT/.claude/hooks/preflight.mjs" || true
+echo
+echo "→ Read WORKING-STATE.md + CLAUDE.md. Verify the MCP list (capabilities.json) against your actual tools. Editing/committing is GATED on preflight."

--- a/.claude/hooks/user-prompt-status.sh
+++ b/.claude/hooks/user-prompt-status.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# UserPromptSubmit — re-injects a one-line live status on EVERY message, so the
+# session can't drift/forget what's wired and what's missing. The missing-env
+# field is the one that would have caught the wiped ELEVENLABS_API_KEY at the
+# first prompt instead of mid-task.
+set -uo pipefail
+BASE_BRANCH="${BASE_BRANCH:-development}"
+# Provider secrets that get wiped on container resets — surfaced every message.
+WATCH_ENV=(ANTHROPIC_API_KEY OPENAI_API_KEY ELEVENLABS_API_KEY ADMIN_RELAY_PASSWORD REMOTION_LAMBDA_SERVE_URL)
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+cd "$ROOT" 2>/dev/null || exit 0
+BR=$(git branch --show-current 2>/dev/null || echo '?')
+BEHIND=$(git rev-list --count HEAD..origin/$BASE_BRANCH 2>/dev/null || echo '?')
+SID=$(cat "$ROOT/.claude/.state/session-id" 2>/dev/null || echo)
+OK="$ROOT/.claude/.state/preflight-ok"
+GATE="closed"; [ -f "$OK" ] && [ "$(cat "$OK" 2>/dev/null)" = "$SID" ] && GATE="open"
+# Current task = newest WORKING-STATE block heading (### ...), trimmed.
+TASK=$(awk '/^### /{sub(/^### /,""); print; exit}' "$ROOT/WORKING-STATE.md" 2>/dev/null)
+MISS=""
+for v in "${WATCH_ENV[@]:-}"; do [ -n "$v" ] && [ -z "${!v:-}" ] && MISS="$MISS $v"; done
+echo "[session] branch=$BR · behind origin/$BASE_BRANCH=$BEHIND · preflight-gate=$GATE${TASK:+ · now: $TASK}${MISS:+ · missing-env:$MISS}"

--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -1,0 +1,15 @@
+{
+  "_comment": "Copy to .claude/settings.json to ACTIVATE the bootstrap hooks: `cp .claude/settings.json.example .claude/settings.json` then commit. A human does this step — the harness blocks the agent from writing its own hook-registration file. Once committed + active, every future Claude Code web session inherits the brief + preflight gate + live status line. Add `\"async\": true` to a hook to trade guaranteed-ready for faster startup.",
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\"" }] }
+    ],
+    "PreToolUse": [
+      { "matcher": "Edit|Write|MultiEdit|NotebookEdit|Bash",
+        "hooks": [{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-tool-gate.sh\"" }] }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/user-prompt-status.sh\"" }] }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 .env.*
 *.log
 .DS_Store
+
+# Claude Code web bootstrap — per-session ephemeral state
+.claude/.state/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,16 @@ The agent should orient itself in this order:
 4. **`STRATEGY.md` on the `strategy` branch** — current strategic narrative and positioning history.
 5. **Confirm active brand context.** Most operations involve the Forge brand (`brand_profile_id = cde5feeb-b3d7-4990-adee-a54977ab9c52`). When working on customer brands, confirm the ID before any destructive operation.
 
+## Session bootstrap (Claude Code on the web)
+
+A hook system boots web sessions warm and self-aware. Full detail in `docs/SESSION-BOOTSTRAP.md`; `capabilities.json` is the source of truth for what a session needs.
+
+- **Read the SessionStart brief** it prints (branch · behind `origin/development` · recent commits · newest WORKING-STATE block), then `WORKING-STATE.md`.
+- **Watch the status line** injected on every message: `branch · behind · preflight-gate · now · missing-env`. If `missing-env` lists a provider secret (e.g. `ELEVENLABS_API_KEY`), surface it **immediately** — a container reset wiped it and the feature will silently misbehave. Don't burn tokens before checking.
+- **The edit/commit gate** (PreToolUse) blocks mutations until the capability preflight passes this session. If blocked, run `bash .claude/hooks/preflight.sh` and resolve/announce any `‼️`.
+- **Capability honesty:** if a required CLI/secret/MCP is missing, say so at boot — never discover it deep into the work.
+- **Activation is a human step:** `cp .claude/settings.json.example .claude/settings.json` then restart (the agent can't write the hook-registration file). Keep `capabilities.json` (`baseBranch`, `env.watched`, `knownBlockers`) current — a cold session only knows what's written there.
+
 ## Branch and PR workflow (non-negotiable)
 
 The repo uses a **trunk → integration → production** model:

--- a/capabilities.json
+++ b/capabilities.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Capability manifest — the single source of truth for what a Forge-Intelligence dev session NEEDS to function. The preflight hook checks the shell-verifiable items (cli/env) and the gate blocks edits until the REQUIRED ones pass; the model verifies the MCP list against its own tool list at boot (a shell can't see MCP connections). Provider secrets live in `env.watched` (NOT required) so a wipe is surfaced loudly on every message without blocking unrelated code edits — that is the exact failure we keep hitting (container reset drops ELEVENLABS_API_KEY etc).",
+  "baseBranch": "development",
+  "cli": {
+    "required": ["node", "npm", "git"],
+    "optional": []
+  },
+  "env": {
+    "_note": "required = block the edit gate when missing (keep this list tiny — most edits don't need a secret). watched = never block, but surface on every message via the status hook so a wiped key is caught at the next prompt, not 900k tokens in.",
+    "required": [],
+    "watched": [
+      { "name": "ANTHROPIC_API_KEY",          "why": "LLM calls — storyboard agent, video arcs, all generation." },
+      { "name": "OPENAI_API_KEY",              "why": "gpt-4o-mini-tts voiceover (fallback path) + embeddings." },
+      { "name": "ELEVENLABS_API_KEY",          "why": "Primary video voiceover. Wiped on container resets — generation silently falls back to OpenAI when gone." },
+      { "name": "ADMIN_RELAY_PASSWORD",        "why": "SQL relay auth for ad-hoc DB inspection (/api/admin/relay)." },
+      { "name": "NEON_DATABASE_URL",           "why": "Postgres (Neon) connection for the app + relay." },
+      { "name": "REMOTION_LAMBDA_SERVE_URL",   "why": "Deployed forge-reels site — without it videoConfigured() is false and renders 503." },
+      { "name": "REMOTION_AWS_ACCESS_KEY_ID",  "why": "Lambda render + S3 presign (mirrored to AWS_* at video.js load)." }
+    ]
+  },
+  "mcp": {
+    "_note": "Verified by the MODEL against its tool list at boot (START-HERE step). A shell hook cannot see MCP connections. These are harness-provided in Claude Code on the web — this repo does NOT use Composio; connectors come in directly.",
+    "required": ["github"],
+    "directMcps": [
+      { "name": "github", "why": "All PR/issue/CI operations (mcp__github__*). Scope is set per session; use list_repos/add_repo to widen." },
+      { "name": "gitnexus", "why": "Code-graph intelligence (gitnexus_*). Optional — CLAUDE.md still orients without it." }
+    ],
+    "alsoSeenInSessions": ["Attio", "Slack", "Gmail", "Google_Drive", "Google_Calendar", "Canva", "Figma", "G2", "PayPal", "Postman", "Clerk"]
+  },
+  "knownBlockers": [
+    "Container idle-reset drops the checkout onto a STALE branch (seen: feat/video-screens) and leaves local behind origin, AND wipes env secrets (ELEVENLABS_API_KEY/OPENAI_API_KEY). ALWAYS `git fetch origin development` + verify base before branching/pushing, and re-check watched env at boot.",
+    "Allowlisted egress: the sandbox may not reach the live deploy (forgeintelligence.ai relay is reachable; provider APIs vary). ElevenLabs free-tier blocks datacenter IPs (401 detected_unusual_activity) — needs a paid plan to call from the sandbox/Render.",
+    "A just-wired MCP cannot be used in the SAME session that added it (tools bind at session start) — restart ONCE, deliberately.",
+    "AWS SDK reads AWS_* not REMOTION_AWS_* — video.js mirrors them at load; don't 'fix' that.",
+    "Render deploys from development (dev service) / main (prod). Never bulk-PUT Render env-vars (wipes all). The forge-reels Lambda site is shared state — last `npm run deploy-site` wins."
+  ]
+}

--- a/docs/SESSION-BOOTSTRAP.md
+++ b/docs/SESSION-BOOTSTRAP.md
@@ -1,0 +1,65 @@
+# Session bootstrap (Claude Code on the web)
+
+Makes a fresh web session boot **warm, gated, and self-aware** instead of cold
+and silently-missing-things. Adapted from the claude-web-bootstrap template to
+this repo: base branch `development`, reuses `WORKING-STATE.md`/`PLAN.md` as the
+live pointer + archive, no Composio (connectors are harness-provided directly).
+
+## What it does
+
+```
+session boots
+  └─ SessionStart (.claude/hooks/session-start.sh)
+        · npm install (web runtime only)
+        · prints a brief: branch · behind origin/development · recent commits · newest WORKING-STATE block
+        · runs the capability preflight → opens/closes the edit gate
+every message
+  └─ UserPromptSubmit (user-prompt-status.sh)
+        · one-line live status: branch · behind · gate · current task · MISSING watched secrets
+any edit / commit / push
+  └─ PreToolUse (pre-tool-gate.sh)
+        · blocked (exit 2) unless the preflight passed THIS session
+```
+
+The payoff for this repo specifically: the **status line surfaces a wiped
+`ELEVENLABS_API_KEY` (or OpenAI/relay/Remotion key) at the first prompt** —
+the exact failure where a container reset drops a secret and video generation
+silently falls back to the wrong voice provider mid-task. The SessionStart brief
+catches the other recurring gremlin: the reset that strands the checkout on a
+**stale branch behind `development`**.
+
+## Files
+
+| File | Role |
+|------|------|
+| `capabilities.json` | Source of truth: required CLIs, required vs **watched** env, MCPs, knownBlockers. |
+| `.claude/hooks/session-start.sh` | SessionStart: deps + brief + preflight. `BASE_BRANCH=development`. |
+| `.claude/hooks/preflight.mjs` / `.sh` | Capability check; writes/removes `.claude/.state/preflight-ok`. |
+| `.claude/hooks/pre-tool-gate.sh` | PreToolUse: deny edits/commits until preflight passes this session. |
+| `.claude/hooks/user-prompt-status.sh` | UserPromptSubmit: live status line. `WATCH_ENV=` the wipe-prone secrets. |
+| `.claude/settings.json.example` | Hook registration → copy to `.claude/settings.json` to activate (human step). |
+
+## Required vs watched env
+
+- **required** (currently empty): a missing one **closes the gate** and blocks all
+  edits. Keep tiny — most code edits need no secret.
+- **watched**: never blocks, but a missing one is printed on every message. This
+  is where the provider keys live (`ELEVENLABS_API_KEY`, `OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `ADMIN_RELAY_PASSWORD`, `REMOTION_LAMBDA_SERVE_URL`).
+
+## Activate (one-time, human step)
+
+```bash
+cp .claude/settings.json.example .claude/settings.json
+git add .claude/settings.json && git commit -m "chore: activate web bootstrap hooks"
+```
+
+The agent is blocked by the harness from writing the hook-registration file
+itself (self-modification of the permission machinery), so this stays manual.
+Hooks bind at session start — **start a fresh session** after activating.
+
+## Honest limit
+
+A hook can't attach a missing MCP to a *running* session or conjure a secret the
+sandbox can't see — that's harness physics. It makes the gap **loud and blocking
+at boot** so you restart once, deliberately, instead of discovering it deep in.


### PR DESCRIPTION
## Why
Web sessions keep hitting two container-reset gremlins that cost real time this session:
1. The checkout gets stranded on a **stale branch behind `development`** (we landed on `feat/video-screens` mid-task).
2. Provider **secrets get wiped** (`ELEVENLABS_API_KEY`), so video generation silently falls back to the wrong TTS provider — discovered only after a spike of misfired calls.

This incorporates the `claude-web-bootstrap` template (Brian-provided), adapted to this repo, so both are caught **at boot** instead of mid-work.

## What
- **SessionStart hook** — `npm install` (web runtime) + a brief: branch · behind `origin/development` · recent commits · newest `WORKING-STATE.md` block + capability preflight.
- **UserPromptSubmit hook** — one-line live status on every message: `branch · behind · preflight-gate · now · MISSING watched secrets`. (This line would have shown `ELEVENLABS_API_KEY` missing on the first prompt.)
- **PreToolUse gate** — blocks edits/commits until the preflight passes this session; read-only Bash stays allowed.
- **`capabilities.json`** — required CLIs + **required-vs-watched** env (watched secrets surface loudly but never block unrelated edits) + MCP list + `knownBlockers`.
- **Docs** — `docs/SESSION-BOOTSTRAP.md` + a "Session bootstrap" section in `CLAUDE.md`.

### Adaptations from the template
- Base branch `development` (not `main`).
- Reuses `WORKING-STATE.md` / `PLAN.md` as live pointer + archive — no new STATE/WORKLOG files.
- **No Composio** — connectors are harness-provided directly in this session; wiring a single Composio MCP isn't how this repo gets its tools.

## Test plan
Verified locally:
- `preflight.mjs` → gate OPEN (node/npm/git present), flags the 5 missing watched secrets incl. `ELEVENLABS_API_KEY`.
- gate hook: blocks `Edit` with no `preflight-ok` (exit 2), allows after preflight passes for the session, allows read-only Bash.
- status line renders branch/behind/gate/now/missing-env correctly.
- All hooks `bash -n` clean; JSON valid.

## Activation (deliberate, human)
Not auto-enabled — a blocking PreToolUse gate shouldn't govern everyone's sessions without a conscious flip:
```bash
cp .claude/settings.json.example .claude/settings.json
git add .claude/settings.json && git commit -m "chore: activate web bootstrap hooks"
```
Then start a fresh session (hooks bind at session start).

## Rollback
Delete `.claude/settings.json` to deactivate instantly; revert the commit to remove the files. `.claude/.state/` is gitignored (ephemeral).

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_