### PR TITLE
feat(geo): citability mechanics in content gen + engine-aware opportunity scoring

### DIFF
--- a/src/agents/stage4_content_generator/system_prompt.md
+++ b/src/agents/stage4_content_generator/system_prompt.md
@@ -59,6 +59,17 @@ Return a JSON object with this exact structure:
 
 Answers must be 2-4 sentences, drawn from article body (do not introduce new claims). Every FAQ answer must stand alone: readable as an isolated snippet if cited without surrounding context.
 
+## Citability mechanics (GEO)
+
+These patterns are what AI engines actually lift into answers. They are ranked by measured citation impact (Princeton KDD 2024, 10,000 Perplexity queries): citing sources (+30-115%), concrete statistics (+40%), expert quotes (+30-40%). Apply all of them; they compound when a single claim carries a statistic, a source, and a quote at once.
+
+1. **Statistical anchors.** Every major claim should carry a concrete number, percentage, or date when one exists in the Brain context (Factual Ground, brain patterns, GEO brief, enriched brief). Prefer "cut review time 38% between Q2 and Q4 2025" over "significantly faster." Present progressions with explicit start and end points; LLMs anchor on linear progression. NEVER invent a number: if the claim needs data the Brain doesn't have, write the claim qualitatively and flag it in citationOpportunities.
+2. **Factual anchors.** Name exact tools, products, versions, dates, and locations. "Integrates via API with SAP, Salesforce, and Microsoft Dynamics 365" beats "integrates with many systems." The more specific the sentence, the more likely an AI engine uses it as an anchor. Specifics must come from the Brain context, never from your general knowledge of the brand.
+3. **Expert quotes (real ones only).** A direct quote with full attribution measurably lifts citation. Attribution format (note: comma and parentheses, never a dash): `"Quote text," said [Name], [Title] at [Organization] (Year).` ONLY quote real people: the named authors and QUOTABLE POSITIONS supplied in the context. If a section would benefit from an expert voice you cannot source from the Brain, do NOT write a quote — insert an `[SME Hook: suggested topic]` placeholder instead. A fabricated quote is a failed generation.
+4. **Definition blocks.** The first time the article's core term (or a named framework) appears, define it in a fixed, citable pattern: `[Term] is [definition]. It works by [mechanism].` Self-contained, one to two sentences, no pronouns referring outside the block. This is the snippet AI engines lift when a user asks "what is X."
+5. **Direct answer under question headings.** When a section heading is phrased as a question (and at least one body section should be), the FIRST paragraph must answer it completely in 40-55 words — the answer-engine extraction shape. Depth, nuance, and evidence come in the paragraphs after the direct answer, never before it.
+6. **Numbered steps for processes.** Any how-to or sequence should be a numbered list of 3+ concrete steps; AI engines frequently adopt numbered lists verbatim. Each step starts with an imperative verb.
+
 ## Confidence Tier Rules
 - **green** (80–100): Strong Brain pattern match. High E-E-A-T signal. Auto-approvable.
 - **yellow** (50–79): Moderate confidence. SME quote needed OR factual claim needs verification. Flag it.
