### PR TITLE
docs: checkpoint — arc envelope, web bootstrap, forge-reels deploy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,24 @@
+## 2026-06-11 — Arc production envelope, Claude-web bootstrap, forge-reels deploy + key incident
+
+All merged to `development`.
+
+### Arc production envelope (#339)
+`videoArcs` (the "suggest 8 video ideas" slate) had no notion of what the renderer can build, so it pitched human voice actors, live footage, talking-head/behind-the-scenes shoots. The storyboard stage was always safe (bounded by the 18 scene archetypes) — the over-promise was upstream at the idea prompt. Added a PRODUCTION ENVELOPE block constraining every concept to: animated typographic/data scenes + synthetic AI voiceover (no human narrator) + optional uploaded product screenshots + a music bed; filmed angles get recast (testimonial → on-screen pull-quote, founder story → animated statements, demo → screenshots + callouts).
+
+### Claude Code web bootstrap (#340)
+Incorporated Brian's `claude-web-bootstrap-template`, adapted to this repo. Three hooks: SessionStart (npm install + brief: branch/behind `origin/development`/commits/newest WORKING-STATE block + capability preflight), UserPromptSubmit (one-line live status: `branch · behind · preflight-gate · now · missing-env`), PreToolUse (blocks edits/commits until preflight passes this session). `capabilities.json` is the source of truth — required CLIs + **watched** env (provider secrets surface loudly on every message but never block unrelated edits, so a wiped `ELEVENLABS_API_KEY` is caught at the first prompt) + MCP list + knownBlockers. Adaptations from the template: base branch `development`; reuses WORKING-STATE.md/PLAN.md as live-pointer + archive (no new STATE/WORKLOG); **no Composio** (this session's connectors are harness-provided directly). Docs in `docs/SESSION-BOOTSTRAP.md` + a CLAUDE.md "Session bootstrap" section. Activation is a deliberate human step (`cp .claude/settings.json.example .claude/settings.json` + commit, then restart) — not auto-enabled, since a blocking gate shouldn't govern sessions without a conscious flip.
+
+### ElevenLabs narration + the pronunciation gotcha
+Confirmed EL is a plain REST integration (`POST /v1/text-to-speech/{voiceId}`, `xi-api-key`), no MCP. Generated the SYSOI product-video VO (7 scenes from `narration.json`, voice Bill `pqHfZKP75CvOlQylNhV4`, stability 0.5 / style 0.35 for the calm ad read). Lesson: the per-scene `instructions` field in the JSON is an OpenAI `gpt-4o-mini-tts` concept — EL ignores it (delivery comes from `voice_settings`). And **all-caps "SIS-oy" triggers EL's acronym detection → spells S-I-S**; mixed-case "Sis-Oy" in the spoken text reads it as one word.
+
+### forge-reels deploy + AWS key incident
+Ran `npm run deploy-site` to push the #334 Fit/timing template to the shared Lambda site. First attempt failed with an explicit deny from `AWSCompromisedKeyQuarantineV3` — AWS's auto-attached quarantine for a **leaked/compromised access key** on IAM user `remotion`. Surfaced as a security event; Brian had already rotated the keys (Render + web env) and talked to AWS that morning, then detached the quarantine policy. Redeploy succeeded — serve URL unchanged (`remotionlambda-useast1-rccmn55lmf` bucket), so no env change. **The deploy was genuinely manual** (only the Remotion *template* needs `deploy-site` → Lambda/S3; the app code auto-deploys via Render) — historically run by hand in-session when creds were present. Proposed but not built: a GitHub Action on `remotion/**` push to auto-deploy the site with `REMOTION_AWS_*` as repo secrets.
+
+### Environment lesson
+This web container's env vars are **intermittent across its lifecycle** — `ELEVENLABS_API_KEY` and `REMOTION_AWS_*` read empty at points (prompting a key paste + a "can't deploy from here" misread) and were fully present later. Always check live env state before declaring a secret missing; the watched-env status line (#340) exists to make this loud.
+
+---
+
 ## 2026-06-10 — Video QA pass: real audio timing, fit-to-frame, per-brand pronunciation
 
 Three fixes off Brian's QA of generated reels, all merged to `development`.

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,16 +10,29 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-11 — Arc production envelope · web bootstrap · forge-reels deploy
+
+- **#339 arc production envelope** — `videoArcs` pitched concepts the renderer can't make (human VO, live footage, talking-head/behind-the-scenes shoots). Storyboard was always safe (bounded by the 18 archetypes); the leak was the arc-idea prompt. Added a PRODUCTION ENVELOPE block: every concept must be achievable with animated text/data scenes + synthetic AI voiceover + optional uploaded screenshots + music. Filmed angles get recast (testimonial → on-screen pull-quote, demo → screenshots+callouts).
+- **#340 Claude Code web bootstrap** — adapted Brian's `claude-web-bootstrap-template`. SessionStart brief (branch · behind `development` · commits · newest WORKING-STATE block) + UserPromptSubmit live status line (`branch · behind · gate · now · missing-env`) + PreToolUse capability gate. `capabilities.json` is source of truth; provider secrets are **watched** (surface loudly, never block). Adaptations: base `development`; reuses WORKING-STATE/PLAN (no STATE/WORKLOG); no Composio (harness MCPs direct). **Activation is a human step (NOT yet done): `cp .claude/settings.json.example .claude/settings.json` + commit, then fresh session.**
+- **ElevenLabs VO**: confirmed it's a plain REST API (no MCP). Generated SYSOI product-video narration (7 scenes, Bill voice, stability 0.5/style 0.35) from `narration.json`. Gotcha: all-caps "SIS-oy" makes EL spell it (acronym detection) → use mixed-case "Sis-Oy" in the spoken text.
+- **`forge-reels` redeployed** ✅ — the #334 Fit/timing template is now live on the shared Lambda site (serve URL unchanged). Surfaced + Brian fixed a real security event mid-deploy: the `remotion` IAM key was quarantined by AWS (`AWSCompromisedKeyQuarantineV3` = leaked-key auto-deny). Keys already rotated + updated in Render and the web env; quarantine policy detached; deploy then succeeded.
+
+#### What's next
+- **Activate the bootstrap hooks** (human step above) — the files are merged but inert until `.claude/settings.json` exists.
+- **Automate the site deploy (proposed, not built):** a GitHub Action on `remotion/**` push to `development`/`main` running `deploy-site` with `REMOTION_AWS_*` as repo secrets — kills the "forgot to redeploy → stale template" footgun. The deploy is genuinely manual today (only `deploy-site` is, not the app — Render auto-deploys the dyno).
+- Drop `framesPerLambda: 400` once the AWS **5,000 concurrency** increase approves.
+- Verify ElevenLabs on Render: `dev.forgeintelligence.ai/api/video/tts-check` (signed in) → confirm `elevenlabs.ok` (vs. silent OpenAI fallback).
+
+---
+
 ### 2026-06-10 — Video: real timing, fit-to-frame, per-brand pronunciation
 
 All merged to `development`. Three voice/render-quality fixes from Brian's QA pass:
 - **#334 timing + fit** — scene length now tracks the REAL audio (ElevenLabs returns exact seconds; OpenAI falls back to word-count estimate) + a ~0.85s tail, so VO no longer overlaps into the next scene. "No repeated copy" prompt rule. New `Fit` component in `DataReel.tsx` measures content and scales down to the safe area → kills out-of-frame text.
 - **#336 pronunciation** — `applyPronunciations(text, dict)` rewrites tricky brand names in the **spoken VO only** (on-screen text keeps real spelling); whole-word, case-insensitive, substring-safe. Sources merge: per-brand `profile_data.pronunciations` → optional per-render override (new "Pronounce names like" UI field). **SYSOI's 3 profiles seeded** `{ "SYSOI": "Sis-Oy" }`.
 
