### PR TITLE
feat(pipeline): Stage 4 writer, Compliance, and Precog read the measured layer

### DIFF
--- a/server.js
+++ b/server.js
@@ -3849,19 +3849,29 @@ app.get('/api/content-generator/generate', requireAuth, async (req, res) => {
       const s = JSON.stringify(obj, null, 2);
       return s.length > maxChars ? s.substring(0, maxChars) + '\n...[truncated for token budget]' : s;
     };
-    // Load Topical Authority Map — strategic context for where this content lives
+    // Load Topical Authority Map — strategic context for where this content lives.
+    // Also extract the MEASURED layer off the same row (citationProbe lives on the
+    // brand-level geo_briefs brief_data) — previously it sat inside the JSONB the
+    // 4000-char trimTo could randomly truncate away, so the writer never reliably
+    // saw who AI actually cites or where the brand is invisible.
     let topicalTerritories = [];
+    let cgCitationProbe = null;
     try {
       const gbRes = await pool.query(
         `SELECT brief_data FROM geo_briefs WHERE brand_profile_id = $1 ORDER BY created_at DESC LIMIT 1`,
         [brandProfileId]
       );
-      const topicalMapRaw = gbRes.rows[0]?.brief_data?.topicalAuthorityMap || gbRes.rows[0]?.brief_data?.topicalMap?.gapsByCluster || [];
+      cgCitationProbe = gbRes.rows[0]?.brief_data?.citationProbe || null;
+      // Prefer the RAW gaps (they carry cluster + informationGainAngle); the
+      // normalized topicalAuthorityMap drops both.
+      const topicalMapRaw = gbRes.rows[0]?.brief_data?.topicalMap?.gapsByCluster || gbRes.rows[0]?.brief_data?.topicalAuthorityMap || [];
       topicalTerritories = topicalMapRaw
         .map(t => ({
           topic: t.topic || t.cluster || t.name,
           coverage: (t.coverage || t.rationale || t.description || '').slice(0, 140),
-          priority: t.priority || (t.citationProbability >= 70 ? 'high' : t.citationProbability >= 40 ? 'medium' : 'low')
+          cluster: t.cluster || null,
+          angle: (t.informationGainAngle || '').slice(0, 160),
+          priority: t.priority || (t.geoCitationScore >= 70 || t.citationProbability >= 70 ? 'high' : t.geoCitationScore >= 40 || t.citationProbability >= 40 ? 'medium' : 'low')
         }))
         .filter(t => t.topic)
         .sort((a, b) => (a.priority === 'high' ? -1 : b.priority === 'high' ? 1 : 0))
@@ -3869,7 +3879,19 @@ app.get('/api/content-generator/generate', requireAuth, async (req, res) => {
     } catch(e) { /* silent — non-fatal */ }
 
     const territoriesBlock = topicalTerritories.length
-      ? `\nSTRATEGIC TERRITORIES THIS BRAND OPERATES IN (write as an authority in these territories — never drift outside them):\n${topicalTerritories.map(t => `  • [${t.priority}] ${t.topic}${t.coverage ? ' — ' + t.coverage : ''}`).join('\n')}\n`
+      ? `\nSTRATEGIC TERRITORIES THIS BRAND OPERATES IN (write as an authority in these territories — never drift outside them):\n${topicalTerritories.map(t => `  • [${t.priority}]${t.cluster ? ` (${t.cluster})` : ''} ${t.topic}${t.coverage ? ' — ' + t.coverage : ''}${t.angle ? `\n    Information-gain angle (the unique claim THIS brand makes here — the article must deliver it): ${t.angle}` : ''}`).join('\n')}\n`
+      : '';
+
+    const cgMeasuredBlock = cgCitationProbe
+      ? `\nMEASURED AI VISIBILITY (live engine probe — this is the gap the article exists to close): the brand appeared in ${cgCitationProbe.visibility}% of ${cgCitationProbe.totalChecks} AI answers (${Object.entries(cgCitationProbe.byEngine || {}).map(([id, v]) => `${id} ${v.available ? v.pct + '%' : 'n/a'}`).join(' · ')}). WHO AI CITES INSTEAD: ${(cgCitationProbe.sources || []).slice(0, 8).map(s => s.domain).join(', ') || 'none captured'}. Write the piece those incumbent sources would have to cite — more specific, better evidenced, more extractable than what they publish.\n`
+      : '';
+    const cgCompetitors = Array.isArray(profileData?.competitorAnalysis) ? profileData.competitorAnalysis : [];
+    const cgCompetitorBlock = cgCompetitors.length
+      ? `\nCOMPETITOR SITE COVERAGE (measured — crawled from their actual websites): ${cgCompetitors.map(c => `${c.url}: ${c.positioning || ''}${(c.signatureClaims || []).length ? ` — claims: ${c.signatureClaims.join(' | ')}` : ''}`).join('\n')}\nDo not echo their claims; write what they demonstrably cannot say.\n`
+      : '';
+    const cgMoats = Array.isArray(profileData?.strategicMoats) ? profileData.strategicMoats : [];
+    const cgMoatsBlock = cgMoats.length
+      ? `\nSTRATEGIC MOATS (deliberate non-actions — reference as trust signals where natural, never as weaknesses): ${cgMoats.map(m => m.capability).join('; ')}\n`
       : '';
 
     // Load Factual Ground — user-verified facts the writer MUST use verbatim
@@ -3933,7 +3955,7 @@ ${(() => {
       : '';
 
         const userPrompt = `Generate a long-form article using the following Brand Intelligence context.
-${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${territoriesBlock}
+${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${territoriesBlock}${cgMeasuredBlock}${cgCompetitorBlock}${cgMoatsBlock}
 BRAND PROFILE:
 ${trimTo(profileData, 6000)}
 

--- a/src/server/routes/compliance.js
+++ b/src/server/routes/compliance.js
@@ -284,6 +284,21 @@ router.post('/critique', async (req, res) => {
     const mistakesRes = await pool.query(`SELECT * FROM brain_mistakes WHERE brand_profile_id = $1 ORDER BY created_at DESC LIMIT 20`, [brandProfileId]).catch(() => ({ rows: [] }));
     const mistakes = mistakesRes.rows;
 
+    // Factual Ground — the user-verified facts. Without this the critique judged
+    // factual claims in total isolation: it could neither clear a claim the brand
+    // owner already verified (false-positive factual_claim flags on true facts)
+    // nor catch a claim that CONTRADICTS what the owner stated. Both directions
+    // matter; contradiction is the severe one.
+    const fg = brand?.settings?.factualGround || null;
+    const fgBlock = fg && Object.values(fg).some(v => v && (typeof v === 'string' ? v.trim() : (Array.isArray(v) && v.length)))
+      ? `\nUSER-VERIFIED FACTS (stated by the brand owner — authoritative ground truth):
+${fg.whatWeDo ? `- What this brand does: ${String(fg.whatWeDo).slice(0, 500)}\n` : ''}${fg.whatWeDontDo ? `- What this brand does NOT do: ${String(fg.whatWeDontDo).slice(0, 500)}\n` : ''}${fg.companyFacts ? `- Company facts: ${String(fg.companyFacts).slice(0, 500)}\n` : ''}${fg.foundingStory ? `- Founding story: ${String(fg.foundingStory).slice(0, 400)}\n` : ''}${fg.methodology ? `- Methodology/frameworks: ${String(fg.methodology).slice(0, 400)}\n` : ''}${Array.isArray(fg.authors) && fg.authors.length ? `- Named team: ${fg.authors.map(a => `${a.name || ''}${a.title ? ` (${a.title})` : ''}`).filter(Boolean).join(', ')}\n` : ''}
+How to use these facts:
+- A claim in the article that MATCHES or is directly supported by these facts is VERIFIED — do not flag it as an unverifiable factual_claim.
+- A claim that CONTRADICTS these facts (wrong founder, wrong methodology, claims the brand does something listed under "does NOT do") is a RED factual_claim flag — quote the contradicting excerpt and name the verified fact it violates.
+- These facts are context for judging claims, NOT article content — the flaggedExcerpt rule is unchanged: every excerpt must still be a verbatim quote from the article section being flagged.`
+      : '';
+
     const systemPrompt = `You are a compliance and brand voice auditor for the brand "${brand?.brand_name || 'Unknown'}". Analyze this article against the brand profile and known mistakes. Return a JSON compliance report.
 
 The article was written for the brand "${brand?.brand_name || 'Unknown'}" (${brand?.brand_url || 'no URL'}). Do NOT flag brand name usage that correctly references this brand.
@@ -298,7 +313,7 @@ CRITICAL RULES:
 
 Brand Voice Profile:
 ${JSON.stringify(brand?.profile_data?.voice_profile || {}, null, 2)}
-
+${fgBlock}
 Known Mistakes to Avoid:
 ${mistakes.map(m => `- ${m.mistake_type}: ${m.human_feedback}`).join('\n') || 'None recorded yet'}
 

--- a/src/server/routes/precog.js
+++ b/src/server/routes/precog.js
@@ -95,11 +95,17 @@ router.post('/score', async (req, res) => {
       positioningPatterns = pcRes.rows;
     } catch(e) { /* best-effort */ }
     try {
-      // Match on topic OR derived keywords from intent_signals.
+      // Match on topic OR derived keywords from intent_signals. Two candidate
+      // classes: strategic_injection rows (the original signal) AND GEO
+      // Strategist opportunities the user actually selected/briefed — those are
+      // human-validated whitespace bets and previously never matched this
+      // dimension at all (their intent_signals.source is unset), so articles
+      // written off the cherry-pick flow scored 0 here by construction.
       const goRes = await pool.query(`
-        SELECT topic, intent_signals->>'source' as source, intent_signals->>'deliverable' as deliverable, avg_score
+        SELECT topic, intent_signals->>'source' as source, intent_signals->>'deliverable' as deliverable, avg_score, status
         FROM geo_opportunities
-        WHERE brand_profile_id = $1 AND intent_signals->>'source' LIKE 'strategic_injection%'
+        WHERE brand_profile_id = $1
+          AND (intent_signals->>'source' LIKE 'strategic_injection%' OR status IN ('selected', 'briefed'))
       `, [brandProfileId]);
       strategicInjectionTopics = goRes.rows;
     } catch(e) { /* best-effort */ }
@@ -318,7 +324,7 @@ router.post('/score', async (req, res) => {
         bestMatch = { count: matches.length, density };
         const isPillar = (opp.deliverable || '').includes('pillar');
         geoOppScore = isPillar ? 7 : 5;
-        matchedOpportunity = { topic: opp.topic, deliverable: opp.deliverable, source: opp.source, matchCount: matches.length, density: density.toFixed(2) };
+        matchedOpportunity = { topic: opp.topic, deliverable: opp.deliverable, source: opp.source || (opp.status ? `strategist_${opp.status}` : null), matchCount: matches.length, density: density.toFixed(2) };
       }
     }
     breakdown.geoOpportunityMatch = {


### PR DESCRIPTION
## Why
Continuing the stage-by-stage audit (Stages 2-3 fixed in #351/#353/#359/#361). The downstream trace found three more consumers blind to upstream research: the writer never saw the measured competitive baseline, Compliance judged factual claims with no ground truth, and Precog's geo-match dimension structurally excluded every cherry-picked Strategist topic.

## What
**Stage 4 Content Generator** (`server.js` generate route)
- `citationProbe` sat inside the `trimTo(geoBrief, 4000)` JSONB where character truncation could randomly eat it; `competitorAnalysis`/`strategicMoats` were never extracted at all. Three explicit prompt blocks now: **MEASURED AI VISIBILITY** ("write the piece the incumbent sources would have to cite"), **COMPETITOR SITE COVERAGE** ("write what they demonstrably cannot say"), **STRATEGIC MOATS** (trust signals, never weaknesses).
- `territoriesBlock` now prefers the RAW topical gaps (the normalized map drops the new fields) and renders each territory's pillar **cluster** + **information-gain angle** with "the article must deliver it".

**Compliance Gate `/critique`** (`compliance.js`)
- Factual Ground injected as ground truth, two-way: claims matching user-verified facts are VERIFIED (kills false-positive `factual_claim` flags on true statements); claims CONTRADICTING them are RED flags naming the violated fact. The verbatim-excerpt and section-isolation rules are explicitly restated as unchanged.

**Precog** (`precog.js`)
- Strategic Geo Opportunity Match only queried `strategic_injection%` rows — Strategist-discovered, user-cherry-picked topics scored 0 by construction. Candidates now include `status IN ('selected','briefed')` opportunities. **Same 0-7 scale, same thresholds — no score re-basing**, so `precog_outcomes` accuracy history stays comparable.

## Deliberately NOT done (needs your call)
A measured-visibility dimension in Precog (anchor predictions on `citationProbe`/`geo_citations` ground truth) would change the 0-100 scale and break accuracy-history comparability — flagged as a proposal, not shipped.

## Test plan
- `node --check` clean on all three files.
- Dev: generate an article on a probed+crawled brand → expect the three new blocks in the prompt context and territory lines carrying cluster/angle; run compliance on an article containing a Factual-Ground-verified claim → no factual_claim flag; precog-score an article written from a cherry-picked topic → geoOpportunityMatch > 0 with source `strategist_briefed`.

## Rollback
Revert — prompt context + one widened SELECT; no migrations.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG