### PR TITLE
feat(geo): Tool 3 reads the measured data Tools 1-2 already use

### DIFF
--- a/src/server/routes/geo-strategist.js
+++ b/src/server/routes/geo-strategist.js
@@ -290,10 +290,13 @@ Return ONLY a raw JSON array (no markdown, no explanation):
       messages: [{ role: 'user', content: `You are the Entity & Schema Mapper for Forge Intelligence.
 
 BRAND: ${profile.brand_name}
-COMPETITIVE GAPS: ${JSON.stringify(competitorTopics).slice(0, 400)}
-TOP GEO OPPORTUNITIES: ${JSON.stringify(geoOpportunities.slice(0, 8))}${factualGround?.competitors?.length ? `\nVERIFIED COMPETITORS (use these, do not include entities from different companies with similar names): ${(Array.isArray(factualGround.competitors) ? factualGround.competitors : [factualGround.competitors]).slice(0, 8).join(', ')}` : ''}
+COMPETITIVE GAPS: ${JSON.stringify(competitorTopics).slice(0, 2000)}
+TOPICAL GAPS (Tool 1 — includes pillar cluster + information-gain angle per gap): ${JSON.stringify((topicalMap.gapsByCluster || []).slice(0, 10))}
+TOP GEO OPPORTUNITIES (Tool 2 per-platform scores): ${JSON.stringify(geoOpportunities.slice(0, 12))}${factualGround?.competitors?.length ? `\nVERIFIED COMPETITORS (use these, do not include entities from different companies with similar names): ${(Array.isArray(factualGround.competitors) ? factualGround.competitors : [factualGround.competitors]).slice(0, 8).join(', ')}` : ''}${competitorCoverageBlock}${citationProbeBlock}
 
 Identify entities needing structured markup for AI citation. Flag competitor entities this brand is NOT being cited for.
+
+Ground the flags in the measured data when present: the MEASURED AI VISIBILITY "who AI cites instead" domains are the sources actually being cited today — set competitorCiting:true from observed citations before inferred ones, and prioritize entities that would let the brand contest the invisible buyer questions. When COMPETITOR SITE COVERAGE is present, derive competitor entities from their measured positioning and signature claims, not prior knowledge of those companies. Prefer entities that reinforce the Tool 1 pillar clusters so the schema work compounds the same content hubs.
 
 Return ONLY valid JSON array:
 [{"entity":"string","schemaTypes":["Article"],"competitorCiting":false,"priority":"high|medium|low","rationale":"string"}]` }]


### PR DESCRIPTION
## Why
Follow-up to #351/#353: the Entity & Schema Mapper (Tool 3) was left out of the measured-data overhaul. It still truncated competitive gaps to 400 chars, never saw the citation probe (despite its core job being "flag competitor entities the brand is NOT cited for" — exactly what the probe measures), never saw crawled competitor coverage, and received only 8 of Tool 2's per-platform rows (~2 topics) with none of Tool 1's gaps.

## What (prompt-only, `src/server/routes/geo-strategist.js`)
- COMPETITIVE GAPS truncation lifted 400 → 2000 chars
- Tool 1's topical gaps passed in (top 10, including `cluster` + `informationGainAngle`)
- Tool 2 per-platform rows widened 8 → 12
- The existing `citationProbeBlock` + `competitorCoverageBlock` injected, with grounding rules: `competitorCiting` from observed who-AI-cites-instead domains before inference; competitor entities derived from measured positioning/signature claims, not prior knowledge; entity priorities aligned to the Tool 1 pillar clusters so schema work compounds the same content hubs

Output schema unchanged — downstream consumers unaffected.

## Test plan
- `node --check` clean on geo-strategist.js + server.js.
- On dev: `force: true` analyze for a brand with engine keys + a re-scanned profile — entity rationales should reference observed cited domains / crawled competitor claims rather than generic priors.

## Rollback
Revert — prompt text only.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG