### PR TITLE
feat(compliance): EU AI Act Art. 50 AI-content marker on public articles (#25)

### DIFF
--- a/SECURITY-COMPLIANCE.md
+++ b/SECURITY-COMPLIANCE.md
@@ -19,7 +19,7 @@ Adapted from the GDPR implementation playbook (community skill, `gdpr-data-handl
 - ✅ Privacy policy clear and accessible (`/privacy`, PrivacyPage.tsx; refreshed 2026-06-12 #357 — added Jina/Bright Data/OpenAI/Gemini/ValueSERP processors)
 - ✅ Processing purposes clearly stated (Privacy §2/§4)
 - 🟡 Data retention periods documented (privacy policy states some; not enforced in code — see Retention)
-- ⬜ **AI-content transparency (EU AI Act Art. 50, applies Aug 2026):** machine-readable "AI-generated" marker on published articles. Video skill already discloses AI voice; articles need a JSON-LD/meta marker. *Cheapest + most clearly-applicable AI Act obligation.*
+- ✅ **AI-content transparency (EU AI Act Art. 50, applies Aug 2026):** machine-readable IPTC `digitalSourceType` (compositeWithTrainedAlgorithmicMedia) in the public article JSON-LD + a visible reader disclosure in the article footer (#394). Video skill already discloses AI voice. _Pending:_ disclosure on externally-syndicated copies (HubSpot/Webflow/etc.) — a content-mutation product decision, deferred.
 
 ### Data Subject Rights (DSAR) — must respond within 30 days
 - ✅ Access request (Art. 15) — `dsar.lookup` across reviewers / support tickets / Factual Ground authors (#391)
@@ -98,7 +98,7 @@ This is the audit subsystem only — table, helper+seams, read/export API, page.
 
 1. **Audit log subsystem** (spec above) — ✅ **BUILT (#388)**, the substrate. Follow-on: read-view logging (DSAR write seams now wired via #391).
 2. **GDPR DSAR endpoints** — ✅ **BUILT (#391)**: access/export/erase across reviewers, support tickets, and Factual Ground authors; writes to the audit log. Deferred: rectification, self-service intake, 30-day-deadline tracking.
-3. **AI-content transparency** (Art. 50 marker on articles) — BUILD, small, time-boxed to Aug 2026.
+3. **AI-content transparency** (Art. 50 marker on articles) — ✅ **BUILT (#394)**: JSON-LD IPTC marker + visible footer disclosure on the Forge-controlled public render. Deferred: external-CMS body disclosure (product decision).
 4. **DPA + sub-processor page + RoPA** — DOCUMENT (the procurement artifacts).
 5. **EU AI Act risk-tier memo** (limited-risk, not high-risk) — DOCUMENT one page, **don't build** conformity machinery. **[legal]**
 6. **Data-residency / transfer basis** — **[legal]** assessment; the real enterprise-EU blocker.
@@ -107,6 +107,9 @@ This is the audit subsystem only — table, helper+seams, read/export API, page.
 ---
 
 ## Change log
+
+### 2026-06-13 — AI-content transparency marker shipped (#394)
+Sub-issue #3 (EU AI Act Art. 50, the cheap time-boxed one): the public server-rendered article now emits a machine-readable IPTC `digitalSourceType = compositeWithTrainedAlgorithmicMedia` on its Article JSON-LD (the Google/IPTC-recognized AI-content signal; "composite" = AI draft under Compliance-Gate human review), and the public React article footer carries a visible reader disclosure. Closes the Transparency checklist line. Deferred: disclosure appended to externally-syndicated article bodies (HubSpot/Webflow/Ghost/WordPress/Medium) — that mutates published content and is a product decision, not a unilateral one.
 
 ### 2026-06-13 — DSAR access/export/erase shipped (#391)
 Sub-issue #2 built and is the first real writer into the audit log: `POST /api/admin/dsar/lookup` (`dsar.access`) + `POST /api/admin/dsar/erase` (`dsar.erase`, `confirm:true`-gated) across reviewers (deleted), support tickets (redacted — row kept as request evidence), and Factual Ground authors (removed from the brand JSONB); Settings → Data Requests page with JSON export (portability). Honest coverage note: free-text surfaces (competitorAnalysis/personas/article bodies) aren't key-erasable → flagged for manual review. Closes the DSAR access/erasure/portability checklist lines; rectification + 30-day-deadline tracking + self-service intake remain.

--- a/server.js
+++ b/server.js
@@ -1770,6 +1770,11 @@ app.get('/articles/:brandSlug/:articleSlug', async (req, res) => {
         "wordCount": wordCount,
         "timeRequired": `PT${readMinutes}M`,
         "inLanguage": "en-US",
+        // EU AI Act Art. 50 — machine-readable AI-content marker (IPTC DigitalSourceType
+        // vocabulary, the de-facto standard Google/IPTC recognize). "composite" = an
+        // AI-generated draft under human editorial review (the Compliance Gate), which
+        // is both accurate and the Art. 50 deployer framing.
+        "digitalSourceType": "https://cv.iptc.org/newscodes/digitalsourcetype/compositeWithTrainedAlgorithmicMedia",
         ...(articleKeywords.length ? { "keywords": articleKeywords } : {}),
         ...(articleAbout.length ? { "about": articleAbout } : {}),
       };

--- a/src/pages/PublicArticlePage.tsx
+++ b/src/pages/PublicArticlePage.tsx
@@ -401,6 +401,11 @@ export default function PublicArticlePage() {
               </div>
               <a href={`/articles/${brandSlug}`} className="pa-back-link">← More articles</a>
             </div>
+            {/* EU AI Act Art. 50 — visible AI-content disclosure for human readers
+                (the machine-readable IPTC marker rides in the SSR JSON-LD). */}
+            <p className="pa-ai-disclosure" style={{ fontSize: 12, color: '#94A3B8', marginTop: 14, fontStyle: 'italic' }}>
+              This article was created with AI assistance and reviewed for accuracy before publication.
+            </p>
           </footer>
 
         </article>


### PR DESCRIPTION
## Why
Sub-issue #3 of #25, and the last buildable one: EU AI Act **Article 50** transparency (applies Aug 2026). It's the only AI Act obligation that clearly bites a marketing-content generator, and it's cheap.

## What
- **`server.js`** (public article SSR, `/articles/:brand/:slug`): the Article JSON-LD now carries the machine-readable **IPTC `digitalSourceType`** marker = `compositeWithTrainedAlgorithmicMedia` — the Google/IPTC-recognized signal for "AI-generated, human-edited." "Composite" is accurate *and* the favorable Art. 50 framing: every article passes the Compliance Gate's human editorial review. This is what crawlers + AI engines read.
- **`src/pages/PublicArticlePage.tsx`**: a visible reader disclosure in the article footer ("created with AI assistance and reviewed for accuracy before publication") — the human-facing half of Art. 50.
- **`SECURITY-COMPLIANCE.md`**: Transparency checklist line ✅, decomposition item 3 → BUILT, change-log entry (bundled since this closes the item outright).

## Scope / deferred (flagged in the doc)
Marked Forge's **own controlled public render** (SSR JSON-LD + React page). **Not** done: appending a disclosure line into externally-syndicated article *bodies* (HubSpot/Webflow/Ghost/WordPress/Medium) — that mutates the published content across many channel adapters and is a product decision, so I left it for you rather than unilaterally editing customers' article text.

## Test plan
- `node --check` + `tsc --noEmit` clean; **197/197 vitest pass**; no route changes (no snapshot diff).
- Dev: view a public article → `view-source` shows `digitalSourceType` in the Article JSON-LD; the rendered footer shows the disclosure line.

## Rollback
Revert — one JSON-LD property + one footer line + doc.

This is the buildable half of #25 done (audit log #388 · DSAR #391 · AI-content marker #394). Remaining items are documentation/legal: DPA + sub-processor page, risk-tier memo, data-residency assessment, breach runbook.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_