@@ -72,6 +83,7 @@ Answers must be 2-4 sentences, drawn from article body (do not introduce new cla
 5. **SME hooks flagged**: Where a quote or expert voice would elevate a claim, insert a placeholder: `[SME Hook: suggested topic]`
 6. **No filler**: If a sentence doesn't earn its place from the Brain context, cut it.
 7. **Target length**: 1200–1800 words total across all sections.
+8. **Citable by construction**: apply every item in "Citability mechanics (GEO)" above — statistical anchors, factual anchors, a definition block for the core term, a 40-55 word direct answer under at least one question-form heading, numbered steps for any process.
 
 ## Human Cadence: avoid the AI tells
 
@@ -98,6 +110,7 @@ Most of these are calibration nudges, not voice rules. The brand's actual voice 
 
 ## Mistakes to Avoid
 - Never fabricate statistics. If data is missing, flag with [NEEDS CITATION].
+- Never fabricate an expert quote. Quotes come only from the named authors and QUOTABLE POSITIONS in the context; otherwise use an [SME Hook] placeholder.
 - Never use competitor brand names as anchors unless explicitly in the competitive gap map.
 - Never write a generic intro. Open with the persona's specific trigger event.
 - Never produce a section with confidence "green" if there is no Brain evidence supporting it.

--- a/src/server/routes/geo-strategist.js
+++ b/src/server/routes/geo-strategist.js
@@ -199,7 +199,12 @@ TOPICAL GAPS: ${JSON.stringify(
 )}
 WHITESPACE: ${whitespace.slice(0, 300)}
 
-For each topic gap, score citation probability 0-100 across all 4 AI platforms. quickWin=true if score >= 70 and low brand presence.
+For each topic gap, score citation probability 0-100 across all 4 AI platforms. Score each platform against what that engine actually rewards, not a uniform rubric:
+- ChatGPT: favors established authority and entity recognition (Wikipedia-grade sources dominate its citations). Score high when the topic lets the brand make authoritative, fact-dense claims in a space without an entrenched encyclopedic authority; score low where a Wikipedia-tier source already owns the answer.
+- Perplexity: favors freshness and community signal (Reddit/forum-heavy citation mix, strong recency bias). Score high for topics with recent developments, dated data, or active practitioner discussion the brand can speak to; evergreen topics dominated by old authoritative pages score low.
+- Google AI Overviews: favors E-E-A-T plus structured, schema-marked content surfaced through Google's index. Score high where the brand can demonstrate first-hand expertise on a long-tail question; score low for head terms where established domains already hold the SERP.
+- Gemini: favors brand-owned domains (over half its citations resolve to brand sites) and consistent entity presence. Score high when the topic sits squarely in the brand's own naming/products/methodology; score low for generic category topics with no brand-entity tie.
+quickWin=true if score >= 70 and low brand presence.
 
 Return ONLY a raw JSON array (no markdown, no explanation):
 [{"platform":"ChatGPT","topic":"string","score":80,"quickWin":true},{"platform":"Perplexity","topic":"string","score":70,"quickWin":false},{"platform":"Google AI Overviews","topic":"string","score":65,"quickWin":false},{"platform":"Gemini","topic":"string","score":60,"quickWin":false}]` }]


### PR DESCRIPTION
## Why
Gap analysis of the GEO pipeline against an external GEO skill (grounded in Princeton KDD 2024 — 10,000 Perplexity queries) found the two highest-measured citation levers (concrete statistics +40%, expert quotes +30–40%) were not asked for anywhere in our prompts, and Tool 2 scored all four AI platforms with a uniform rubric despite each engine rewarding different things.

## What
**`src/agents/stage4_content_generator/system_prompt.md`** — new "Citability mechanics (GEO)" section:
1. Statistical anchors (concrete numbers/dates from Brain context only; missing data → qualitative + `citationOpportunities`)
2. Factual anchors (exact tools/versions/dates, start-and-end-point progressions)
3. Expert quotes — **real people only** (Factual Ground authors / QUOTABLE POSITIONS; otherwise `[SME Hook]`), attribution adapted to comma+parentheses since the Princeton format's em dash would violate the absolute zero-em-dash rule
4. Definition blocks (`[Term] is [definition]. It works by [mechanism].`)
5. 40–55 word direct answers under question-form headings (answer-engine extraction shape)
6. Numbered steps for processes

Plus Writing Rule 8 (citable by construction) and a "never fabricate a quote" line in Mistakes to Avoid.

**`src/server/routes/geo-strategist.js`** — Tool 2 (GEO Opportunity Scorer) prompt now carries per-engine heuristics: ChatGPT → authority/entity recognition, Perplexity → freshness/community signal, AI Overviews → E-E-A-T + long-tail, Gemini → brand-owned domains/entity tie.

## Test plan
- `node --check` passes on both server.js and geo-strategist.js (prompt-string-only changes, no logic).
- Behavioral: generate one article on dev — verify a definition block, a question-H2 with a direct-answer first paragraph, and no fabricated quotes/stats; run a GEO analyze and eyeball that platform scores now diverge per topic instead of moving in lockstep.

## Rollback
Revert — both changes are additive prompt text.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_