### PR TITLE
chore(ui): stage 1-3 copy + progress stages catch up to the measured pipeline

### DIFF
--- a/src/components/views/ActiveRun.tsx
+++ b/src/components/views/ActiveRun.tsx
@@ -42,6 +42,7 @@ const stageMessages: Record<string, string[]> = {
   ],
   scrape: [
     'Crawling primary site content...',
+    'Crawling competitor websites...',
     'Analyzing competitor positioning...',
     'Extracting voice patterns...'
   ],

--- a/src/components/views/NewAnalysis.tsx
+++ b/src/components/views/NewAnalysis.tsx
@@ -65,7 +65,7 @@ export function NewAnalysis() {
         <div className="geo-eyebrow">Stage 1</div>
         <h2 className="view-title">Generate Brand Intelligence</h2>
         <p className="view-description">
-          Drop in a URL. Forge discovers competitors, maps your ICP, and builds a full Brand Intelligence Profile — automatically.
+          Drop in a URL. Forge discovers competitors, crawls their sites to see what they actually publish, maps your ICP, and builds a full Brand Intelligence Profile — automatically.
         </p>
       </div>
 

--- a/src/pages/AuthenticityEnricherPage.tsx
+++ b/src/pages/AuthenticityEnricherPage.tsx
@@ -349,7 +349,7 @@ function AuthenticityEnricherContent() {
           <div className="geo-eyebrow">Stage 3</div>
           <h1 className="geo-title">Authenticity Enricher</h1>
           <p className="geo-description">
-            Injects E-E-A-T signals, SME credentials, and voice-matched hooks to make content AI-citation ready.
+            Injects E-E-A-T signals, SME credentials, and voice-matched hooks — grounded in measured AI visibility, crawled competitor claims, and your Brain's learned patterns — to make content AI-citation ready.
           </p>
         </div>
         {result && (

--- a/src/pages/GeoStrategistPage.tsx
+++ b/src/pages/GeoStrategistPage.tsx
@@ -69,10 +69,11 @@ const icons = {
 
 const STAGES = [
   { id: 1, label: 'Reading Brain', sub: 'Patterns, mistakes, memories' },
-  { id: 2, label: 'Topical Authority Map', sub: 'Mapping content gaps + citation probability' },
-  { id: 3, label: 'GEO Opportunity Scoring', sub: 'ChatGPT · Perplexity · AI Overviews · Gemini' },
-  { id: 4, label: 'Entity & Schema Map', sub: 'Structured markup + competitor entity gaps' },
-  { id: 5, label: 'Generating GEO Brief', sub: 'H1/H2 · FAQ · GEO anchors · opportunity score' },
+  { id: 2, label: 'Live Citation Probe', sub: 'Asking the real engines — measured AI visibility' },
+  { id: 3, label: 'Topical Authority Map', sub: 'Measured whitespace · pillar clusters · information-gain angles' },
+  { id: 4, label: 'GEO Opportunity Scoring', sub: 'ChatGPT · Perplexity · AI Overviews · Gemini' },
+  { id: 5, label: 'Entity & Schema Map', sub: 'Structured markup + competitor entity gaps' },
+  { id: 6, label: 'Generating GEO Brief', sub: 'H1/H2 · FAQ · GEO anchors · opportunity score' },
 ];
 
 function GeoStrategistContent() {
@@ -309,19 +310,22 @@ function GeoStrategistContent() {
       body: JSON.stringify({ brandProfileId: selectedBrainId, force: shouldForce })
     });
 
-    const timings = [5000, 12000, 15000, 10000];
+    // Display pacing only (the real work is the fetch). The probe stage gets the
+    // longest slot — it genuinely runs 8 buyer questions across up to 4 live
+    // engines, which is most of the wall-clock since #351.
+    const timings = [5000, 45000, 15000, 12000, 10000];
     for (let i = 0; i < timings.length; i++) {
       setCurrentStage(i + 1);
       await new Promise(r => setTimeout(r, timings[i]));
       setCompletedStages(prev => [...prev, i + 1]);
     }
-    setCurrentStage(5);
+    setCurrentStage(6);
 
     try {
       const res = await analyzePromise;
       const data = await res.json();
       if (!data.success) throw new Error(data.error || 'Analysis failed');
-      setCompletedStages([1,2,3,4,5]);
+      setCompletedStages([1,2,3,4,5,6]);
       setCurrentStage(0);
       console.log('[GEO DEBUG] topicalAuthorityMap[0]:', JSON.stringify(data.data?.topicalAuthorityMap?.[0]));
       console.log('[GEO DEBUG] geoOpportunities[0]:', JSON.stringify(data.data?.geoOpportunities?.[0]));
@@ -342,7 +346,7 @@ function GeoStrategistContent() {
           <div className="geo-eyebrow">Stage 2</div>
           <h2 className="geo-title">GEO Strategist</h2>
           <p className="geo-description">
-            Maps topical authority gaps, scores GEO citation opportunities across AI platforms, and generates a structured brief ready for Stage 3.
+            Probes the live AI engines to measure who actually gets cited today, maps topical authority gaps grounded in that evidence (plus crawled competitor coverage), scores opportunities per platform, and builds briefs from the topics you cherry-pick.
           </p>
         </div>
         {result && (


### PR DESCRIPTION
## Why
Audit of stage 1–3 UI copy against today's measured-pipeline work. Most copy was merely stale, but one surface was actively misleading: the GEO Strategist's progress display is timer-paced (42s of staged progress), and since #351 the real run spends its longest stretch in the live citation probe — so the UI parked on "Generating GEO Brief" for a minute-plus of probing.

## What (copy + display pacing only, no behavior)
**Stage 1**
- `NewAnalysis` description: now mentions crawling competitor sites to see what they actually publish (#353).
- `ActiveRun` scrape stage: new "Crawling competitor websites..." activity line (the existing "Analyzing competitor positioning..." line was aspirational before #353 — now it's literal).

**Stage 2 (`GeoStrategistPage`)**
- Header: "Probes the live AI engines to measure who actually gets cited today, maps topical authority gaps grounded in that evidence (plus crawled competitor coverage), scores opportunities per platform, and builds briefs from the topics you cherry-pick."
- Progress stages: new **"Live Citation Probe — asking the real engines"** step with the longest display slot (45s), so the progress bar tracks where the wall-clock actually goes; Topical Authority sub updated to "Measured whitespace · pillar clusters · information-gain angles". Stage ids renumbered 1–6 (timer pacing + completion array updated to match).

**Stage 3 (`AuthenticityEnricherPage`)**
- Header: enrichment "grounded in measured AI visibility, crawled competitor claims, and your Brain's learned patterns" (#361).

Checked and left alone: the SME-author tooltip (still accurate, now also true for from-topic briefs per #361), the cherry-pick section subs, the Enricher tool-step labels (they mirror the server's SSE progress labels), and the dynamic gap tooltips (server-generated).

## Test plan
`npx tsc --noEmit` clean. Visual: run a GEO analyze on dev — progress should sit in "Live Citation Probe" during the long stretch and complete all 6 stages on finish.

## Rollback
Revert — copy + display pacing only.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_