### PR TITLE
feat(gdpr): DSAR access/export/erase — Settings → Data Requests (#25)

### DIFF
--- a/server.js
+++ b/server.js
@@ -8100,6 +8100,122 @@ app.get('/api/admin/audit-log/actions', requireAuth, async (req, res) => {
   }
 });
 
+// ── DSAR — Data Subject Access / Erasure (GDPR Art. 15/17/20, issue #25) ──────
+// Super-admin-operated for now (not self-service). Covers Forge's reachable
+// third-party-PII surface: reviewers (email+name), support_tickets (email), and
+// Factual Ground authors (name/linkedin, JSONB on brand_profiles). Names buried
+// in free text (competitorAnalysis, personas, article bodies) are NOT
+// key-erasable and are returned as a manual-review note rather than silently
+// missed. Every call writes to the audit log (DSAR is the first real writer).
+const DSAR_UNREACHED_NOTE = 'Free-text surfaces (competitor analysis, personas, generated article bodies) are not key-searchable and require manual review if the subject may appear there.';
+
+async function dsarFind(email, name) {
+  const e = (email || '').trim().toLowerCase();
+  const n = (name || '').trim().toLowerCase();
+  const out = { reviewers: [], supportTickets: [], factualGroundAuthors: [] };
+
+  if (e || n) {
+    const rv = await pool.query(
+      `SELECT id, brand_profile_id, name, email, title, created_at FROM reviewers
+       WHERE ($1 <> '' AND lower(email) = $1) OR ($2 <> '' AND lower(name) = $2)`,
+      [e, n]
+    ).catch(() => ({ rows: [] }));
+    out.reviewers = rv.rows;
+  }
+  if (e) {
+    const st = await pool.query(
+      `SELECT id, brand_profile_id, user_email, subject, status, created_at FROM support_tickets WHERE lower(user_email) = $1`,
+      [e]
+    ).catch(() => ({ rows: [] }));
+    out.supportTickets = st.rows;
+  }
+  // Factual Ground authors: scan brands with an authors array, match by name or linkedin.
+  const br = await pool.query(
+    `SELECT id, brand_name, settings->'factualGround'->'authors' AS authors
+     FROM brand_profiles WHERE jsonb_typeof(settings->'factualGround'->'authors') = 'array'`
+  ).catch(() => ({ rows: [] }));
+  for (const row of br.rows) {
+    const authors = Array.isArray(row.authors) ? row.authors : [];
+    const matches = authors.filter(a =>
+      (n && (a.name || '').trim().toLowerCase() === n) ||
+      (e && (a.linkedinUrl || '').toLowerCase().includes(e)) // rare, but check
+    );
+    if (matches.length) out.factualGroundAuthors.push({ brand_profile_id: row.id, brand_name: row.brand_name, matches });
+  }
+  return out;
+}
+
+app.post('/api/admin/dsar/lookup', requireAuth, express.json(), async (req, res) => {
+  if (!SUPER_ADMIN_IDS.includes(req.userId)) return res.status(403).json({ error: 'Forbidden' });
+  const { email, name } = req.body || {};
+  if (!email && !name) return res.status(400).json({ error: 'email or name required' });
+  try {
+    const found = await dsarFind(email, name);
+    const counts = {
+      reviewers: found.reviewers.length,
+      supportTickets: found.supportTickets.length,
+      factualGroundAuthors: found.factualGroundAuthors.reduce((s, b) => s + b.matches.length, 0),
+    };
+    recordAudit({ req, action: 'dsar.access', targetType: 'person', targetId: (email || name),
+      summary: `DSAR lookup — ${counts.reviewers} reviewer(s), ${counts.supportTickets} ticket(s), ${counts.factualGroundAuthors} author(s)`,
+      metadata: { email: email || null, name: name || null, counts } });
+    res.json({ success: true, subject: { email: email || null, name: name || null }, counts, data: found, note: DSAR_UNREACHED_NOTE });
+  } catch (e) { res.status(500).json({ success: false, error: e.message }); }
+});
+
+app.post('/api/admin/dsar/erase', requireAuth, express.json(), async (req, res) => {
+  if (!SUPER_ADMIN_IDS.includes(req.userId)) return res.status(403).json({ error: 'Forbidden' });
+  const { email, name, confirm } = req.body || {};
+  if (!email && !name) return res.status(400).json({ error: 'email or name required' });
+  if (confirm !== true) return res.status(400).json({ error: 'confirm:true required (run lookup first)' });
+  const e = (email || '').trim().toLowerCase();
+  const n = (name || '').trim().toLowerCase();
+  try {
+    const result = { reviewersDeleted: 0, supportTicketsRedacted: 0, authorsRemoved: 0, brandsTouched: [] };
+
+    const rv = await pool.query(
+      `DELETE FROM reviewers WHERE ($1 <> '' AND lower(email) = $1) OR ($2 <> '' AND lower(name) = $2) RETURNING id`,
+      [e, n]
+    );
+    result.reviewersDeleted = rv.rowCount;
+
+    if (e) {
+      const st = await pool.query(
+        `UPDATE support_tickets SET user_email = NULL, subject = '[erased per DSAR]', body = '[erased per DSAR]'
+         WHERE lower(user_email) = $1 RETURNING id`,
+        [e]
+      );
+      result.supportTicketsRedacted = st.rowCount;
+    }
+
+    // Remove matching authors from each brand's factualGround.authors JSONB.
+    const br = await pool.query(
+      `SELECT id, settings->'factualGround'->'authors' AS authors
+       FROM brand_profiles WHERE jsonb_typeof(settings->'factualGround'->'authors') = 'array'`
+    );
+    for (const row of br.rows) {
+      const authors = Array.isArray(row.authors) ? row.authors : [];
+      const kept = authors.filter(a => !(
+        (n && (a.name || '').trim().toLowerCase() === n) ||
+        (e && (a.linkedinUrl || '').toLowerCase().includes(e))
+      ));
+      if (kept.length !== authors.length) {
+        await pool.query(
+          `UPDATE brand_profiles SET settings = jsonb_set(settings, '{factualGround,authors}', $2::jsonb), updated_at = NOW() WHERE id = $1`,
+          [row.id, JSON.stringify(kept)]
+        );
+        result.authorsRemoved += (authors.length - kept.length);
+        result.brandsTouched.push(row.id);
+      }
+    }
+
+    recordAudit({ req, action: 'dsar.erase', targetType: 'person', targetId: (email || name),
+      summary: `DSAR erasure — ${result.reviewersDeleted} reviewer(s) deleted, ${result.supportTicketsRedacted} ticket(s) redacted, ${result.authorsRemoved} author(s) removed`,
+      metadata: { email: email || null, name: name || null, result } });
+    res.json({ success: true, subject: { email: email || null, name: name || null }, result, note: DSAR_UNREACHED_NOTE });
+  } catch (e2) { res.status(500).json({ success: false, error: e2.message }); }
+});
+
 // ── Zernio Test Endpoints (dev-only) ──────────────────────────────────────────
 // Three diagnostic endpoints that exercise the Zernio social media API with
 // per-stage signal. Reject on production host so we can't accidentally fire

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -230,6 +230,7 @@ const settingsNavItems = [
   { id: 'integrations',   label: 'Integrations',   icon: 'plug',     href: '/app/integrations' },
   { id: 'admin',          label: 'Mission Control', icon: 'cpu',     href: '/app/mc' },
   { id: 'audit-log',      label: 'Audit Log',       icon: 'fileText', href: '/app/audit-log' },
+  { id: 'data-requests',  label: 'Data Requests',   icon: 'shieldCheck', href: '/app/data-requests' },
 ] as const;
 
 const topNavItems: TopNavItem[] = [
@@ -566,7 +567,7 @@ export function Sidebar() {
               </button>
               {!sidebarCollapsed && settingsGroupOpen && (
                 <div className="nav-group-children">
-                  {settingsNavItems.filter(c => !['admin', 'audit-log'].includes(c.id) || isSuperAdmin).map(child => {
+                  {settingsNavItems.filter(c => !['admin', 'audit-log', 'data-requests'].includes(c.id) || isSuperAdmin).map(child => {
                     const childActive = path.startsWith(child.href);
                     return (
                       <a

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -28,6 +28,7 @@ import ContentLibraryPage from './pages/ContentLibraryPage';
 import ContentImportPage from './pages/ContentImportPage';
 import AdminPage from './pages/AdminPage';
 import AuditLogPage from './pages/AuditLogPage';
+import DataRequestsPage from './pages/DataRequestsPage';
 import TopicQueuePage from './pages/TopicQueuePage';
 import ReviewPage from './pages/ReviewPage';
 import PrivacyPage from './pages/PrivacyPage';
@@ -152,6 +153,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/app/content-import" element={<AppProvider><ContentImportPage /></AppProvider>} />
         <Route path="/app/mc" element={<AppProvider><AdminPage /></AppProvider>} />
         <Route path="/app/audit-log" element={<AppProvider><AuditLogPage /></AppProvider>} />
+        <Route path="/app/data-requests" element={<AppProvider><DataRequestsPage /></AppProvider>} />
         <Route path="/app/topic-queue" element={<AppProvider><TopicQueuePage /></AppProvider>} />
         <Route path="/app/brand-settings" element={<AppProvider><BrandSettingsPage /></AppProvider>} />
 

--- a/src/pages/DataRequestsPage.tsx
+++ b/src/pages/DataRequestsPage.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import { AppShell } from '../layouts/AppShell';
+
+// Settings → Data Requests. Super-admin DSAR tool (GDPR Art. 15/17/20, #25).
+// Lookup a person by email/name across Forge's reachable PII (reviewers,
+// support tickets, Factual Ground authors), export the bundle, or erase.
+// Server enforces the super-admin gate + writes every action to the audit log.
+
+interface DsarData {
+  reviewers: Array<{ id: string; brand_profile_id: string; name: string; email: string; title: string; created_at: string }>;
+  supportTickets: Array<{ id: string; brand_profile_id: string; user_email: string; subject: string; status: string; created_at: string }>;
+  factualGroundAuthors: Array<{ brand_profile_id: string; brand_name: string; matches: Array<Record<string, unknown>> }>;
+}
+interface LookupResp {
+  subject: { email: string | null; name: string | null };
+  counts: { reviewers: number; supportTickets: number; factualGroundAuthors: number };
+  data: DsarData;
+  note: string;
+}
+
+export default function DataRequestsPage() {
+  const { getToken } = useAuth();
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [result, setResult] = useState<LookupResp | null>(null);
+  const [erased, setErased] = useState<Record<string, unknown> | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const call = async (path: string, body: Record<string, unknown>) => {
+    const token = await getToken();
+    const r = await fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(body),
+    });
+    const d = await r.json();
+    if (!r.ok || !d.success) throw new Error(d.error || `HTTP ${r.status}`);
+    return d;
+  };
+
+  const lookup = async () => {
+    setBusy(true); setError(''); setErased(null); setResult(null);
+    try { setResult(await call('/api/admin/dsar/lookup', { email: email.trim(), name: name.trim() })); }
+    catch (e) { setError(e instanceof Error ? e.message : 'Lookup failed'); }
+    setBusy(false);
+  };
+
+  const total = result ? result.counts.reviewers + result.counts.supportTickets + result.counts.factualGroundAuthors : 0;
+
+  const erase = async () => {
+    if (!window.confirm(`Permanently erase all reachable PII for ${email || name}? This deletes reviewer rows, redacts support tickets, and removes Factual Ground authors. Logged to the audit trail. This cannot be undone.`)) return;
+    setBusy(true); setError('');
+    try {
+      const d = await call('/api/admin/dsar/erase', { email: email.trim(), name: name.trim(), confirm: true });
+      setErased(d.result); setResult(null);
+    } catch (e) { setError(e instanceof Error ? e.message : 'Erase failed'); }
+    setBusy(false);
+  };
+
+  const exportJson = () => {
+    if (!result) return;
+    const blob = new Blob([JSON.stringify(result, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `dsar-${(email || name).replace(/[^a-z0-9]/gi, '-')}-${new Date().toISOString().slice(0, 10)}.json`;
+    document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+  };
+
+  const S: Record<string, React.CSSProperties> = {
+    page: { padding: '24px 28px', maxWidth: 1000, margin: '0 auto', color: '#0F172A' },
+    bar: { display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'flex-end', margin: '16px 0' },
+    field: { display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12, color: '#64748B' },
+    input: { padding: '8px 10px', border: '1px solid #E2E8F0', borderRadius: 8, fontSize: 13, minWidth: 240, background: '#fff' },
+    btn: { padding: '9px 18px', borderRadius: 8, border: '1px solid #3563FF', background: '#3563FF', color: '#fff', fontSize: 13, fontWeight: 600, cursor: 'pointer' },
+    btnGhost: { padding: '9px 18px', borderRadius: 8, border: '1px solid #E2E8F0', background: '#fff', color: '#0F172A', fontSize: 13, fontWeight: 600, cursor: 'pointer' },
+    btnDanger: { padding: '9px 18px', borderRadius: 8, border: '1px solid #DC2626', background: '#fff', color: '#DC2626', fontSize: 13, fontWeight: 600, cursor: 'pointer' },
+    card: { border: '1px solid #E2E8F0', borderRadius: 10, padding: 16, margin: '12px 0' },
+    h3: { fontSize: 14, fontWeight: 700, margin: '0 0 8px' },
+    note: { fontSize: 12, color: '#92400E', background: '#FEF3C7', padding: '10px 12px', borderRadius: 8, margin: '12px 0' },
+    pre: { fontFamily: 'JetBrains Mono, monospace', fontSize: 12, background: '#F8FAFC', padding: 12, borderRadius: 8, overflow: 'auto', whiteSpace: 'pre-wrap' },
+  };
+
+  return (
+    <AppShell pageTitle="Data Requests">
+      <div style={S.page}>
+        <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.1em', color: '#3563FF' }}>GDPR · DSAR</div>
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: '4px 0 2px' }}>Data Requests</h1>
+        <p style={{ color: '#64748B', fontSize: 14, margin: 0 }}>Access, export, or erase a person's data across reviewers, support tickets, and Factual Ground authors. Every action is logged to the Audit Log.</p>
+
+        <div style={S.bar}>
+          <label style={S.field}>Email
+            <input style={S.input} value={email} onChange={e => setEmail(e.target.value)} placeholder="person@example.com" />
+          </label>
+          <label style={S.field}>Name (matches authors / reviewers)
+            <input style={S.input} value={name} onChange={e => setName(e.target.value)} placeholder="Jane Doe" />
+          </label>
+          <button style={S.btn} onClick={lookup} disabled={busy || (!email.trim() && !name.trim())}>Look up</button>
+        </div>
+
+        {error && <div style={{ color: '#DC2626', fontSize: 13 }}>Error: {error}</div>}
+        {busy && <div style={{ color: '#94A3B8', fontSize: 13 }}>Working…</div>}
+
+        {erased && (
+          <div style={{ ...S.card, borderColor: '#16A34A' }}>
+            <div style={S.h3}>Erasure complete</div>
+            <pre style={S.pre}>{JSON.stringify(erased, null, 2)}</pre>
+          </div>
+        )}
+
+        {result && (
+          <>
+            <div style={S.bar}>
+              <strong style={{ fontSize: 15 }}>{total} record{total === 1 ? '' : 's'} found</strong>
+              <span style={{ flex: 1 }} />
+              <button style={S.btnGhost} onClick={exportJson} disabled={total === 0}>Export JSON</button>
+              <button style={S.btnDanger} onClick={erase} disabled={total === 0}>Erase all</button>
+            </div>
+            <div style={S.note}>{result.note}</div>
+
+            <div style={S.card}>
+              <div style={S.h3}>Reviewers ({result.counts.reviewers})</div>
+              {result.data.reviewers.length === 0 ? <div style={{ color: '#94A3B8', fontSize: 13 }}>None.</div> :
+                result.data.reviewers.map(r => <div key={r.id} style={{ fontSize: 13, padding: '4px 0' }}>{r.name} · {r.email} · {r.title || '—'} <span style={{ color: '#94A3B8' }}>(brand {r.brand_profile_id.slice(0, 8)})</span></div>)}
+            </div>
+            <div style={S.card}>
+              <div style={S.h3}>Support tickets ({result.counts.supportTickets})</div>
+              {result.data.supportTickets.length === 0 ? <div style={{ color: '#94A3B8', fontSize: 13 }}>None.</div> :
+                result.data.supportTickets.map(t => <div key={t.id} style={{ fontSize: 13, padding: '4px 0' }}>{t.subject} · {t.status} <span style={{ color: '#94A3B8' }}>({new Date(t.created_at).toLocaleDateString()})</span></div>)}
+            </div>
+            <div style={S.card}>
+              <div style={S.h3}>Factual Ground authors ({result.counts.factualGroundAuthors})</div>
+              {result.data.factualGroundAuthors.length === 0 ? <div style={{ color: '#94A3B8', fontSize: 13 }}>None.</div> :
+                result.data.factualGroundAuthors.map(b => <div key={b.brand_profile_id} style={{ fontSize: 13, padding: '4px 0' }}>{b.matches.length} in <strong>{b.brand_name}</strong></div>)}
+            </div>
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -115,6 +115,8 @@
   "POST /api/admin/backfill-facebook-zernio-ids",
   "POST /api/admin/backfill-linkedin-zernio-ids",
   "POST /api/admin/digest/send/:brandProfileId",
+  "POST /api/admin/dsar/erase",
+  "POST /api/admin/dsar/lookup",
   "POST /api/admin/indexnow/backfill",
   "POST /api/admin/indexnow/submit",
   "POST /api/admin/mark-unpublished",


### PR DESCRIPTION
## Why
Sub-issue #2 of #25: data-subject **access** (Art. 15/20) + **erasure** (Art. 17), and the first real writers into the audit log (#388). Super-admin-operated for now (not self-service).

## Scope — grounded in the real schema
Forge's reachable third-party-PII surface, now that outreach is gone:
- **`reviewers`** (name + email) — deleted on erasure.
- **`support_tickets`** (user_email) — **redacted** (`user_email→NULL`, subject/body → `[erased per DSAR]`), not deleted, so the row survives as evidence of the request.
- **Factual Ground `authors`** (name / linkedinUrl, JSONB on `brand_profiles`) — matching authors removed from each brand's array via `jsonb_set`.

**Honest about limits:** names buried in free text (competitorAnalysis, personas, generated article bodies) aren't key-erasable — returned as a `note` for manual review rather than silently missed. `email_campaign_emails` holds generated *content*, not recipient lists (those live in HubSpot), so no recipient PII there.

## Backend (`server.js`, super-admin gated, both audit-logged)
- `POST /api/admin/dsar/lookup` → `{ counts, data, note }`; logs `dsar.access`.
- `POST /api/admin/dsar/erase` (requires `confirm:true` — run lookup first) → per-surface deletion/redaction; logs `dsar.erase` with full counts + brands touched.

## Frontend
`src/pages/DataRequestsPage.tsx` at `/app/data-requests` — email/name lookup, per-surface result cards, **Export JSON** (portability artifact), **Erase all** behind a hard `window.confirm`. Settings nav item gated on `isSuperAdmin` alongside Audit Log / Mission Control.

## Deferred (noted)
Rectification (Brand Settings already edits authors), self-service intake, 30-day-deadline tracking.

## Test plan
- `tsc --noEmit` clean; **197/197 vitest pass**; route snapshot +2 (nothing else).
- Dev: lookup a known reviewer email → appears; export JSON; erase → reviewer gone, ticket redacted, author pulled from factualGround; **both actions show in the Audit Log** (`dsar.access` / `dsar.erase`). Non-super-admin → 403 + no nav item.

## Rollback
Revert — additive routes/page/nav; erasure is gated behind `confirm:true` + a UI confirm.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_