### PR TITLE
Add token-gated external brand-profile read by domain (for Mailforge pull)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2643,6 +2643,43 @@ app.patch('/api/brand-settings/:brandProfileId', async (req, res) => {
   }
 });
 
+// External: token-gated brand-profile read by domain. Lets Mailforge (and other
+// internal Sandbox apps) pull the active brand profile for a company by its
+// domain, machine-to-machine. Gated by a shared bearer MAILFORGE_SERVICE_TOKEN
+// (constant-time compare); disabled (503) until that env var is set.
+app.get('/api/external/brand-profile', async (req, res) => {
+  const expected = process.env.MAILFORGE_SERVICE_TOKEN;
+  if (!expected) return res.status(503).json({ error: 'service token not configured' });
+  const token = (req.get('authorization') || '').replace(/^Bearer\s+/i, '');
+  const ok =
+    token.length === expected.length &&
+    timingSafeEqual(Buffer.from(token), Buffer.from(expected));
+  if (!ok) return res.status(401).json({ error: 'unauthorized' });
+
+  const raw = String(req.query.url || '').trim().toLowerCase();
+  if (!raw) return res.status(400).json({ error: 'url query param required' });
+  const domain = raw.replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/.*$/, '');
+  if (!domain) return res.status(400).json({ error: 'invalid url' });
+
+  try {
+    const result = await pool.query(
+      `SELECT id, brand_url, brand_name, version, profile_data
+         FROM brand_profiles
+        WHERE is_active = true
+          AND rtrim(regexp_replace(lower(brand_url), '^https?://(www\\.)?', ''), '/') = $1
+        ORDER BY updated_at DESC
+        LIMIT 1`,
+      [domain]
+    );
+    if (!result.rows.length) return res.status(404).json({ error: 'no active profile for domain' });
+    const r = result.rows[0];
+    const profile = { id: r.id, brandName: r.brand_name, brandUrl: r.brand_url, version: r.version, ...(r.profile_data || {}) };
+    return res.json({ profile });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
 app.get('/api/brand-profiles/list', requireAuth, async (req, res) => {
   try {
     const result = await pool.query(

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -52,6 +52,7 @@
   "GET /api/email-campaign/brief-templates/:brandProfileId",
   "GET /api/email-campaign/generate/:id",
   "GET /api/email-campaign/list/:brandProfileId",
+  "GET /api/external/brand-profile",
   "GET /api/facebook/pipedream/list-pages",
   "GET /api/factual-ground/authors/:brandProfileId",
   "GET /api/geo-strategist/briefs",


### PR DESCRIPTION
## Why
Mailforge's new Pitch Dossier engine generates a prospect pitch from a company's brand profile. To auto-fill that profile (instead of pasting JSON), Mailforge needs to pull a company's **active brand profile by domain**, machine-to-machine. Every existing brand-profile route is Clerk `requireAuth` + id-keyed, so there's no path for a sibling service to read by domain.

## What
New additive, read-only route in `server.js`:

```
GET /api/external/brand-profile?url=<domain>
```
- **Auth:** `Authorization: Bearer <MAILFORGE_SERVICE_TOKEN>`, constant-time compare. Returns **503** until the env var is set, **401** on mismatch.
- Normalizes the input (strips scheme/`www`/path) and matches `brand_profiles.brand_url` (also normalized: scheme/`www`/trailing slash stripped) where `is_active = true`, newest first.
- Returns `{ profile: { id, brandName, brandUrl, version, ...profile_data } }`, or **404** if no active profile for the domain.

## Test plan
- With `MAILFORGE_SERVICE_TOKEN` unset → `503`.
- Set the token, then: `curl -H "Authorization: Bearer <token>" "https://dev.forgeintelligence.ai/api/external/brand-profile?url=novaintelligenceai.com"` → returns the Nova profile JSON. Wrong/no token → `401`. Unknown domain → `404`.
- `node --check server.js` passes.

## Rollback
Additive route; revert this commit. No existing behavior or schema touched.

## Activation (after merge)
Set `MAILFORGE_SERVICE_TOKEN` (same value) on **both** Forge Intelligence and Mailforge, and `FORGE_INTEL_URL` on Mailforge. Then Mailforge's "Pull from Forge" button auto-fills the brand profile.

https://claude.ai/code/session_016fPjetBRfpSaDfiNzPv7Be

---
_Generated by [Claude Code](https://claude.ai/code/session_016fPjetBRfpSaDfiNzPv7Be)_