-#### What's next (video) — DEPLOY PENDING
-- **⚠️ Run `cd remotion && npm run deploy-site` (needs `REMOTION_AWS_*` env — Render side, not the sandbox).** #334 changed the `DataReel.tsx` template (Fit component); the live `forge-reels` Lambda site won't have it until this redeploy. Pronunciation (#336) is server-side only and needs no deploy.
-- Then verify ElevenLabs on Render: hit `dev.forgeintelligence.ai/api/video/tts-check` signed in, confirm the `elevenlabs` block (EL works vs. datacenter-IP blocked → silent OpenAI fallback).
-- Drop `framesPerLambda: 400` once the AWS **5,000 concurrency** increase approves.
+#### Deploy status
+- ✅ **`forge-reels` redeployed 2026-06-11** — the Fit/timing template is live (see the 2026-06-11 block above). Pronunciation (#336) was server-side only, no deploy needed.
 
 ---
 


### PR DESCRIPTION
## Why
End-of-session doc protocol — record the 2026-06-11 work in the archive (`PLAN.md`) and the live pointer (`WORKING-STATE.md`).

## What
- **`PLAN.md`** — full entry: arc production envelope (#339), Claude Code web bootstrap (#340), ElevenLabs narration + the all-caps acronym pronunciation gotcha, the `forge-reels` redeploy (Fit/timing now live) including the `AWSCompromisedKeyQuarantineV3` leaked-key incident, and the intermittent-env lesson.
- **`WORKING-STATE.md`** — new top block (newest-first), and the prior 2026-06-10 "DEPLOY PENDING" flipped to ✅ done. 75 lines (under the 100 cap).

Docs only — no code.

## Outstanding (carried in WORKING-STATE)
- Activate the bootstrap hooks (human: `cp .claude/settings.json.example .claude/settings.json` + commit, then fresh session).
- Proposed: GitHub Action to auto-deploy `forge-reels` on `remotion/**` push.
- Drop `framesPerLambda: 400` once AWS 5,000 concurrency approves.

https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CU44TtqHKGxqa6yvG1Fui7)_