### PR TITLE
docs: session wrap — SYSOI reel + DataReel hardening (#347)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4409,3 +4409,42 @@ Isolated and scanned all 4 recurring bug patterns across the entire codebase:
 1. "The Bottleneck Isn't Production. It's Intelligence." — 1,696 words, 100% auto-approved
 2. "Is Your Content Team Actually AI Ready? The Five-Dimension Framework" — 2,250 words, 88% confidence, 1 factual claim CYA flag
 
+
+---
+
+## 2026-06-12 — SYSOI product reel + DataReel template hardening (PR #347)
+
+Brian asked for a 60s SYSOI product video built with the Forge DataReel tooling (not the
+product-video-creation skill). Rendered locally in-sandbox (`npx remotion render` against
+`remotion/src/index.ts`, no Lambda) — the local round-trip exposed and closed real template gaps:
+
+**Template (remotion/src):**
+- `ScreensScene.motion: "static" | "dynamic"` — opt-in motion for product screenshots: 3D
+  perspective fly-in, one hard 6-frame punch-in zoom per shot that then HOLDS (a cut, not a
+  drift — Ken Burns stays dead per #344), slide-over spring transitions between shots. A
+  sheen-sweep shipped in round 1 and was cut in Brian's review ("diminishes the product").
+- `ScreensScene.shotAspect` — viewport takes the capture's native aspect ratio. SYSOI's
+  dashboard captures are 2940×1414 (≈2.08:1); the hardcoded 16:9 cover-crop cut both edges.
+  Dynamic cards widened to 1640 with a brand-accent outer glow + amber-tinted border.
+- `brand.wordmark` — full lockup image replaces the typed brand name (Stage corner + CTA).
+- `assetSrc()` — bare filenames for `shots`/`logo`/`music.src` resolve via `staticFile()`;
+  full https URLs pass through, so the Lambda/S3 backend path is byte-identical.
+- `onAccent` palette key (default #FFFFFF) — replaces six hardcoded white-on-accent spots;
+  light accents (SYSOI amber #F5B454) set a dark ink (#1A1208).
+- `PipelineView` — fixed-size rounded squares (labels clipped) → auto-width glowing pills;
+  the highlighted stage glows strongest.
+
+**Production pipeline lessons:**
+- ElevenLabs via the Composio toolkit when the raw key isn't in the env. mp3_44100_128 is
+  CBR → exact clip seconds = bytes/16000 (Forge backend's own trick) → scene
+  `durationInFrames` = VO frames + tail, no overlap, no measurement pass.
+- Original CC0 music authored in node (`scripts/sysoi-music.mjs`, 122 BPM, four-on-floor,
+  sidechain pump) — zero licensing surface, regenerates from source.
+- "No audio" reports against rendered mp4s: probe before re-encoding. `@ffmpeg-installer/ffmpeg`
+  (binaries ship inside the npm package — works without system ffmpeg) + volumedetect proved
+  the track was healthy (max −6.8 dB); the chat inline player just mutes.
+- Portrait was free: `orientation: "portrait"` re-rendered 9:16 with zero layout edits.
+
+**Artifacts:** PR #347 (draft → development) carries the template changes + the reproducible
+SYSOI example (props + shots + VO mp3s; renders and the generated wav gitignored). Both mp4s
+delivered to Brian (approved); not yet committed to any repo.

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,6 +10,28 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-12 (cont. 2) — SYSOI product reel · DataReel round-trip hardening (#347, merged)
+
+Built the 60s SYSOI product video **with DataReel rendered locally** (no Lambda), which forced template gaps closed — **#347 merged to `development`**:
+
+- **`ScreensScene.motion: "static" | "dynamic"`** — default unchanged (static, per #344's no-Ken-Burns rule). `dynamic` = 3D fly-in, one hard 6-frame punch-in per shot that holds, slide-over spring transitions. Brian's review killed an earlier sheen-sweep ("diminishes the product").
+- **`ScreensScene.shotAspect`** — viewport matches the capture's native ratio (SYSOI captures are 2940×1414 ≈ 2.08:1; the hardcoded 16:9 cropped both edges). Dynamic card: wider (1640) + brand-accent outer glow.
+- **`brand.wordmark`** — full lockup image replaces the TYPED brand name in the Stage corner + CTA title (system font butchers custom wordmarks).
+- **`assetSrc()`** — `shots`/`logo`/`music.src` accept bare filenames via `staticFile()` (audio's convention); https URLs pass through, Lambda path untouched.
+- **`onAccent` palette key** — dark-ink text on light accents (SYSOI amber); replaces hardcoded white on CTA button / statement / pipeline highlight / orbit core / steps / checklist.
+- **PipelineView** — rounded squares → auto-width pills with accent outer glow (the squares clipped their labels).
+- **VO via Composio ElevenLabs** (key wasn't in the SYSOI session env): Charlie/`verse`, stability 0.35 / style 0.6, mp3_44100_128 → exact seconds = bytes/16000. **Music**: `scripts/sysoi-music.mjs`, original CC0 driving bed (122 BPM, sidechained).
+- `sysoi-reel.props.json` + `public/shots`/`audio` committed = reproducible example. Rendered both cuts (16:9 1907f/63.6s + 9:16 portrait — zero layout changes needed); Brian approved. Renders gitignored (`remotion/.gitignore`: `out/`, generated wav).
+- **Audio-silent false alarm**: the mp4's AAC track was healthy (max −6.8 dB via `@ffmpeg-installer/ffmpeg` volumedetect — npm-packaged binary, no system ffmpeg); chat inline preview plays muted.
+
+#### What's next
+- **Redeploy `forge-reels`** so Lambda picks up #347's template changes (same footgun as #334/#344 — see the deploy warning below).
+- Decide where the rendered mp4s live (SYSOI repo `marketing/`?) — currently container-only.
+- Backend storyboard agent doesn't emit `motion`/`shotAspect`/`wordmark` yet — wire when a productized reel should use them.
+- Stale remote branch `feat/datareel-dynamic-screens` was accidentally recreated by a post-merge docs push (this branch supersedes it) — delete it.
+
+---
+
 ### 2026-06-12 (cont.) — GEO overhaul: measured whitespace, not priors
 
 All merged to `development`. Sprung from a gap analysis against an external GEO skill (Princeton KDD 2024) + a depth trace of the competitive-intel pipeline (verdict: whitespace was pure LLM inference over 700 chars of cached Stage 1 data; competitor sites never crawled; geoProbe unused by the Strategist).


### PR DESCRIPTION
## Why
Session-wrap docs for the SYSOI reel / DataReel hardening work (#347, merged). #347 merged while the docs were being written, so they land separately here, rebased onto current `development` and reconciled with today's other session blocks (GEO overhaul, env-group incident).

## What
- `WORKING-STATE.md`: new top block — 2026-06-12 (cont. 2), #347 marked merged; next steps = redeploy `forge-reels`, decide where the rendered mp4s live, wire `motion`/`shotAspect`/`wordmark` into the storyboard agent, delete the stale resurrected `feat/datareel-dynamic-screens` branch.
- `PLAN.md`: archive entry with the full template-change list + production-pipeline lessons (Composio ElevenLabs path, CBR-bytes duration trick, npm-packaged ffmpeg for audio probing, free portrait re-render).

## Note
The remote branch `feat/datareel-dynamic-screens` was accidentally recreated by a docs push after the merge — it's superseded by this PR and safe to delete.

https://claude.ai/code/session_014jDcELL1Di39aep1Fook7x