### PR TITLE
chore(seo): sitemap catches /scan + the articles library indexes

### DIFF
--- a/server.js
+++ b/server.js
@@ -7473,8 +7473,10 @@ app.get('/sitemap.xml', async (req, res) => {
   const urls = [
     { loc: 'https://forgeintelligence.ai/',               priority: '1.0',  changefreq: 'weekly',  lastmod: now },
     { loc: 'https://forgeintelligence.ai/product',        priority: '0.9',  changefreq: 'weekly',  lastmod: now },
+    { loc: 'https://forgeintelligence.ai/scan',           priority: '0.8',  changefreq: 'monthly', lastmod: now },
     { loc: 'https://forgeintelligence.ai/about',          priority: '0.85', changefreq: 'monthly', lastmod: now },
     { loc: 'https://forgeintelligence.ai/faq',            priority: '0.85', changefreq: 'monthly', lastmod: now },
+    { loc: 'https://forgeintelligence.ai/articles',       priority: '0.8',  changefreq: 'weekly',  lastmod: now },
     { loc: 'https://forgeintelligence.ai/docs',           priority: '0.7',  changefreq: 'monthly', lastmod: now },
     { loc: 'https://forgeintelligence.ai/privacy',        priority: '0.3',  changefreq: 'yearly',  lastmod: now },
     { loc: 'https://forgeintelligence.ai/terms',          priority: '0.3',  changefreq: 'yearly',  lastmod: now },
@@ -7505,6 +7507,9 @@ app.get('/sitemap.xml', async (req, res) => {
       // Mismatch causes Google Search Console to flag "Duplicate without user-selected canonical"
       // because the published/shared URLs and the sitemap point at different paths.
       const brandSlug = (brand.brand_url || brand.brand_name || 'brand').replace(/https?:\/\//, '').replace(/[^a-z0-9]/gi, '-').toLowerCase().replace(/^-+|-+$/g, '');
+      // The brand's article-library index — article details were in the sitemap
+      // but their listing page wasn't.
+      urls.push({ loc: `https://forgeintelligence.ai/articles/${brandSlug}`, priority: '0.75', changefreq: 'weekly', lastmod: now });
       const articlesRes = await pool.query(
         `SELECT title, created_at, updated_at FROM generated_content_${safeId} WHERE compliance_status IN ('approved', 'ready') ORDER BY created_at DESC LIMIT 500`
       ).catch(() => ({ rows: [] }));


### PR DESCRIPTION
## Why
"Refresh the sitemap" — it's request-time generated (1-hour cache), so the XML itself can't go stale, but its **hand-maintained static list** had drifted from `src/main.tsx`'s actual public routes.

## What (`server.js` `/sitemap.xml`)
- **`/scan` added** (priority 0.8) — the public AI Visibility Scan lead magnet was never in the sitemap; it's the highest-intent public page after `/product`.
- **`/articles` + `/articles/<brand-slug>` added** — every article *detail* URL was listed but neither library index was; crawlers had the leaves, not the branches.
- Verified in sync: `docSlugs` matches `src/docs/index.ts` (`my-website` only); gated/tokenized routes (`/welcome`, `/review/:token`, `/app/*`) correctly excluded.

## After merge + promotion to main
The sitemap serves the new URLs automatically (prod-hostname gated, so it takes effect on the **main** deploy, not dev). Optional follow-up: hit `POST /api/admin/indexnow/backfill` (ADMIN_RELAY_PASSWORD-gated) to push the new URLs to Bing/Yandex immediately rather than waiting for the next crawl.

## Test plan
- `node --check` clean.
- Post-promotion: `curl https://forgeintelligence.ai/sitemap.xml` → contains `/scan`, `/articles`, `/articles/forgeintelligence-ai`, all doc + article URLs.

## Rollback
Revert — three URL entries.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_