### PR TITLE
fix(video): kill the Ken Burns zoom on product screenshots

### DIFF
--- a/remotion/src/DataReel.tsx
+++ b/remotion/src/DataReel.tsx
@@ -352,9 +352,10 @@ const CurveView: React.FC<{ s: CurveScene }> = ({ s }) => {
   );
 };
 
-// Product showcase — REAL screenshots in browser chrome with a slow Ken Burns
-// push. The single biggest lever on "this is a brand reel" vs "that's the actual
-// product". `shots` are S3 URLs filled by the backend; crossfades if >1. Browser
+// Product showcase — REAL screenshots in browser chrome, held static (no Ken
+// Burns push — the zoom read as filler and blurred the product). The single
+// biggest lever on "this is a brand reel" vs "that's the actual product".
+// `shots` are S3 URLs filled by the backend; crossfades if >1. Browser
 // chrome + image area use the palette so it sits in any theme (clean/bold/…).
 const ScreensView: React.FC<{ s: ScreensScene }> = ({ s }) => {
   const { C } = React.useContext(Ctx);
@@ -365,11 +366,6 @@ const ScreensView: React.FC<{ s: ScreensScene }> = ({ s }) => {
   const rise = useRise(8, 40);
   const shots = Array.isArray(s.shots) ? s.shots.filter(Boolean) : [];
   const dur = s.durationInFrames || 1;
-
-  // Ken Burns over the whole scene (slow zoom + slight rise).
-  const p = interpolate(frame, [0, dur], [0, 1], { extrapolateRight: "clamp" });
-  const scale = interpolate(p, [0, 1], [1.05, 1.13]);
-  const ty = interpolate(p, [0, 1], [0, -3]); // %
 
   // Crossfade across multiple shots: equal slices, ~14f dissolve.
   const seg = shots.length > 1 ? dur / shots.length : dur;
@@ -415,13 +411,12 @@ const ScreensView: React.FC<{ s: ScreensScene }> = ({ s }) => {
                 <div style={{ marginLeft: 16 * k, flex: 1, maxWidth: 520 * k, height: 30 * k, borderRadius: 999, background: C.card, border: `2px solid ${C.border}`, display: "flex", alignItems: "center", padding: `0 ${18 * k}px`, fontSize: 22 * k, color: C.muted, fontWeight: 600, overflow: "hidden", whiteSpace: "nowrap" }}>{s.urlLabel}</div>
               )}
             </div>
-            {/* viewport with Ken Burns; cover-crop a constant 16:9 window so the page top reads */}
+            {/* static viewport; cover-crop a constant 16:9 window so the page top reads */}
             <div style={{ position: "relative", width: "100%", aspectRatio: "16 / 9", overflow: "hidden", background: C.card }}>
               {shots.map((src, i) => (
                 <Img key={i} src={src} style={{
                   position: "absolute", inset: 0, width: "100%", height: "100%",
                   objectFit: "cover", objectPosition: "center top",
-                  transform: `scale(${scale}) translateY(${ty}%)`, transformOrigin: "center top",
                   opacity: shotOpacity(i),
                 }} />
               ))}

--- a/remotion/src/types.ts
+++ b/remotion/src/types.ts
@@ -80,7 +80,7 @@ export type CtaScene = SceneBase & {
 
 // Product showcase: real screenshots of the brand's live site/app, captured by
 // the backend (captureProductShots) and uploaded to S3. `shots` are full https
-// URLs; the view frames them in browser chrome with a slow Ken Burns push and
+// URLs; the view frames them in browser chrome, held static (no zoom), and
 // crossfades if more than one. Copy (eyebrow/headline/stat) is written by the
 // storyboard agent; `shots` + `urlLabel` are filled server-side.
 export type ScreensScene = SceneBase & {


### PR DESCRIPTION
## Why
The product-screenshot scene (`ScreensView`) applied a slow Ken Burns push — scale 1.05→1.13 plus a -3% upward drift over the whole scene. Brian hates it: it reads as filler motion and keeps the product UI slightly soft for the entire shot.

## What
- `remotion/src/DataReel.tsx` — removed the Ken Burns interpolations and the `transform` on the screenshot `Img`s. Screenshots now hold static inside the browser chrome. The multi-shot crossfade is untouched.
- `remotion/src/types.ts` — comment updated to match.

## Test plan
- `npx tsc --noEmit` in `remotion/` passes.
- Visual: render any storyboard with a `screens` scene — screenshot should sit still; multi-shot scenes still dissolve every segment.

## Rollback
Revert the commit — the removed transform was self-contained.

## Deploy note
This changes the Remotion template, so it is NOT live until the Lambda site is redeployed: `cd remotion && npm run deploy-site` (needs `REMOTION_AWS_*`). Render auto-deploy alone won't pick it up — same footgun as #334.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_