### PR TITLE
feat(security): audit log subsystem — Settings → Audit Log (#25)

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ import { forgeScrape, getBrandPageContent, discoverSubpages, _forgeScrapeRateLim
 import { anthropic, dateContext } from './src/server/llm.js';
 import { CITATION_ENGINES, isCited, findCitedSection, urlHasDomain, coldScan, extractDomain } from './src/server/geoProbe.js';
 import { installLogCapture, logBuffer, logSSEClients, errorAggregates } from './src/server/logging.js';
+import { recordAudit } from './src/server/audit.js';
 import {
   LOVABLE_UUID_RE, LOVABLE_URL_SAFE_LIMIT, LOVABLE_MAX_PROMPT_CHARS, LOVABLE_SUPPORTED_APP_TYPES,
   lovableSafeJoin, lovableHasData, lovableFormatVoice, lovableFormatPersonas, lovableFormatWhitespace,
@@ -6344,6 +6345,8 @@ app.post('/api/admin/seed-brain', async (req, res) => {
     });
     const contextData = await contextRes.json().catch(() => ({}));
 
+    recordAudit({ req, actorLabel: 'admin-relay-password', action: 'brand.seed', targetType: 'brand', targetId: brandProfileId, brandProfileId,
+      summary: `Seeded brand ${brandName || url}`, metadata: { url } });
     res.json({
       success: true,
       brandProfileId,
@@ -7410,6 +7413,8 @@ app.post('/api/admin/reset-brand-paid', async (req, res) => {
       `DELETE FROM promo_redemptions WHERE brand_profile_id = $1`,
       [brandProfileId]
     );
+    recordAudit({ req, actorLabel: 'admin-relay-password', action: 'brand.reset_paid', targetType: 'brand', targetId: brandProfileId, brandProfileId,
+      summary: 'Brand reset to free tier + promo redemptions cleared' });
     res.json({ success: true, message: 'Brand reset to free tier + promo redemptions cleared' });
   } catch(e) {
     res.status(500).json({ error: e.message });
@@ -8033,8 +8038,64 @@ app.post('/api/admin/relay', express.json({ limit: '500kb' }), async (req, res) 
   }
   try {
     const result = await pool.query(query, values || []);
+    recordAudit({ req, actorLabel: 'admin-relay-password', action: 'relay.query', targetType: 'relay',
+      summary: `Relay query (${result.rowCount} rows)`, metadata: { sqlPreview: String(query || '').slice(0, 500), rowCount: result.rowCount } });
     return res.json({ success: true, rows: result.rows, rowCount: result.rowCount });
   } catch(e) {
+    recordAudit({ req, actorLabel: 'admin-relay-password', action: 'relay.query', targetType: 'relay',
+      summary: `Relay query FAILED`, metadata: { sqlPreview: String(query || '').slice(0, 500), error: e.message } });
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
+// ── Audit Log (Settings → Audit Log) ──────────────────────────────────────────
+// Super-admin-only read + CSV export of the security/GDPR evidence trail.
+// Strict gate (the logs/stream pattern), never the client-only MC hide.
+app.get('/api/admin/audit-log', requireAuth, async (req, res) => {
+  if (!SUPER_ADMIN_IDS.includes(req.userId)) return res.status(403).json({ error: 'Forbidden' });
+  try {
+    const { actor, action, targetType, brandProfileId, from, to, format } = req.query;
+    const limit = Math.min(parseInt(req.query.limit) || 100, 500);
+    const offset = parseInt(req.query.offset) || 0;
+    const where = []; const params = []; let i = 1;
+    if (actor) { where.push(`(actor_clerk_user_id = $${i} OR actor_email = $${i})`); params.push(actor); i++; }
+    if (action) { where.push(`action = $${i}`); params.push(action); i++; }
+    if (targetType) { where.push(`target_type = $${i}`); params.push(targetType); i++; }
+    if (brandProfileId) { where.push(`brand_profile_id = $${i}`); params.push(brandProfileId); i++; }
+    if (from) { where.push(`created_at >= $${i}`); params.push(from); i++; }
+    if (to) { where.push(`created_at <= $${i}`); params.push(to); i++; }
+    const wh = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    if (format === 'csv') {
+      const cols = ['created_at','actor_clerk_user_id','actor_email','action','target_type','target_id','brand_profile_id','summary','ip'];
+      const r = await pool.query(`SELECT ${cols.join(', ')} FROM audit_log ${wh} ORDER BY created_at DESC LIMIT 5000`, params);
+      const esc = (v) => { const s = v == null ? '' : String(v); return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s; };
+      const csv = [cols.join(',')].concat(r.rows.map(row => cols.map(c => esc(row[c])).join(','))).join('\n');
+      // Exporting the audit log is itself an audited event.
+      recordAudit({ req, action: 'audit_log.export', targetType: 'audit_log',
+        summary: `Exported ${r.rows.length} audit rows (CSV)`, metadata: { filters: { actor, action, targetType, brandProfileId, from, to }, rowCount: r.rows.length } });
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="audit-log-${new Date().toISOString().slice(0, 10)}.csv"`);
+      return res.send(csv);
+    }
+
+    const [rowsRes, countRes] = await Promise.all([
+      pool.query(`SELECT * FROM audit_log ${wh} ORDER BY created_at DESC LIMIT $${i} OFFSET $${i + 1}`, [...params, limit, offset]),
+      pool.query(`SELECT COUNT(*)::int AS n FROM audit_log ${wh}`, params),
+    ]);
+    res.json({ success: true, rows: rowsRes.rows, total: countRes.rows[0].n, limit, offset });
+  } catch (e) {
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
+// GET /api/admin/audit-log/actions — distinct action vocab for the filter dropdown.
+app.get('/api/admin/audit-log/actions', requireAuth, async (req, res) => {
+  if (!SUPER_ADMIN_IDS.includes(req.userId)) return res.status(403).json({ error: 'Forbidden' });
+  try {
+    const r = await pool.query(`SELECT DISTINCT action FROM audit_log ORDER BY action`);
+    res.json({ success: true, actions: r.rows.map(x => x.action) });
+  } catch (e) {
     res.status(500).json({ success: false, error: e.message });
   }
 });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -229,6 +229,7 @@ const settingsNavItems = [
   { id: 'brand-settings', label: 'Brand Settings', icon: 'settings', href: '/app/brand-settings' },
   { id: 'integrations',   label: 'Integrations',   icon: 'plug',     href: '/app/integrations' },
   { id: 'admin',          label: 'Mission Control', icon: 'cpu',     href: '/app/mc' },
+  { id: 'audit-log',      label: 'Audit Log',       icon: 'fileText', href: '/app/audit-log' },
 ] as const;
 
 const topNavItems: TopNavItem[] = [
@@ -565,7 +566,7 @@ export function Sidebar() {
               </button>
               {!sidebarCollapsed && settingsGroupOpen && (
                 <div className="nav-group-children">
-                  {settingsNavItems.filter(c => c.id !== 'admin' || isSuperAdmin).map(child => {
+                  {settingsNavItems.filter(c => !['admin', 'audit-log'].includes(c.id) || isSuperAdmin).map(child => {
                     const childActive = path.startsWith(child.href);
                     return (
                       <a

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,6 +27,7 @@ import BrandSettingsPage from './pages/BrandSettingsPage';
 import ContentLibraryPage from './pages/ContentLibraryPage';
 import ContentImportPage from './pages/ContentImportPage';
 import AdminPage from './pages/AdminPage';
+import AuditLogPage from './pages/AuditLogPage';
 import TopicQueuePage from './pages/TopicQueuePage';
 import ReviewPage from './pages/ReviewPage';
 import PrivacyPage from './pages/PrivacyPage';
@@ -150,6 +151,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/app/content-library" element={<AppProvider><ContentLibraryPage /></AppProvider>} />
         <Route path="/app/content-import" element={<AppProvider><ContentImportPage /></AppProvider>} />
         <Route path="/app/mc" element={<AppProvider><AdminPage /></AppProvider>} />
+        <Route path="/app/audit-log" element={<AppProvider><AuditLogPage /></AppProvider>} />
         <Route path="/app/topic-queue" element={<AppProvider><TopicQueuePage /></AppProvider>} />
         <Route path="/app/brand-settings" element={<AppProvider><BrandSettingsPage /></AppProvider>} />
 

--- a/src/pages/AuditLogPage.tsx
+++ b/src/pages/AuditLogPage.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import { AppShell } from '../layouts/AppShell';
+
+// Settings → Audit Log. Super-admin-only read + CSV export of the security /
+// GDPR evidence trail (issue #25). Server enforces the super-admin gate; this
+// page is also hidden from the nav for non-super-admins.
+
+interface AuditRow {
+  id: string;
+  actor_clerk_user_id: string | null;
+  actor_email: string | null;
+  action: string;
+  target_type: string | null;
+  target_id: string | null;
+  brand_profile_id: string | null;
+  summary: string | null;
+  metadata: Record<string, unknown> | null;
+  ip: string | null;
+  created_at: string;
+}
+
+const PAGE = 100;
+
+export default function AuditLogPage() {
+  const { getToken } = useAuth();
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [actions, setActions] = useState<string[]>([]);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  // filters
+  const [fAction, setFAction] = useState('');
+  const [fActor, setFActor] = useState('');
+  const [fFrom, setFFrom] = useState('');
+  const [fTo, setFTo] = useState('');
+
+  const qs = useCallback((extra: Record<string, string> = {}) => {
+    const p = new URLSearchParams();
+    if (fAction) p.set('action', fAction);
+    if (fActor) p.set('actor', fActor.trim());
+    if (fFrom) p.set('from', fFrom);
+    if (fTo) p.set('to', fTo);
+    Object.entries(extra).forEach(([k, v]) => p.set(k, v));
+    return p.toString();
+  }, [fAction, fActor, fFrom, fTo]);
+
+  const load = useCallback(async (off: number) => {
+    setLoading(true); setError('');
+    try {
+      const token = await getToken();
+      const r = await fetch(`/api/admin/audit-log?${qs({ limit: String(PAGE), offset: String(off) })}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d.error || `HTTP ${r.status}`);
+      setRows(d.rows); setTotal(d.total); setOffset(off);
+    } catch (e) { setError(e instanceof Error ? e.message : 'Load failed'); }
+    setLoading(false);
+  }, [getToken, qs]);
+
+  useEffect(() => {
+    (async () => {
+      const token = await getToken();
+      try {
+        const r = await fetch('/api/admin/audit-log/actions', { headers: { Authorization: `Bearer ${token}` } });
+        const d = await r.json();
+        if (d.success) setActions(d.actions || []);
+      } catch { /* non-fatal */ }
+    })();
+    load(0);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const exportCsv = async () => {
+    const token = await getToken();
+    const r = await fetch(`/api/admin/audit-log?${qs({ format: 'csv' })}`, { headers: { Authorization: `Bearer ${token}` } });
+    const blob = await r.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+  };
+
+  const fmt = (iso: string) => new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  const S: Record<string, React.CSSProperties> = {
+    page: { padding: '24px 28px', maxWidth: 1200, margin: '0 auto', color: '#0F172A' },
+    bar: { display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end', margin: '16px 0 20px' },
+    field: { display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#64748B' },
+    input: { padding: '7px 10px', border: '1px solid #E2E8F0', borderRadius: 8, fontSize: 13, color: '#0F172A', background: '#fff' },
+    btn: { padding: '8px 16px', borderRadius: 8, border: '1px solid #3563FF', background: '#3563FF', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer' },
+    btnGhost: { padding: '8px 16px', borderRadius: 8, border: '1px solid #E2E8F0', background: '#fff', color: '#0F172A', fontSize: 13, fontWeight: 600, cursor: 'pointer' },
+    table: { width: '100%', borderCollapse: 'collapse', fontSize: 13 },
+    th: { textAlign: 'left', padding: '8px 10px', borderBottom: '2px solid #E2E8F0', color: '#64748B', fontWeight: 600, whiteSpace: 'nowrap' },
+    td: { padding: '8px 10px', borderBottom: '1px solid #F1F5F9', verticalAlign: 'top' },
+    chip: { fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#3563FF', fontWeight: 600 },
+    meta: { fontFamily: 'JetBrains Mono, monospace', fontSize: 11, background: '#F8FAFC', padding: 10, borderRadius: 6, whiteSpace: 'pre-wrap', wordBreak: 'break-all', margin: '6px 0 0' },
+  };
+
+  return (
+    <AppShell pageTitle="Audit Log">
+      <div style={S.page}>
+        <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.1em', color: '#3563FF' }}>SECURITY · GDPR</div>
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: '4px 0 2px' }}>Audit Log</h1>
+        <p style={{ color: '#64748B', fontSize: 14, margin: 0 }}>Privileged + data-access events. {total.toLocaleString()} total.</p>
+
+        <div style={S.bar}>
+          <label style={S.field}>Action
+            <select style={S.input} value={fAction} onChange={e => setFAction(e.target.value)}>
+              <option value="">All</option>
+              {actions.map(a => <option key={a} value={a}>{a}</option>)}
+            </select>
+          </label>
+          <label style={S.field}>Actor (clerk id or label)
+            <input style={S.input} value={fActor} onChange={e => setFActor(e.target.value)} placeholder="user_… / admin-relay-password" />
+          </label>
+          <label style={S.field}>From
+            <input style={S.input} type="date" value={fFrom} onChange={e => setFFrom(e.target.value)} />
+          </label>
+          <label style={S.field}>To
+            <input style={S.input} type="date" value={fTo} onChange={e => setFTo(e.target.value)} />
+          </label>
+          <button style={S.btn} onClick={() => load(0)}>Apply</button>
+          <button style={S.btnGhost} onClick={() => { setFAction(''); setFActor(''); setFFrom(''); setFTo(''); setTimeout(() => load(0), 0); }}>Clear</button>
+          <button style={{ ...S.btnGhost, marginLeft: 'auto' }} onClick={exportCsv}>Export CSV</button>
+        </div>
+
+        {error && <div style={{ color: '#DC2626', fontSize: 13, marginBottom: 12 }}>Error: {error}</div>}
+
+        <table style={S.table}>
+          <thead><tr>
+            <th style={S.th}>Time</th><th style={S.th}>Actor</th><th style={S.th}>Action</th>
+            <th style={S.th}>Target</th><th style={S.th}>Summary</th>
+          </tr></thead>
+          <tbody>
+            {rows.map(row => (
+              <tr key={row.id} onClick={() => setExpanded(expanded === row.id ? null : row.id)} style={{ cursor: 'pointer' }}>
+                <td style={{ ...S.td, whiteSpace: 'nowrap', color: '#64748B' }}>{fmt(row.created_at)}</td>
+                <td style={{ ...S.td, fontFamily: 'JetBrains Mono, monospace', fontSize: 11 }}>{row.actor_email || row.actor_clerk_user_id || '—'}</td>
+                <td style={S.td}><span style={S.chip}>{row.action}</span></td>
+                <td style={{ ...S.td, color: '#475569' }}>{row.target_type || ''}{row.target_id ? ` · ${row.target_id.slice(0, 12)}` : ''}</td>
+                <td style={S.td}>
+                  {row.summary || ''}
+                  {expanded === row.id && (
+                    <pre style={S.meta}>{JSON.stringify({ id: row.id, brand_profile_id: row.brand_profile_id, ip: row.ip, metadata: row.metadata }, null, 2)}</pre>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {!loading && rows.length === 0 && (
+              <tr><td style={{ ...S.td, color: '#94A3B8', textAlign: 'center', padding: 32 }} colSpan={5}>No audit events match these filters.</td></tr>
+            )}
+          </tbody>
+        </table>
+
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginTop: 16 }}>
+          <button style={S.btnGhost} disabled={offset === 0 || loading} onClick={() => load(Math.max(0, offset - PAGE))}>← Prev</button>
+          <span style={{ fontSize: 13, color: '#64748B' }}>
+            {total === 0 ? '0' : `${offset + 1}–${Math.min(offset + PAGE, total)}`} of {total.toLocaleString()}
+          </span>
+          <button style={S.btnGhost} disabled={offset + PAGE >= total || loading} onClick={() => load(offset + PAGE)}>Next →</button>
+          {loading && <span style={{ fontSize: 13, color: '#94A3B8' }}>Loading…</span>}
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/src/server/audit.js
+++ b/src/server/audit.js
@@ -1,0 +1,57 @@
+// Audit log — the security / GDPR evidence trail (issue #25 substrate).
+//
+// Records privileged + PII-touching actions: admin relay queries, brand
+// mutations, data exports, and — as they land — DSAR export/delete. Surfaced
+// read-only at Settings → Audit Log (super-admin only).
+//
+// recordAudit() is BEST-EFFORT: it never throws and never blocks the request it
+// is logging, the same discipline as raiseAnomaly / `void notifyX(...)`. A
+// logging outage must never break the action being logged.
+//
+// The table IS the evidence, so it is NEVER auto-purged — the boot-time
+// orphan-data purge that hits brain tables must not touch audit_log. If a
+// retention cap is ever wanted it is a deliberate, years-scale, separate job.
+import { pool } from './db.js';
+
+let ensured = false;
+
+export async function ensureAuditLogTable() {
+  if (ensured) return;
+  try {
+    await pool.query(`CREATE TABLE IF NOT EXISTS audit_log (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      actor_clerk_user_id TEXT,         -- JWT sub; null for password-gated/system actions
+      actor_email TEXT,                 -- best-effort label (no users table in Forge)
+      action TEXT NOT NULL,             -- e.g. 'relay.query', 'brand.reset_paid', 'audit_log.export'
+      target_type TEXT,                 -- 'brand' | 'relay' | 'audit_log' | ...
+      target_id TEXT,                   -- plain text, no FK (survives target deletion)
+      brand_profile_id TEXT,            -- scope when brand-specific; null = platform-level
+      summary TEXT,                     -- human-readable one-liner for the UI row
+      metadata JSONB DEFAULT '{}',
+      ip TEXT,
+      user_agent TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_log(created_at DESC)`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_audit_actor   ON audit_log(actor_clerk_user_id, created_at DESC)`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_audit_brand   ON audit_log(brand_profile_id, created_at DESC)`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_audit_action  ON audit_log(action, created_at DESC)`);
+    ensured = true;
+  } catch (e) { console.error('[AUDIT] table init:', e.message); }
+}
+ensureAuditLogTable();
+
+// Record one audit event. Pass `req` for actor/ip/user-agent capture; pass an
+// explicit `actorLabel` for password-gated routes that carry no JWT actor.
+export async function recordAudit({ req = null, actorLabel = null, action, targetType = null, targetId = null, brandProfileId = null, summary = null, metadata = {} }) {
+  try {
+    if (!ensured) await ensureAuditLogTable();
+    const ip = req ? (req.headers?.['x-forwarded-for'] || req.ip || null) : null;
+    const ua = req ? (req.headers?.['user-agent'] || null) : null;
+    await pool.query(
+      `INSERT INTO audit_log (actor_clerk_user_id, actor_email, action, target_type, target_id, brand_profile_id, summary, metadata, ip, user_agent)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+      [req?.userId || null, actorLabel || null, action, targetType, targetId, brandProfileId, summary, JSON.stringify(metadata || {}), ip, ua]
+    );
+  } catch (e) { console.error('[AUDIT] write:', e.message); }
+}

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -10,6 +10,8 @@
   "GET /${INDEXNOW_KEY}.txt",
   "GET /api/admin/activity",
   "GET /api/admin/api-keys",
+  "GET /api/admin/audit-log",
+  "GET /api/admin/audit-log/actions",
   "GET /api/admin/deploys",
   "GET /api/admin/facebook/diag",
   "GET /api/admin/logs/errors",


### PR DESCRIPTION
## Why
Sub-issue #1 of #25, and the substrate for everything else in it: DSAR export/delete and consent all write into this. Built to the spec in `SECURITY-COMPLIANCE.md`.

## Backend
- **`src/server/audit.js`** — `audit_log` table (self-creating + idempotent on import, like `ensureSocialPostsTable`; **never auto-purged** — it's the evidence) and `recordAudit()`, a best-effort writer that never throws and never blocks the action it logs (the `raiseAnomaly` / `void notifyX` discipline). `actor_clerk_user_id` is the source of truth (no `users` table in Forge); password-gated routes pass an explicit `actorLabel`.
- **`GET /api/admin/audit-log`** — filters (`action`, `actor`, `targetType`, `brandProfileId`, `from`, `to`), offset pagination (≤500/page), and **`?format=csv`** (up to 5000 rows, honors filters) → the compliance evidence artifact. **`.../audit-log/actions`** returns the distinct-action vocab for the filter dropdown. Both **strict super-admin gated** (the `logs/stream` pattern — not the client-only MC hide). The CSV export writes its own `audit_log.export` row (exporting the log is auditable).
- **v1 write seams** (the privileged/mutating password-gated routes): `relay.query` (success + failure, with SQL preview), `brand.reset_paid`, `brand.seed`.

## Frontend
- **`src/pages/AuditLogPage.tsx`** at `/app/audit-log` — filter bar (action dropdown + actor + date range), table with row-click metadata expand, **Export CSV** (token-fetch → Blob download), Prev/Next pagination. Reuses `AdminPage`'s `getToken`/`AppShell` pattern; action rendered as mono-text chip per the design convention.
- **Settings nav** — `Audit Log` item, gated on `isSuperAdmin` alongside Mission Control (filter widened from `c.id !== 'admin'` to `['admin','audit-log'].includes(c.id)`).

## Deliberately deferred (noted, not built)
- **Read-view logging** (e.g. every MC dashboard load) — high noise, low signal; v1 logs mutations + raw-DB access + exports, which is what an auditor reads.
- **DSAR seams** — those endpoints don't exist yet (sub-issue #2); they'll call `recordAudit` when built.

## Test plan
- `npx tsc --noEmit` clean; **197/197 vitest pass**; route snapshot regenerated (+2 routes, nothing else).
- Dev: as super-admin, Settings → Audit Log lists events; run a relay query → a `relay.query` row appears; Export CSV downloads + self-logs; non-super-admin gets 403 on the API and no nav item.

## Rollback
Revert — new module/page/routes + nav item; the `audit_log` table is additive and harmless if orphaned.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_