### PR TITLE
feat(legal): shareable DPA + sub-processors pages + sub-processor SSOT (#25)

### DIFF
--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -261,6 +261,10 @@ export default function Landing() {
             <a href="/docs" style={styles.footerLink}>Docs</a>
             <span style={styles.footerDivider}>·</span>
             <a href="/acceptable-use" style={styles.footerLink}>Acceptable Use</a>
+            <span style={styles.footerDivider}>·</span>
+            <a href="/dpa" style={styles.footerLink}>DPA</a>
+            <span style={styles.footerDivider}>·</span>
+            <a href="/subprocessors" style={styles.footerLink}>Sub-processors</a>
           </div>
         </div>
       </div>

--- a/src/data/subprocessors.ts
+++ b/src/data/subprocessors.ts
@@ -1,0 +1,56 @@
+// Single source of truth for Forge Intelligence's sub-processors.
+//
+// Consumed by: /subprocessors (public page), the Privacy Policy (Section 6),
+// the DPA page (Annex), and the attorney-review Word export. Update HERE when a
+// vendor is added or removed — never maintain a second copy in prose. (Adding
+// Jina / Bright Data / OpenAI / Gemini / ValueSERP in #357 required hand-editing
+// the privacy policy; this module exists so that never happens again.)
+//
+// `customerDirected: true` = the customer connects the service and data flows at
+// THEIR instruction (publishing/CRM channels). These are onward recipients the
+// customer chooses, legally distinct from sub-processors Forge engages to deliver
+// the core service — the DPA separates them accordingly.
+
+export interface SubProcessor {
+  name: string;
+  url: string;
+  purpose: string;            // what it does + what data flows
+  dataCategories: string;     // categories of personal/operational data sent
+  region: string;             // hosting / processing region
+  customerDirected?: boolean; // customer-connected integration vs. Forge sub-processor
+}
+
+export const SUBPROCESSORS_UPDATED = '2026-06-13';
+
+// Forge-engaged sub-processors (deliver the core service).
+export const subProcessors: SubProcessor[] = [
+  { name: 'Clerk', url: 'clerk.com', purpose: 'Authentication, session management, and user identity.', dataCategories: 'Account email, user identifier', region: 'United States' },
+  { name: 'Neon', url: 'neon.tech', purpose: 'Primary database (serverless Postgres) with Row Level Security; stores all brand workspace data.', dataCategories: 'All customer + brand workspace data', region: 'United States (us-west-2)' },
+  { name: 'Render', url: 'render.com', purpose: 'Application hosting and deployment.', dataCategories: 'All data in transit through the application', region: 'United States' },
+  { name: 'Anthropic', url: 'anthropic.com', purpose: 'LLM inference (Claude) for all AI-powered stages. API terms prohibit using inputs for model training.', dataCategories: 'Brand voice, personas, competitive analysis, brain data, article content', region: 'United States' },
+  { name: 'Perplexity AI', url: 'perplexity.ai', purpose: 'Web-sourced market research, competitor analysis, source discovery, and AI-visibility probing (Sonar).', dataCategories: 'Brand/competitor URLs, market-context queries, brand-free buyer questions', region: 'United States' },
+  { name: 'Jina Reader', url: 'jina.ai', purpose: 'Primary web-content extraction for brand and competitor site crawls.', dataCategories: 'Publicly available page URLs', region: 'Global' },
+  { name: 'Bright Data', url: 'brightdata.com', purpose: 'Fallback web-content extraction (Web Unlocker / Scraping Browser) when a public page cannot be read directly.', dataCategories: 'Publicly available page URLs', region: 'Global' },
+  { name: 'OpenAI', url: 'openai.com', purpose: 'AI-visibility probing only — measuring whether ChatGPT cites a brand. No brand content or personal data is sent.', dataCategories: 'Brand-free, category-level buyer questions', region: 'United States' },
+  { name: 'Google (Gemini API)', url: 'ai.google.dev', purpose: 'AI-visibility probing only, via Gemini with Search grounding.', dataCategories: 'Brand-free buyer questions', region: 'United States / Global' },
+  { name: 'ValueSERP / SerpAPI', url: 'valueserp.com', purpose: 'SERP data providers used to read Google AI Overviews for visibility measurement.', dataCategories: 'Buyer-question search queries', region: 'United States' },
+  { name: 'fal.ai', url: 'fal.ai', purpose: 'Hero image generation via Flux models.', dataCategories: 'Image prompts derived from article content', region: 'United States' },
+  { name: 'Resend', url: 'resend.com', purpose: 'Transactional email delivery (account notifications, review requests, digests).', dataCategories: 'Recipient email, message content', region: 'United States' },
+  { name: 'PayPal', url: 'paypal.com', purpose: 'Payment processing. Forge does not receive or store card/bank details.', dataCategories: 'Payment confirmation only', region: 'Global' },
+  { name: 'Pipedream Connect', url: 'pipedream.com', purpose: 'OAuth connection management for customer-connected channels; raw tokens are not stored in Forge’s database.', dataCategories: 'OAuth account identifiers', region: 'United States' },
+  { name: 'Bitly', url: 'bitly.com', purpose: 'URL shortening for social post copy.', dataCategories: 'Article URLs and UTM parameters', region: 'United States' },
+  { name: 'EasyCron', url: 'easycron.com', purpose: 'Scheduled job triggers (pattern extraction, decay monitoring, GEO refresh).', dataCategories: 'No personal data (trigger signals only)', region: 'Global' },
+  { name: 'HubSpot', url: 'hubspot.com', purpose: 'CRM sync of the account holder on sign-in.', dataCategories: 'Account email and sign-in timestamp', region: 'United States' },
+];
+
+// Customer-directed integrations — connected by the customer; data flows at the
+// customer's instruction. Onward recipients, not Forge sub-processors.
+export const customerDirectedRecipients: SubProcessor[] = [
+  { name: 'LinkedIn', url: 'linkedin.com', purpose: 'Publishing articles/posts and syncing engagement metrics to a connected account.', dataCategories: 'Published content; engagement metrics', region: 'Global', customerDirected: true },
+  { name: 'X (Twitter)', url: 'x.com', purpose: 'Publishing posts and syncing engagement; OAuth 2.0 tokens stored encrypted and refreshed.', dataCategories: 'Published content; engagement metrics', region: 'Global', customerDirected: true },
+  { name: 'Facebook', url: 'facebook.com', purpose: 'Publishing to connected Pages and syncing engagement.', dataCategories: 'Published content; engagement metrics', region: 'Global', customerDirected: true },
+  { name: 'Reddit', url: 'reddit.com', purpose: 'Publishing articles to designated subreddits.', dataCategories: 'Published content', region: 'Global', customerDirected: true },
+  { name: 'Medium', url: 'medium.com', purpose: 'Publishing articles to a connected Medium account.', dataCategories: 'Published content', region: 'Global', customerDirected: true },
+  { name: 'Ghost / WordPress / Webflow', url: 'ghost.org', purpose: 'Publishing articles to a connected CMS; credentials managed via Pipedream Connect.', dataCategories: 'Published content', region: 'Global', customerDirected: true },
+  { name: 'Google Search Console', url: 'search.google.com/search-console', purpose: 'SEO performance data, synced on demand with the customer’s authorization (read-only scope).', dataCategories: 'Search performance metrics', region: 'United States', customerDirected: true },
+];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,6 +32,8 @@ import DataRequestsPage from './pages/DataRequestsPage';
 import TopicQueuePage from './pages/TopicQueuePage';
 import ReviewPage from './pages/ReviewPage';
 import PrivacyPage from './pages/PrivacyPage';
+import SubProcessorsPage from './pages/SubProcessorsPage';
+import DpaPage from './pages/DpaPage';
 import TermsPage from './pages/TermsPage';
 import DocsPage from './pages/DocsPage';
 import AcceptableUsePage from './pages/AcceptableUsePage';
@@ -113,6 +115,8 @@ createRoot(document.getElementById('root')!).render(
         {/* Marketing site */}
         <Route path="/" element={<Landing />} />
         <Route path="/privacy" element={<PrivacyPage />} />
+        <Route path="/subprocessors" element={<SubProcessorsPage />} />
+        <Route path="/dpa" element={<DpaPage />} />
         <Route path="/terms" element={<TermsPage />} />
         <Route path="/acceptable-use" element={<AcceptableUsePage />} />
         <Route path="/docs" element={<DocsPage />} />

--- a/src/pages/DpaPage.tsx
+++ b/src/pages/DpaPage.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+// Public Data Processing Addendum (GDPR Art. 28). Shareable by URL with a
+// customer's legal team; not in the app nav. Standard terms; an executed,
+// counter-signed copy is available on request. The sub-processor list lives at
+// /subprocessors (single source of truth) and is incorporated as Annex III.
+
+const Section = ({ n, title, children }: { n: string; title: string; children: React.ReactNode }) => (
+  <div style={styles.section}>
+    <h2 style={styles.h2}>{n}. {title}</h2>
+    {children}
+  </div>
+);
+const P = ({ children }: { children: React.ReactNode }) => <p style={styles.p}>{children}</p>;
+const UL = ({ items }: { items: React.ReactNode[] }) => <ul style={styles.ul}>{items.map((it, i) => <li key={i} style={styles.li}>{it}</li>)}</ul>;
+
+export default function DpaPage() {
+  return (
+    <div style={styles.root}>
+      <div style={styles.container}>
+        <div style={styles.header}>
+          <a href="/" style={styles.backLink}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M19 12H5M12 19l-7-7 7-7" /></svg>
+            Back
+          </a>
+          <h1 style={styles.title}>Data Processing Addendum</h1>
+          <p style={styles.subtitle}>Version 1.0 · 2026-06-13 &nbsp;·&nbsp; Forge Intelligence LLC &nbsp;·&nbsp; Portland, OR</p>
+        </div>
+
+        <div style={styles.banner}>
+          This is Forge Intelligence's standard Data Processing Addendum (DPA), offered to customers who process personal data through the platform. To execute a counter-signed copy for your organization, contact <a href="mailto:legal@forgeintelligence.ai" style={styles.bannerLink}>legal@forgeintelligence.ai</a>. The current sub-processor list (Annex III) is maintained at <a href="/subprocessors" style={styles.bannerLink}>forgeintelligence.ai/subprocessors</a>.
+        </div>
+
+        <div style={styles.card}>
+          <P>This Data Processing Addendum (&ldquo;DPA&rdquo;) forms part of the agreement between the customer (&ldquo;Customer&rdquo;) and Forge Intelligence LLC (&ldquo;Forge&rdquo;) for use of the Forge Intelligence platform (the &ldquo;Service&rdquo;) and reflects the parties&rsquo; agreement on the processing of personal data under the EU General Data Protection Regulation (GDPR), UK GDPR, and applicable US state privacy laws.</P>
+
+          <Section n="1" title="Definitions">
+            <P>&ldquo;Controller&rdquo;, &ldquo;Processor&rdquo;, &ldquo;Data Subject&rdquo;, &ldquo;Personal Data&rdquo;, &ldquo;Processing&rdquo;, and &ldquo;Personal Data Breach&rdquo; have the meanings given in the GDPR. &ldquo;Sub-processor&rdquo; means any processor engaged by Forge to process Customer Personal Data. &ldquo;Customer Personal Data&rdquo; means personal data Forge processes on Customer&rsquo;s behalf under the Service.</P>
+          </Section>
+
+          <Section n="2" title="Roles of the Parties">
+            <P>For Customer Personal Data, Customer is the Controller and Forge is the Processor. Forge processes Customer Personal Data only to provide the Service and only on Customer&rsquo;s documented instructions, including as set out in this DPA and the agreement.</P>
+          </Section>
+
+          <Section n="3" title="Scope and Details of Processing">
+            <P>The subject matter, duration, nature, and purpose of processing, the types of personal data, and categories of data subjects are described in <strong style={styles.strong}>Annex I</strong>.</P>
+          </Section>
+
+          <Section n="4" title="Processor Obligations">
+            <UL items={[
+              'Process Customer Personal Data only on Customer&rsquo;s documented instructions, unless required by law (in which case Forge will inform Customer unless legally prohibited).',
+              'Ensure persons authorized to process Customer Personal Data are bound by confidentiality.',
+              'Implement the technical and organizational measures set out in Annex II (Art. 32).',
+              'Respect the sub-processor conditions in Section 6.',
+              'Assist Customer, taking into account the nature of processing, in responding to data-subject-rights requests (Section 7) and in meeting its obligations under Arts. 32–36 (security, breach notification, DPIA).',
+              'At Customer&rsquo;s election, delete or return Customer Personal Data at the end of the Service (Section 10).',
+              'Make available information necessary to demonstrate compliance and allow for audits (Section 9).',
+            ]} />
+          </Section>
+
+          <Section n="5" title="Security">
+            <P>Forge maintains the technical and organizational measures described in <strong style={styles.strong}>Annex II</strong>, including encryption in transit, tenant isolation enforced at the authentication, ownership-verification, and database (Row Level Security) layers, and an access audit log.</P>
+          </Section>
+
+          <Section n="6" title="Sub-processors">
+            <P>Customer provides a general authorization for Forge to engage the sub-processors listed at <a href="/subprocessors" style={styles.link}>forgeintelligence.ai/subprocessors</a> (incorporated as <strong style={styles.strong}>Annex III</strong>). Forge imposes data-protection obligations on each sub-processor no less protective than those in this DPA and remains responsible for their performance. Forge will update the list before engaging a new sub-processor and, on request, provide a mechanism for advance notice so Customer may object on reasonable data-protection grounds.</P>
+          </Section>
+
+          <Section n="7" title="Data Subject Rights">
+            <P>Taking into account the nature of the processing, Forge assists Customer by appropriate technical and organizational measures, insofar as possible, in fulfilling Customer&rsquo;s obligation to respond to requests to exercise data-subject rights (access, rectification, erasure, restriction, portability, objection). Forge provides operator tooling to locate, export, and erase a data subject&rsquo;s personal data across the Service.</P>
+          </Section>
+
+          <Section n="8" title="Personal Data Breach">
+            <P>Forge notifies Customer without undue delay after becoming aware of a Personal Data Breach affecting Customer Personal Data, and provides information reasonably available to assist Customer in meeting its breach-notification obligations.</P>
+          </Section>
+
+          <Section n="9" title="Audit">
+            <P>Forge makes available information necessary to demonstrate compliance with this DPA and allows for and contributes to audits, including inspections, conducted by Customer or an auditor mandated by Customer, subject to reasonable confidentiality and frequency limits.</P>
+          </Section>
+
+          <Section n="10" title="Deletion or Return">
+            <P>Upon termination of the Service, Forge will, at Customer&rsquo;s election, delete or return Customer Personal Data, and delete existing copies unless retention is required by law.</P>
+          </Section>
+
+          <Section n="11" title="International Transfers">
+            <P>Where Forge processes Customer Personal Data originating in the EEA, UK, or Switzerland outside those territories, the parties rely on an appropriate transfer mechanism, including the Standard Contractual Clauses, which are incorporated by reference where applicable.</P>
+          </Section>
+
+          <Section n="12" title="Annexes">
+            <UL items={[
+              <><strong style={styles.strong}>Annex I — Details of Processing.</strong> Subject matter: provision of the Forge Intelligence content-intelligence platform. Duration: the term of the agreement. Nature/purpose: brand analysis, content generation, compliance review, publishing, and performance analytics. Categories of data subjects: Customer&rsquo;s personnel and authorized users; named authors/SMEs; reviewers; and individuals referenced in Customer-provided or publicly sourced brand material. Types of personal data: names, business email addresses, job titles, professional biographies, and professional profile links.</>,
+              <><strong style={styles.strong}>Annex II — Technical and Organizational Measures.</strong> Encryption in transit (TLS); tenant isolation at three layers (authentication via JWT, per-request ownership verification, and database Row Level Security); least-privilege access; an access/audit log of privileged and data-access events; automated purge of orphaned data.</>,
+              <><strong style={styles.strong}>Annex III — Sub-processors.</strong> The current list at <a href="/subprocessors" style={styles.link}>forgeintelligence.ai/subprocessors</a>.</>,
+            ]} />
+          </Section>
+
+          <Section n="13" title="Contact">
+            <P>Forge Intelligence LLC, Portland, Oregon, USA &nbsp;·&nbsp; <a href="mailto:legal@forgeintelligence.ai" style={styles.link}>legal@forgeintelligence.ai</a></P>
+          </Section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: { minHeight: '100vh', backgroundColor: '#0B0F1A', color: '#F8FAFC', fontFamily: "Inter, 'Geist', system-ui, -apple-system, sans-serif", padding: '80px 24px' },
+  container: { maxWidth: 800, margin: '0 auto', width: '100%' },
+  header: { marginBottom: 24 },
+  backLink: { display: 'inline-flex', alignItems: 'center', gap: 6, color: '#64748B', textDecoration: 'none', fontSize: 14, marginBottom: 32 },
+  title: { fontSize: 36, fontWeight: 700, color: '#F8FAFC', margin: '0 0 8px', letterSpacing: '-0.5px' },
+  subtitle: { fontSize: 13, color: '#64748B', margin: 0 },
+  banner: { background: 'rgba(53,99,255,0.1)', border: '1px solid rgba(53,99,255,0.25)', borderRadius: 10, padding: '14px 18px', fontSize: 13, color: '#CBD5E1', lineHeight: 1.65, marginBottom: 24 },
+  bannerLink: { color: '#3563FF', textDecoration: 'none' },
+  card: { backgroundColor: '#1E293B', borderRadius: 12, border: '1px solid rgba(255,255,255,0.06)', padding: '48px 52px' },
+  section: { marginBottom: 28, paddingBottom: 28, borderBottom: '1px solid rgba(255,255,255,0.06)' },
+  h2: { fontSize: 16, fontWeight: 600, color: '#F8FAFC', margin: '0 0 12px', letterSpacing: '-0.2px' },
+  p: { fontSize: 15, color: '#94A3B8', lineHeight: 1.75, margin: '0 0 12px' },
+  ul: { margin: '0 0 12px', paddingLeft: 20 },
+  li: { fontSize: 15, color: '#94A3B8', lineHeight: 1.75, marginBottom: 8 },
+  strong: { color: '#CBD5E1', fontWeight: 600 },
+  link: { color: '#3563FF', textDecoration: 'none' },
+};

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { subProcessors, customerDirectedRecipients } from '../data/subprocessors';
 
 const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
   <div style={styles.section}>
@@ -90,32 +91,12 @@ export default function PrivacyPage() {
           </Section>
 
           <Section title="6. Third-Party Services">
-            <P>The following services process data as part of operating the platform. Each is governed by their own privacy policy.</P>
+            <P>The following services process data as part of operating the platform; each is governed by their own privacy policy. The canonical, dated list is maintained at <a href="/subprocessors" style={styles.link}>forgeintelligence.ai/subprocessors</a>.</P>
+            <P><strong style={styles.strong}>Sub-processors</strong> (engaged by Forge to deliver the service):</P>
+            <UL items={subProcessors.map(s => `${s.name} (${s.url}) — ${s.purpose}`)} />
+            <P><strong style={styles.strong}>Customer-directed integrations</strong> (connected by you; data flows at your instruction):</P>
+            <UL items={customerDirectedRecipients.map(s => `${s.name} (${s.url}) — ${s.purpose}`)} />
             <UL items={[
-              "Clerk (clerk.com) — authentication, session management, user identity.",
-              "NeonDB (neon.tech) — primary database, serverless Postgres with Row Level Security.",
-              "Anthropic (anthropic.com) — LLM inference for all AI-powered stages. Claude Opus, Sonnet, and Haiku models. Brand voice, personas, competitive analysis, and brain data are sent as context with each request. Anthropic's API terms prohibit using API inputs for training.",
-              "Perplexity AI (perplexity.ai) — web-sourced market research, competitor analysis, source discovery via the Sonar model, and AI-visibility probing. Brand URLs, competitor URLs, market-context queries, and brand-free buyer questions are sent during brand analysis, topic mapping, and citation tracking.",
-              "Jina Reader (jina.ai) — primary web-content extraction for brand and competitor site crawls. Only publicly available page URLs are sent.",
-              "Bright Data (brightdata.com) — fallback web-content extraction (Web Unlocker and Scraping Browser) when a public page cannot be read directly. Only publicly available page URLs are sent.",
-              "OpenAI (openai.com) — AI-visibility probing only. Brand-free, category-level buyer questions are sent to measure whether ChatGPT cites your brand. No brand content, brain data, or personal data is sent to OpenAI.",
-              "Google Gemini API (Google LLC) — AI-visibility probing only, via Gemini with Search grounding. Same brand-free buyer questions; no personal data.",
-              "ValueSERP / SerpAPI — SERP data providers used to read Google AI Overviews for visibility measurement. Only the buyer-question search queries are sent.",
-              "fal.ai — hero image generation via Flux models. Image prompts derived from article content are sent to fal.ai.",
-              "Resend (resend.com) — transactional email delivery for account notifications, review requests, and performance digests.",
-              "PayPal (paypal.com) — one-time payment processing at $99.",
-              "Pipedream Connect (pipedream.com) — OAuth management for LinkedIn, Facebook, HubSpot, and Webflow. Raw tokens are never stored in our database.",
-              "Bitly (bitly.com) — URL shortening for social post copy. Only article URLs and UTM parameters are sent.",
-              "Render (render.com) — application hosting and deployment.",
-              "Google Search Console (Google LLC) — SEO performance data, synced on demand with your authorization via read-only API scope.",
-              "HubSpot (hubspot.com) — CRM sync on login. Email and sign-in timestamp only.",
-              "EasyCron (easycron.com) — scheduled job triggers for pattern extraction, decay monitoring, and GEO refresh.",
-              "LinkedIn API (linkedin.com) — publishing articles and post copy to your connected LinkedIn account. Engagement metrics are synced back for analytics.",
-              "X / Twitter API (x.com) — publishing tweets and syncing engagement data. OAuth 2.0 tokens are stored in our database and refreshed automatically.",
-              "Facebook Graph API (facebook.com) — publishing to connected Facebook Pages and syncing engagement metrics.",
-              "Reddit API (reddit.com) — publishing articles to subreddits you designate. OAuth tokens are obtained at publish time.",
-              "Medium API (medium.com) — publishing articles to your connected Medium account.",
-              "Ghost, WordPress, and Webflow APIs — publishing articles to your connected CMS. Connection credentials are managed via Pipedream Connect.",
               "LinkedIn Insight Tag — we embed the LinkedIn Insight Tag on our marketing pages for conversion measurement and audience analytics. This tag may set cookies and collect browsing data on forgeintelligence.ai. It is governed by LinkedIn's privacy policy. See Section 9 for details.",
             ]} />
           </Section>

--- a/src/pages/SubProcessorsPage.tsx
+++ b/src/pages/SubProcessorsPage.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { subProcessors, customerDirectedRecipients, SUBPROCESSORS_UPDATED, type SubProcessor } from '../data/subprocessors';
+
+// Public sub-processor list (GDPR Art. 28). Shareable by URL with a customer's
+// legal/procurement team; not in the app nav. Mirrors the PrivacyPage layout.
+// Single source of truth: src/data/subprocessors.ts.
+
+const Table = ({ rows }: { rows: SubProcessor[] }) => (
+  <div style={styles.tableWrap}>
+    <table style={styles.table}>
+      <thead>
+        <tr>
+          <th style={styles.th}>Sub-processor</th>
+          <th style={styles.th}>Purpose</th>
+          <th style={styles.th}>Data categories</th>
+          <th style={styles.th}>Region</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(r => (
+          <tr key={r.name}>
+            <td style={styles.td}><strong style={styles.strong}>{r.name}</strong><br /><span style={styles.url}>{r.url}</span></td>
+            <td style={styles.td}>{r.purpose}</td>
+            <td style={styles.td}>{r.dataCategories}</td>
+            <td style={styles.td}>{r.region}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default function SubProcessorsPage() {
+  return (
+    <div style={styles.root}>
+      <div style={styles.container}>
+        <div style={styles.header}>
+          <a href="/" style={styles.backLink}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M19 12H5M12 19l-7-7 7-7" /></svg>
+            Back
+          </a>
+          <h1 style={styles.title}>Sub-processors</h1>
+          <p style={styles.subtitle}>Last updated: {SUBPROCESSORS_UPDATED} &nbsp;·&nbsp; Forge Intelligence LLC &nbsp;·&nbsp; Portland, OR</p>
+        </div>
+
+        <div style={styles.card}>
+          <p style={styles.p}>This page lists the third-party sub-processors Forge Intelligence LLC engages to provide the platform, and the customer-directed integrations that may receive data at a customer's instruction. It is referenced by our <a href="/privacy" style={styles.link}>Privacy Policy</a> and forms an Annex to our <a href="/dpa" style={styles.link}>Data Processing Addendum</a>. Each sub-processor is bound by its own data-protection terms.</p>
+          <p style={styles.p}>We will update this page before engaging a new sub-processor that processes customer personal data. Customers under an executed DPA may request advance notice of changes by contacting <a href="mailto:legal@forgeintelligence.ai" style={styles.link}>legal@forgeintelligence.ai</a>.</p>
+
+          <h2 style={styles.h2}>Sub-processors</h2>
+          <p style={styles.note}>Engaged by Forge to deliver the core service.</p>
+          <Table rows={subProcessors} />
+
+          <h2 style={styles.h2}>Customer-directed integrations</h2>
+          <p style={styles.note}>Connected by the customer; data flows to these services at the customer's instruction. They are onward recipients the customer selects, not sub-processors Forge engages.</p>
+          <Table rows={customerDirectedRecipients} />
+
+          <h2 style={styles.h2}>International transfers</h2>
+          <p style={styles.p}>Forge is operated from the United States and most sub-processors process data in the United States. Where customer personal data originating in the EEA or UK is transferred, it is done under appropriate safeguards (e.g. Standard Contractual Clauses) as described in our Data Processing Addendum.</p>
+
+          <h2 style={styles.h2}>Contact</h2>
+          <p style={styles.p}>Forge Intelligence LLC, Portland, Oregon, USA &nbsp;·&nbsp; <a href="mailto:legal@forgeintelligence.ai" style={styles.link}>legal@forgeintelligence.ai</a></p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: { minHeight: '100vh', backgroundColor: '#0B0F1A', color: '#F8FAFC', fontFamily: "Inter, 'Geist', system-ui, -apple-system, sans-serif", padding: '80px 24px' },
+  container: { maxWidth: 920, margin: '0 auto', width: '100%' },
+  header: { marginBottom: 48 },
+  backLink: { display: 'inline-flex', alignItems: 'center', gap: 6, color: '#64748B', textDecoration: 'none', fontSize: 14, marginBottom: 32 },
+  title: { fontSize: 36, fontWeight: 700, color: '#F8FAFC', margin: '0 0 8px', letterSpacing: '-0.5px' },
+  subtitle: { fontSize: 13, color: '#64748B', margin: 0 },
+  card: { backgroundColor: '#1E293B', borderRadius: 12, border: '1px solid rgba(255,255,255,0.06)', padding: '48px 52px' },
+  p: { fontSize: 15, color: '#94A3B8', lineHeight: 1.75, margin: '0 0 12px' },
+  note: { fontSize: 13, color: '#64748B', fontStyle: 'italic', margin: '0 0 12px' },
+  h2: { fontSize: 18, fontWeight: 600, color: '#F8FAFC', margin: '36px 0 8px' },
+  tableWrap: { overflowX: 'auto', margin: '0 0 8px' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: 13 },
+  th: { textAlign: 'left', padding: '8px 10px', borderBottom: '2px solid rgba(255,255,255,0.12)', color: '#CBD5E1', fontWeight: 600, whiteSpace: 'nowrap' },
+  td: { padding: '10px', borderBottom: '1px solid rgba(255,255,255,0.06)', color: '#94A3B8', verticalAlign: 'top', lineHeight: 1.6 },
+  strong: { color: '#F8FAFC', fontWeight: 600 },
+  url: { color: '#64748B', fontSize: 12 },
+  link: { color: '#3563FF', textDecoration: 'none' },
+};


### PR DESCRIPTION
## Why
You asked for a live DPA + sub-processor page you can share by URL with a client's legal team, not in the app nav. This builds exactly that (mirroring the `/privacy` route pattern), and fixes the sub-processor-list drift that bit us in #357.

## What
- **`/subprocessors`** — Art. 28 sub-processor list as a dated table, split into **Forge-engaged sub-processors** vs **customer-directed integrations** (onward recipients the customer connects — a real legal distinction). Includes change-notice + international-transfer language.
- **`/dpa`** — standard SaaS Data Processing Addendum terms (roles, processor obligations, security, sub-processors, DSAR assist, breach, audit, deletion, transfers) + Annexes I/II/III; bannered as the standard DPA with an execute-by-contact path; Annex III points at the live sub-processor page.
- **`src/data/subprocessors.ts`** — **single source of truth**. The Privacy Policy Section 6 now **renders from it** instead of keeping its own prose copy, so adding a vendor updates the policy, the page, and the DPA annex at once (no more #357-style manual drift).
- Marketing footer: `DPA` + `Sub-processors` links.

Both are public SPA routes (no `AppProvider`, no auth), like `/privacy` — shareable, not in the authenticated nav.

## Boundary
The DPA prose is standard-SaaS-template shaped with execute-by-contact; the **binding contract language is for your counsel to finalize**. A Word export of the DPA (with the sub-processor list as Annex III) accompanies this for attorney review — delivered in chat.

## Test plan
- `tsc --noEmit` clean; **197/197 vitest pass**; SPA routes (no server-route snapshot change).
- Dev: `/subprocessors`, `/dpa` render and are reachable by URL + footer; privacy Section 6 still lists every processor (now from the SSOT).

## Rollback
Revert — new pages/data + a privacy-section render swap + footer links.

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_