### PR TITLE
feat(context-hub): crawl competitor sites — measured coverage grounds the whitespace

### DIFF
--- a/src/server/routes/context-hub.js
+++ b/src/server/routes/context-hub.js
@@ -545,10 +545,58 @@ Content themes in this market: ${(sonarJson.contentThemes || []).join(', ')}`;
       console.log('[Context Hub] Sonar research failed, proceeding without:', e.message);
     }
 
+    // ── Tool 1.6: Competitor site crawl (best-effort) ─────────────────────────
+    // Until now competitor URLs were passed to Claude as a bare list — the
+    // competitiveGaps/whitespace inference never saw what competitors ACTUALLY
+    // publish, only Claude's prior knowledge of them. Crawl each competitor's
+    // homepage through the same Jina→Bright Data primitive the brand crawl uses,
+    // extract their measured topic coverage with one Haiku call, and ground the
+    // profile (and downstream GEO Strategist) in observed competitor content.
+    // Best-effort: any failure degrades to the previous list-of-URLs behavior.
+    let competitorAnalysis = [];
+    try {
+      const crawlTargets = (competitorUrls.length > 0 ? competitorUrls : sonarCompetitors)
+        .filter(u => typeof u === 'string' && u.trim()).slice(0, 4);
+      if (crawlTargets.length) {
+        console.log(`[Context Hub] Tool 1.6: crawling ${crawlTargets.length} competitor site(s)...`);
+        const pages = await Promise.all(crawlTargets.map(u =>
+          getBrandPageContent(u.startsWith('http') ? u : `https://${u}`, { caller: 'context-hub-competitor' })
+            .catch(err => ({ success: false, markdown: null, error: err?.message }))
+        ));
+        const crawled = crawlTargets
+          .map((url, i) => ({ url, markdown: pages[i]?.success ? (pages[i].markdown || '') : '' }))
+          .filter(c => c.markdown.length > 300);
+        if (crawled.length) {
+          const compRes = await anthropic.messages.create({
+            model: 'claude-haiku-4-5-20251001',
+            max_tokens: 2000,
+            messages: [{ role: 'user', content: `For each competitor website below, extract what they actually publish and how they position themselves. Base your answer ONLY on the provided content — do not use prior knowledge of these companies.
+
+${crawled.map(c => `=== ${c.url} ===\n${c.markdown.slice(0, 5000)}`).join('\n\n')}
+
+Return ONLY a raw JSON array (no markdown), one object per site:
+[{"url":"string","positioning":"one sentence — what they sell and to whom, from their own copy","topicsCovered":["the content/messaging topics this site demonstrably covers — max 12"],"signatureClaims":["up to 3 specific claims or differentiators stated on the site"]}]` }]
+          });
+          const parsed = safeParseLLM(compRes.content[0].text, 'array', 'context-hub-competitors');
+          if (Array.isArray(parsed) && parsed.length) {
+            competitorAnalysis = parsed;
+            console.log(`[Context Hub] Tool 1.6: analyzed ${competitorAnalysis.length}/${crawlTargets.length} competitor site(s)`);
+          }
+        } else {
+          console.log('[Context Hub] Tool 1.6: no competitor page yielded usable content');
+        }
+      }
+    } catch(e) {
+      console.log('[Context Hub] Competitor crawl skipped:', e.message);
+    }
+
     // ── Tool 2: Claude — Brand Intelligence Profile ───────────────────────────
     console.log(`[Context Hub] Tool 2: Claude brand analysis...`);
 
     const competitorSection = sonarCompetitors.length ? `\nCompetitor URLs (auto-discovered): ${sonarCompetitors.join(', ')}` : '';
+    const competitorContentSection = competitorAnalysis.length
+      ? `\nCOMPETITOR SITE CONTENT (measured — crawled from their actual websites; ground competitiveGaps and whitespaceOpportunity in what they DEMONSTRABLY publish, not assumptions):\n${competitorAnalysis.map(c => `- ${c.url}\n  Positioning: ${c.positioning || 'n/a'}\n  Topics covered: ${(c.topicsCovered || []).join(', ') || 'n/a'}\n  Signature claims: ${(c.signatureClaims || []).join(' | ') || 'n/a'}`).join('\n')}`
+      : '';
     const icpSection = sonarICP ? `\nICP context (auto-discovered): ${sonarICP}` : '';
     const marketSection = sonarContext ? `\nMarket context: ${sonarContext}` : '';
     const audienceSection = audienceNotes ? `\nAdditional audience context: ${audienceNotes}` : '';
@@ -581,7 +629,7 @@ Content themes in this market: ${(sonarJson.contentThemes || []).join(', ')}`;
 
     const prompt = `You are the Forge Intelligence Context Agent — Stage 1 of an 8-stage Brand Intelligence platform.
 
-Analyze the brand at: ${brandUrl}${siteContentSection}${competitorSection}${icpSection}${marketSection}${audienceSection}${strategicSection}${patternSection}${mistakeSection}
+Analyze the brand at: ${brandUrl}${siteContentSection}${competitorSection}${competitorContentSection}${icpSection}${marketSection}${audienceSection}${strategicSection}${patternSection}${mistakeSection}
 
 Return ONLY valid JSON (no markdown, no explanation, no newlines inside string values — use spaces instead):
 {
@@ -663,6 +711,11 @@ Requirements: 5 toneAttributes, 2-3 personas, 4-6 thirdPartySignals, 3-5 competi
     } else if (Array.isArray(sonarCompetitors) && sonarCompetitors.length > 0) {
       profileData.discoveredCompetitors = sonarCompetitors;
     } // else: keep profileData.discoveredCompetitors as Claude derived it
