### PR TITLE
feat(enricher): Stage 3 applies the research it was already fetching

### DIFF
--- a/server.js
+++ b/server.js
@@ -2935,6 +2935,47 @@ app.post('/api/authenticity-enricher/analyze', requireAuth, async (req, res) => 
       ? `\nMANUAL INPUTS PROVIDED BY USER (treat as verified, high-confidence):\n${JSON.stringify(otherInputs, null, 2)}${correctionsCtx}`
       : correctionsCtx || '';
 
+    // ── Measured + brain context blocks ──────────────────────────────────────
+    // The enricher historically loaded the brain tables and the full geo brief
+    // and then used almost none of it: brain patterns/mistakes reached zero
+    // prompts, and citationProbe / topical gaps / competitorAnalysis /
+    // strategicMoats were invisible to every tool. Build the blocks once here;
+    // Tools 2-4 inject them below. citationProbe + the raw topical gaps live on
+    // the brand-level geo_briefs row (the per-topic brief doesn't carry them),
+    // so load that row regardless of which brief path ran above. All
+    // best-effort — absent data renders as an empty block.
+    let geoMeasured = null;
+    try {
+      const gmRes = await pool.query(
+        `SELECT brief_data FROM geo_briefs WHERE brand_profile_id = $1 ORDER BY version DESC LIMIT 1`,
+        [brandProfileId]
+      );
+      geoMeasured = gmRes.rows[0]?.brief_data || null;
+    } catch(e) { /* enrichment proceeds without measured context */ }
+    const citationProbe = geoMeasured?.citationProbe || null;
+    const rawTopicalGaps = Array.isArray(geoMeasured?.topicalMap?.gapsByCluster) ? geoMeasured.topicalMap.gapsByCluster : [];
+    const briefTopicLc = String(geoBrief?.topic || geoBrief?.h1 || '').toLowerCase();
+    const matchedGap = briefTopicLc ? rawTopicalGaps.find(g => {
+      const t = String(g.topic || '').toLowerCase();
+      return t && (briefTopicLc.includes(t) || t.includes(briefTopicLc));
+    }) : null;
+
+    const probeBlock = citationProbe ? `
+MEASURED AI VISIBILITY (live engine probe — ground truth): the brand appeared in ${citationProbe.visibility}% of ${citationProbe.totalChecks} AI answers (${Object.entries(citationProbe.byEngine || {}).map(([id, v]) => `${id} ${v.available ? v.pct + '%' : 'n/a'}`).join(' · ')}). WHO AI CITES INSTEAD: ${(citationProbe.sources || []).slice(0, 8).map(s => s.domain).join(', ') || 'none captured'}. E-E-A-T injections must give this brand the citable authority those incumbent sources currently hold.` : '';
+    const topicAngleBlock = matchedGap ? `
+TOPIC ANGLE (from the topical authority map): pillar cluster "${matchedGap.cluster || 'n/a'}" — information-gain angle: ${String(matchedGap.informationGainAngle || matchedGap.rationale || '').slice(0, 300)}. Every injection should reinforce THIS unique angle, not generic authority.` : '';
+
+    const competitorAnalysisArr = Array.isArray(pd.competitorAnalysis) ? pd.competitorAnalysis : [];
+    const strategicMoatsArr = Array.isArray(pd.strategicMoats) ? pd.strategicMoats : [];
+    const competitorBlock = competitorAnalysisArr.length ? `
+COMPETITOR SITE COVERAGE (measured — crawled from their actual websites): ${competitorAnalysisArr.map(c => `${c.url}: ${c.positioning || ''}${(c.signatureClaims || []).length ? ` — claims: ${c.signatureClaims.join(' | ')}` : ''}`).join('\n')}
+Score authoritativeness and trust RELATIVE to these measured competitor claims; a gap should name the evidence that would beat them.` : '';
+    const moatsBlock = strategicMoatsArr.length ? `
+STRATEGIC MOATS (deliberate non-actions — treat as trust signals to amplify, never as gaps): ${strategicMoatsArr.map(m => m.capability).join('; ')}` : '';
+    const brainBlock = (brainPatterns.length || brainMistakes.length) ? `
+BRAIN PATTERNS (proven for this brand — reuse these angles and structures): ${JSON.stringify(brainPatterns).slice(0, 1200)}
+BRAIN MISTAKES (do NOT repeat for this brand): ${JSON.stringify(brainMistakes).slice(0, 800)}` : '';
+
     // ── Tool 1: SME Signal Scraper ────────────────────────────────────────────
     send('progress', { stage: 1, label: 'SME Signal Scraper', detail: 'Scanning for named experts, awards, certifications...' });
     console.log('[ENRICH] Tool 1: SME Signal Scraper...');
@@ -3026,8 +3067,8 @@ Return empty arrays if not found. Be factual and accurate. When in doubt, return
 
 E-E-A-T scoring task for ${brandName} (${brandUrl}).
 
-SCRAPED SIGNALS: ${JSON.stringify(sonarSignals).slice(0, 800)}
-STAGE 1 SIGNALS: ${JSON.stringify(thirdPartySignals).slice(0, 400)}${manualCtx}
+SCRAPED SIGNALS: ${JSON.stringify(sonarSignals).slice(0, 2400)}
+STAGE 1 SIGNALS: ${JSON.stringify(thirdPartySignals).slice(0, 1200)}${competitorBlock}${moatsBlock}${brainBlock}${manualCtx}
 
 Score Experience, Expertise, Authoritativeness, Trustworthiness 0-100. List gaps where score < 60. List smeSignals found.
 
@@ -3059,12 +3100,12 @@ Respond with this exact JSON structure:
       messages: [
         { role: 'user', content: `Voice & persona injection mapping task for ${brandName}. Be concise — max 4 injectionMap items, 2 hooks, 3 powerPhrases.
 
-VOICE: ${JSON.stringify(voiceProfile).slice(0, 400)}
-PERSONAS: ${JSON.stringify(personas).slice(0, 400)}
-SME SIGNALS: ${JSON.stringify(scorerData.smeSignals || []).slice(0, 400)}
-GEO TOPICS: ${geoBrief ? JSON.stringify((geoBrief.h2s || []).slice(0,4)) : '[]'}${manualCtx}
+VOICE: ${JSON.stringify(voiceProfile).slice(0, 1200)}
+PERSONAS: ${JSON.stringify(personas).slice(0, 1500)}
+SME SIGNALS: ${JSON.stringify(scorerData.smeSignals || []).slice(0, 1200)}
+GEO TOPICS: ${geoBrief ? JSON.stringify((geoBrief.h2s || []).slice(0,8)) : '[]'}${probeBlock}${topicAngleBlock}${brainBlock}${manualCtx}
 
-Map E-E-A-T signals to content sections. Generate hooks. Build author schema.
+Map E-E-A-T signals to content sections. Generate hooks. Build author schema. When MEASURED AI VISIBILITY is present, target the injections at what would make THIS brand citable where the incumbent sources are today; when a TOPIC ANGLE is present, the injections and hooks must reinforce that information-gain angle.
 
 Respond with this exact JSON structure:
 {"voiceConsistencyScore":0,"injectionMap":[{"section":"","injectionType":"sme_quote|stat|case_study|first_person_hook|customer_voice|founding_story|award_mention|certification_reference","suggestedContent":"","persona":"","eeatDimension":"experience|expertise|authoritativeness|trustworthiness","confidence":0}],"powerPhrases":[],"authorSchema":{"name":null,"title":null,"expertise":[],"credentials":[],"sameAs":[]},"contentHooks":[{"hook":"","persona":"","type":"curiosity|pain_point|stat|story|contrarian"}]}` },
@@ -3089,12 +3130,12 @@ Respond with this exact JSON structure:
       messages: [
         { role: 'user', content: `Enriched brief assembly task for ${brandName}.
 
-EEAT SCORES: ${JSON.stringify(scorerData.scores || {}).slice(0, 400)}
-INJECTIONS: ${JSON.stringify(injectionData.injectionMap || []).slice(0, 600)}
-POWER PHRASES: ${JSON.stringify(injectionData.powerPhrases || []).slice(0, 200)}
-AUTHOR SCHEMA: ${JSON.stringify(injectionData.authorSchema || {}).slice(0, 200)}
-GEO H2S: ${geoBrief ? JSON.stringify((geoBrief.h2s || []).slice(0,6)) : '[]'}
-HIGH GAPS: ${JSON.stringify(gaps.filter(g => g.severity === 'high').map(g => g.gapType))}
+EEAT SCORES: ${JSON.stringify(scorerData.scores || {}).slice(0, 1200)}
+INJECTIONS: ${JSON.stringify(injectionData.injectionMap || []).slice(0, 1600)}
+POWER PHRASES: ${JSON.stringify(injectionData.powerPhrases || []).slice(0, 400)}
+AUTHOR SCHEMA: ${JSON.stringify(injectionData.authorSchema || {}).slice(0, 400)}
+GEO H2S: ${geoBrief ? JSON.stringify((geoBrief.h2s || []).slice(0,10)) : '[]'}
+HIGH GAPS: ${JSON.stringify(gaps.filter(g => g.severity === 'high').map(g => g.gapType))}${topicAngleBlock}${brainBlock}
 
 Assemble enriched brief. Flag sections green/yellow/red by confidence. Mark smeRequired where needed.
 
@@ -8652,7 +8693,7 @@ Generate 5-7 H2s that build a coherent argument. Align entities with schema requ
 // holding. Downstream code that joins topic briefs to opportunities by ID
 // continues to work unchanged.
 app.post('/api/geo/topic-brief/from-topic', requireAuth, express.json(), async (req, res) => {
-  const { brandProfileId, topic, refinement } = req.body || {};
+  const { brandProfileId, topic, refinement, assignedAuthorId } = req.body || {};
   if (!brandProfileId) return res.status(400).json({ success: false, error: 'brandProfileId required' });
   if (!topic || !topic.trim()) return res.status(400).json({ success: false, error: 'topic required' });
 
@@ -8682,6 +8723,23 @@ app.post('/api/geo/topic-brief/from-topic', requireAuth, express.json(), async (
       fg.methodology && `Methodology: ${fg.methodology.slice(0, 400)}`
     ].filter(Boolean).join('\n\n');
 
+    // Author assignment — same contract as the batch build-briefs path: resolve
+    // assignedAuthorId from factualGround.authors and embed the snapshot in
+    // brief_data so downstream stages (enricher author override, content-gen
+    // byline) read it from one place. Lookup miss = no author, never an error.
+    const ftAuthors = Array.isArray(fg.authors) ? fg.authors : [];
+    const ftAssignedAuthor = (assignedAuthorId && typeof assignedAuthorId === 'string')
+      ? (ftAuthors.find(a => a && a.id === assignedAuthorId) || null)
+      : null;
+    const ftAuthorContext = ftAssignedAuthor
+      ? `ASSIGNED SME AUTHOR (build the brief from this person's vantage; their expertise should shape the angle):\n` +
+        `  Name: ${ftAssignedAuthor.name || ''}\n` +
+        `  Title: ${ftAssignedAuthor.title || ''}\n` +
+        `  Expertise: ${ftAssignedAuthor.expertise || ''}\n` +
+        `  Credentials: ${ftAssignedAuthor.credentials || ''}\n` +
+        (ftAssignedAuthor.bio ? `  Background: ${String(ftAssignedAuthor.bio).slice(0, 600)}\n` : '') + '\n'
+      : '';
+
     // 1) Materialize a synthetic opportunity row so the FK on geo_topic_briefs
     //    holds. Source is implicit (no quick_win, no platform_scores, no TAC)
     //    — downstream readers treat it as a hand-entered topic.
@@ -8706,7 +8764,7 @@ BRAND: ${profile.brand_name}
 VOICE: ${JSON.stringify(voiceProfile).slice(0, 400)}
 PERSONAS: ${JSON.stringify(personas).slice(0, 400)}
 
-${factualContext ? 'FACTUAL GROUND (use verbatim):\n' + factualContext + '\n\n' : ''}${brainContext}
+${factualContext ? 'FACTUAL GROUND (use verbatim):\n' + factualContext + '\n\n' : ''}${ftAuthorContext}${brainContext}
 
 TOPIC THE USER ENTERED: "${topic.trim()}"
 ${refinement && refinement.trim() ? `USER REFINEMENT / ANGLE NOTES: "${refinement.trim()}"\n` : ''}
@@ -8745,11 +8803,13 @@ Generate 5-7 H2s that build a coherent argument. Align entities with schema requ
       };
     }
 
-    // 3) Persist the brief
+    // 3) Persist the brief (author snapshot embedded when one was assigned —
+    //    same shape as the batch build-briefs path)
+    const briefDataToPersist = ftAssignedAuthor ? { ...briefData, assignedAuthor: { ...ftAssignedAuthor } } : briefData;
     const briefInsert = await pool.query(
       `INSERT INTO geo_topic_briefs (opportunity_id, brand_profile_id, brief_data, brain_version, status)
        VALUES ($1, $2, $3, $4, 'briefed') RETURNING id, created_at`,
-      [opportunityId, brandProfileId, JSON.stringify(briefData), profile.version || 1]
+      [opportunityId, brandProfileId, JSON.stringify(briefDataToPersist), profile.version || 1]
     );
 
     res.json({


### PR DESCRIPTION
## Why
Stage 3 trace verdict: the Authenticity Enricher loaded the brain tables and the full geo brief, then applied almost none of it. Brain patterns/mistakes reached **zero prompts** (the README's Brain-First claim was false for Stage 3); `citationProbe` and the topical gaps were spread into `geoBrief` and ignored; `competitorAnalysis` and `strategicMoats` were never loaded; and the E-E-A-T Confidence Scorer judged authenticity from **1,200 characters of evidence total** (sonarSignals 800 + thirdPartySignals 400).

## What (all in `/api/authenticity-enricher/analyze` + the from-topic brief route)
**New context blocks** (built once after manualCtx, all best-effort — absent data renders empty):
- `probeBlock` — MEASURED AI VISIBILITY: visibility %, per-engine rates, who-AI-cites-instead. Loaded from the brand-level `geo_briefs` row since the per-topic brief doesn't carry it.
- `topicAngleBlock` — the topical gap matching this brief's topic: pillar `cluster` + `informationGainAngle`.
- `competitorBlock` — #353's crawled competitor positioning/signature claims, with "score authoritativeness RELATIVE to these" instruction.
- `moatsBlock` — strategic moats framed as trust signals, never gaps.
- `brainBlock` — the already-loaded patterns + mistakes, finally injected.

**Per tool:**
- Tool 2 scorer: + competitor/moats/brain; `sonarSignals` 800→2400, `thirdPartySignals` 400→1200
- Tool 3 injection mapper: + probe/topic-angle/brain with targeting instructions (injections aim at what would make the brand citable where incumbents are; hooks reinforce the info-gain angle); voice 400→1200, personas 400→1500, smeSignals 400→1200, h2s 4→8
- Tool 4 assembler: + topic-angle/brain; eeat 400→1200, injections 600→1600, power phrases/author schema 200→400, h2s 6→10

**Item 5:** `POST /api/geo/topic-brief/from-topic` now accepts `assignedAuthorId` and embeds the author snapshot in `brief_data` — same contract as the batch build-briefs path, which the enricher's author override (server.js:3234) already reads. (Note: the batch path was NOT broken — verified `briefDataWithAuthor` at 8597 flows through; only this route lacked it.)

## Test plan
- `node --check server.js` clean.
- On dev: run an enrichment for a topic brief on a brand with a fresh GEO analyze — expect injections referencing who-AI-cites-instead domains and the topic's info-gain angle; E-E-A-T gaps naming competitor claims to beat.
- Brand with no probe/crawl data → blocks render empty, behavior identical to before.

## Rollback
Revert — prompt context + one additive request field; no schema migration.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG