### PR TITLE
Add token-gated POST /api/external/analyze for Mailforge on-demand brand profiles

### DIFF
--- a/server.js
+++ b/server.js
@@ -2686,7 +2686,69 @@ app.get('/api/external/brand-profile', async (req, res) => {
   }
 });
 
+// POST /api/external/analyze — token-gated, headless "New Analysis" for Mailforge.
+// Generates a brand profile for a domain that has none, then makes it PERMANENT
+// (drops the anonymous 24h trial expiry) and unclaimed, so it's both usable now
+// AND a ready-to-claim asset if the prospect later converts to a paid Forge
+// account (their onboarding claim flow attaches them to the existing row).
+// Reuses the Context Hub analysis pipeline (scrape + Sonar + Claude).
+app.post('/api/external/analyze', express.json({ limit: '16kb' }), async (req, res) => {
+  const expected = process.env.MAILFORGE_SERVICE_TOKEN;
+  if (!expected) return res.status(503).json({ error: 'service token not configured' });
+  const token = (req.get('authorization') || '').replace(/^Bearer\s+/i, '');
+  const ok =
+    token.length === expected.length &&
+    timingSafeEqual(Buffer.from(token), Buffer.from(expected));
+  if (!ok) return res.status(401).json({ error: 'unauthorized' });
+
+  const raw = String(req.body?.url || '').trim().toLowerCase();
+  if (!raw) return res.status(400).json({ error: 'url required' });
+  const domain = raw.replace(/^https?:\/\//, '').replace(/^www\./, '').replace(/\/.*$/, '');
+  if (!domain || !domain.includes('.')) return res.status(400).json({ error: 'invalid url' });
+
+  const matchDomain = `rtrim(regexp_replace(lower(brand_url), '^https?://(www\\.)?', ''), '/') = $1`;
+  const shapeProfile = (r) => ({ id: r.id, brandName: r.brand_name, brandUrl: r.brand_url, version: r.version, ...(r.profile_data || {}) });
+
+  try {
+    // Already have a real (non-empty) active profile? Return it — never re-scan
+    // a domain we already know (no double spend). Ensure it's permanent.
+    const existing = await pool.query(
+      `SELECT id, brand_url, brand_name, version, profile_data FROM brand_profiles
+        WHERE is_active = true AND profile_data <> '{}'::jsonb AND ${matchDomain}
+        ORDER BY updated_at DESC LIMIT 1`,
+      [domain]
+    );
+    if (existing.rows.length) {
+      await pool.query(`UPDATE brand_profiles SET expires_at = NULL WHERE id = $1`, [existing.rows[0].id]);
+      return res.json({ profile: shapeProfile(existing.rows[0]), generated: false });
+    }
+
+    // Run the full pipeline (same internal call seed-brain uses).
+    const analyzeRes = await fetch(`https://${req.headers.host}/api/context-hub/analyze`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ brandUrl: `https://${domain}`, saveToBrain: true, checkBrainFirst: true })
+    });
+    const out = await analyzeRes.json().catch(() => ({}));
+    if (!analyzeRes.ok || !out.success || !out.data?.id) {
+      const code = analyzeRes.status === 409 ? 409 : 502;
+      return res.status(code).json({ error: out.error || out.message || 'analysis failed', reason: out.reason });
+    }
+
+    // Make it permanent + unclaimed (drop the 24h anonymous trial expiry).
+    await pool.query(`UPDATE brand_profiles SET expires_at = NULL WHERE id = $1`, [out.data.id]);
+    const fresh = await pool.query(
+      `SELECT id, brand_url, brand_name, version, profile_data FROM brand_profiles WHERE id = $1`,
+      [out.data.id]
+    );
+    return res.json({ profile: shapeProfile(fresh.rows[0]), generated: true });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
 app.get('/api/brand-profiles/list', requireAuth, async (req, res) => {
+
   try {
     const result = await pool.query(
       `SELECT id, brand_url, brand_name, profile_data FROM brand_profiles WHERE is_active = true ORDER BY updated_at DESC`

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -166,6 +166,7 @@
   "POST /api/email-campaign/email/:id/dismiss-flag-as-false-positive",
   "POST /api/email-campaign/email/:id/resolve-flag",
   "POST /api/email-campaign/save-brief-template",
+  "POST /api/external/analyze",
   "POST /api/facebook/pipedream/select-page",
   "POST /api/forge-scrape",
   "POST /api/forge/prompt-pack/lovable",


### PR DESCRIPTION
## Why
Mailforge's pitch engine pulls brand profiles from FI via `GET /api/external/brand-profile`, but that 404s for any prospect FI hasn't analyzed yet (most cold prospects) — so those pitches fall back to ungrounded. This lets Mailforge **kick off a new analysis on demand** for a domain with no profile, and get the profile JSON back.

Strategic note (Brian): generating these **permanently** means the brand profile sits pre-loaded in FI's DB, so converting a prospect to a paid Forge engagement later is just a claim/flip — no re-scan.

## What
New sibling endpoint `POST /api/external/analyze { url }`, token-gated by the shared `MAILFORGE_SERVICE_TOKEN` (same constant-time `timingSafeEqual` auth as the brand-profile endpoint):

- **Reuses the Context Hub pipeline** (the same engine onboarding + `seed-brain` use): Firecrawl scrape → Sonar competitor/ICP discovery → Claude. Internal `fetch` to `/api/context-hub/analyze` with `saveToBrain: true`, matching `seed-brain`'s pattern.
- **Makes the result PERMANENT** — drops the anonymous 24h trial `expires_at` that an unauthenticated analyze run otherwise stamps (`context-hub.js:764`) — and leaves it **unclaimed** (no `clerk_user_id`), so the prospect's own onboarding claim flow can attach them later.
- **Idempotent / no double-spend:** if a real (non-empty) active profile already exists for the domain, returns it without re-scanning, ensuring it's permanent on the way out.
- Returns the same `{ profile }` shape as `GET /api/external/brand-profile`.

## Test plan
- `node --check server.js` ✅
- Route snapshot regenerated via `node test/gen-snapshot.js` (+1 route: `POST /api/external/analyze`) so `route-inventory` stays green ✅
- Post-merge/deploy: call with the service token against a domain FI hasn't profiled (e.g. `resolve.ai`) → expect a generated profile + `generated: true`; second call → `generated: false` (cached). The Mailforge-side consumer (a `company.forge_enrich` job + on-demand trigger) lands in a follow-up PR on the Mailforge app branch once this is live.

## Rollback
Single additive route, no schema changes, no changes to existing routes/mounts. Revert the commit to remove.

https://claude.ai/code/session_016fPjetBRfpSaDfiNzPv7Be

---
_Generated by [Claude Code](https://claude.ai/code/session_016fPjetBRfpSaDfiNzPv7Be)_