### PR TITLE
feat(precog): shadow measured-visibility dimension (phase 1, score-neutral)

### DIFF
--- a/src/server/routes/precog.js
+++ b/src/server/routes/precog.js
@@ -358,6 +358,54 @@ router.post('/score', async (req, res) => {
     };
     score += whitespaceScore;
 
+    // ───── L. SHADOW: Measured Visibility (0-10, NOT added to score) ─────
+    // Phase 1 of the measured-visibility rollout. Computes a candidate dimension
+    // from the GEO citation probe (live engine ground truth) and stores it in
+    // the breakdown WITHOUT touching the 0-100 score — so the headline number
+    // and the precog_outcomes accuracy history stay on the v2 model while every
+    // scored article accumulates the shadow signal. Promotion to a live
+    // dimension is a deliberate v3.0 re-base once outcomes prove it predictive.
+    let shadowVisibility = null;
+    try {
+      const probeRes = await pool.query(
+        `SELECT brief_data->'citationProbe' as probe FROM geo_briefs WHERE brand_profile_id = $1 ORDER BY version DESC LIMIT 1`,
+        [brandProfileId]
+      );
+      const probe = probeRes.rows[0]?.probe || null;
+      if (probe && typeof probe.visibility === 'number') {
+        // Invisible questions: at least one engine answered, none cited/mentioned.
+        const invisibleQuestions = (probe.perQuestion || []).filter(r => {
+          const checked = Object.values(r.engines || {}).filter(s => s !== 'error');
+          return checked.length > 0 && !checked.some(s => s === 'cited' || s === 'mentioned');
+        }).map(r => (r.question || '').toLowerCase());
+
+        // Does this article target a question the brand is measurably invisible on?
+        const articleText = `${titleLower} ${bodyText}`;
+        let bestOverlap = 0;
+        for (const q of invisibleQuestions) {
+          const qKeywords = q.split(/\W+/).filter(w => w.length > 4 && !STOPWORDS.has(w));
+          if (!qKeywords.length) continue;
+          const matches = qKeywords.filter(k => articleText.includes(k)).length;
+          if (matches > bestOverlap) bestOverlap = matches;
+        }
+        const invisibleQuestionOverlap = bestOverlap >= 3 ? 5 : bestOverlap >= 2 ? 3 : 0;
+        const brandVisibilityGap = probe.visibility < 20 ? 3 : probe.visibility < 40 ? 2 : probe.visibility < 60 ? 1 : 0;
+        const validatedWhitespaceWithProbe = matchedOpportunity ? 2 : 0;
+        shadowVisibility = {
+          score: invisibleQuestionOverlap + brandVisibilityGap + validatedWhitespaceWithProbe,
+          max: 10,
+          shadow: true,
+          includedInScore: false,
+          model: 'measured-visibility-v1',
+          components: { invisibleQuestionOverlap, brandVisibilityGap, validatedWhitespaceWithProbe },
+          probeVisibility: probe.visibility,
+          invisibleQuestionCount: invisibleQuestions.length,
+          enginesProbed: probe.enginesProbed || []
+        };
+      }
+    } catch(e) { /* best-effort — shadow dimension never blocks scoring */ }
+    if (shadowVisibility) breakdown.measuredVisibilityShadow = shadowVisibility;
+
     // Normalize to 0-100
     score = Math.max(0, Math.min(100, score));
 


### PR DESCRIPTION
## Why
Phase 1 of the agreed gradual rollout: Precog needs a measured-visibility signal (anchored on the citation probe's ground truth), but bolting it into the 0–100 score would re-base every prediction and break `precog_outcomes` accuracy-history comparability. So it ships **score-neutral**: computed and stored on every scored article, counted in nothing.

## What (`src/server/routes/precog.js`)
New shadow dimension `breakdown.measuredVisibilityShadow` (0–10, `includedInScore: false`, `model: 'measured-visibility-v1'`):
- **invisibleQuestionOverlap (0–5)** — article title+body keywords vs the probe's buyer questions where the brand was invisible on every responding engine (≥2 distinctive matches → 3, ≥3 → 5)
- **brandVisibilityGap (0–3)** — measured brand visibility <20% → 3, <40% → 2, <60% → 1
- **validatedWhitespaceWithProbe (0–2)** — the existing geo-opportunity match co-occurring with a probe

Loaded best-effort from the brand-level `geo_briefs.brief_data.citationProbe`; brands without a probe simply get no shadow key. The 0–100 score, tiers, and persistence are byte-identical to v2.

## The plan this enables
- **Phase 2** (no code yet): correlate shadow scores against `precog_outcomes` + the weekly `geo_citations` tracker results — does shadow-high actually get cited more?
- **Phase 3** (only if phase 2 says yes): promote to a live dimension as an explicit v3.0 scoring model with a `model_version` stamp so v2/v3 outcomes are never cross-compared.

## Test plan
- `node --check` clean.
- Dev: precog-score any article on a probed brand → `precog_breakdown.measuredVisibilityShadow` present with components; total score identical to a pre-PR run. Un-probed brand → key absent, score identical.

## Rollback
Revert — additive breakdown key, zero scoring impact by construction.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_