+
+    // Persist the measured competitor crawl so downstream stages (GEO Strategist
+    // Tool 1, social/video arc context) can read observed coverage instead of
+    // re-deriving it from priors. Empty crawl = key absent (old shape preserved).
+    if (competitorAnalysis.length) profileData.competitorAnalysis = competitorAnalysis;
 
     const latencyMs = Date.now() - startTime;
     console.log(`[Context Hub] Complete — ${brandName} | Latency: ${latencyMs}ms | Competitors found: ${sonarCompetitors.length}`);

--- a/src/server/routes/geo-strategist.js
+++ b/src/server/routes/geo-strategist.js
@@ -184,6 +184,14 @@ Return ONLY a raw JSON array of strings. No markdown, no explanation.` }]
     } catch (e) {
       console.log('[GEO] Citation probe skipped:', e.message);
     }
+    // Measured competitor coverage from Stage 1's competitor crawl (Tool 1.6) —
+    // what competitors DEMONSTRABLY publish, vs the inferred competitorTopics.
+    const competitorAnalysis = Array.isArray(pd.competitorAnalysis) ? pd.competitorAnalysis : [];
+    const competitorCoverageBlock = competitorAnalysis.length ? `
+
+COMPETITOR SITE COVERAGE (measured — crawled from competitors' actual websites at the last brand scan; prefer this over inferred competitor knowledge):
+${competitorAnalysis.map(c => `- ${c.url}: ${c.positioning || ''}\n  Publishes on: ${(c.topicsCovered || []).slice(0, 12).join(', ') || 'n/a'}${(c.signatureClaims || []).length ? `\n  Claims: ${c.signatureClaims.join(' | ')}` : ''}`).join('\n')}` : '';
+
     // A question is "invisible" only when at least one engine answered AND none
     // cited or mentioned the brand — engine errors are not evidence of absence.
     const invisibleQuestions = citationProbe
@@ -211,9 +219,9 @@ BRAND: ${profile.brand_name} (${profile.brand_url})
 PERSONAS: ${JSON.stringify(personas).slice(0, 1500)}
 COMPETITOR TOPICS: ${JSON.stringify(competitorTopics).slice(0, 4000)}
 WHITESPACE: ${whitespace.slice(0, 2000)}
-${topicFocus ? 'FOCUS: ' + topicFocus : ''}${factualGroundBlock}${strategicMoatsBlock}${citationProbeBlock}
+${topicFocus ? 'FOCUS: ' + topicFocus : ''}${factualGroundBlock}${strategicMoatsBlock}${competitorCoverageBlock}${citationProbeBlock}
 
-Identify 8-12 topical gaps where this brand has low AI citation probability vs competitors. Topics must be consistent with the USER-VERIFIED FACTS above and must NOT fall inside the STRATEGIC MOATS (those are intentional exclusions, not opportunities).
+Identify 8-12 topical gaps where this brand has low AI citation probability vs competitors. Topics must be consistent with the USER-VERIFIED FACTS above and must NOT fall inside the STRATEGIC MOATS (those are intentional exclusions, not opportunities). When COMPETITOR SITE COVERAGE is present, ground every "owner" and gap claim in what competitors measurably publish — a topic a competitor demonstrably covers and the brand does not is a stronger gap than anything inferred.
 
 When MEASURED AI VISIBILITY is present, it outranks every inferred signal: the invisible buyer questions are the strongest gap evidence (derive topics directly from them where they fit the brand), and the "who AI cites instead" domains are the real topic owners — use the actual cited domain as the owner when you have no stronger candidate.
 


### PR DESCRIPTION
## Why
Item 2 of the five-item Tool 1 plan (items 1/3/4/5 shipped in #351). The trace showed competitor websites were **never fetched** — competitor URLs went to the Stage 1 profile prompt as a bare string list, so `competitiveGaps` and whitespace came from Claude's prior knowledge of those companies, not their actual content.

## What
**`src/server/routes/context-hub.js`** — new Tool 1.6, between Sonar discovery and the Opus profile build (best-effort):
- Crawls up to 4 competitor homepages via the existing `getBrandPageContent` (Jina → Bright Data), parallel and per-page error-isolated; pages under 300 chars of content are dropped.
- One Haiku call extracts per site: `positioning`, `topicsCovered` (max 12), `signatureClaims` (max 3) — instructed to use ONLY the crawled content, no prior knowledge.
- The Opus profile prompt gets a `COMPETITOR SITE CONTENT (measured)` block + instruction to ground `competitiveGaps`/`whitespaceOpportunity` in what competitors demonstrably publish.
- Result persists on `profile_data.competitorAnalysis`.

**`src/server/routes/geo-strategist.js`** — Tool 1 reads `competitorAnalysis` as a `COMPETITOR SITE COVERAGE` block and is instructed that measured coverage outranks inferred owners ("a topic a competitor demonstrably covers and the brand does not is a stronger gap than anything inferred").

## Failure modes
Scrape miss, Haiku failure, or no competitors → one log line, previous behavior. Profiles scanned before this ships simply lack the key (GEO block renders empty).

## Cost/latency
Stage 1 gains up to 4 parallel page fetches (15s Jina timeout each, concurrent) + 1 Haiku call — roughly +15–25s on a ~15–20s crawl, on the user-initiated analyze. Re-scans refresh the analysis automatically.

## Test plan
- `node --check` clean on context-hub.js, geo-strategist.js, server.js.
- On dev: re-analyze a brand with known competitors → expect `[Context Hub] Tool 1.6: analyzed N/M competitor site(s)` and `profile_data.competitorAnalysis` populated; then run GEO analyze and confirm the COMPETITOR SITE COVERAGE block appears and owners reference crawled domains.
- Analyze a brand with no competitors → Tool 1.6 no-ops silently.

## Rollback
Revert — additive, best-effort, no migration.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_