### PR TITLE
fix(generation): closed-world grounding guardrail to stop confabulation

### DIFF
--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,6 +10,16 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-16 — Closed-world grounding guardrail (anti-confabulation)
+
+A published SYSOI article (`field-event-attribution…`) recommended an attribution model SYSOI doesn't offer (W-shaped), named a competitor (Cometly), and dumped pricing without terms. Root cause traced: the article faithfully echoed a **polluted brand profile** (`profile_data.voiceProfile` literally said *"openly names competitors, publishes real prices"*; pricing baked in bare), while the strong **Factual Ground** guardrail was **NULL for SYSOI** (so inert), and even when present it only says "don't *contradict*" — not closed-world.
+
+- **Fix (this PR):** added an **unconditional closed-world GROUNDING rule** to both generation user-prompts (`server.js` content-generator + `src/server/routes/campaign.js`): ground every concrete claim in Brand Profile / Factual Ground / briefs; do NOT introduce prices, named competitors, named methodologies/models, stats, customers, case studies, dates, credentials, or product names not present; never a bare price (always with terms); never name/disparage competitor products. Applies even when Factual Ground is empty (the SYSOI case).
+- **Done out-of-band (DB):** SYSOI brand `profile_data` de-polluted (competitor-naming voice directive removed; pricing now carries terms). The live article + Forge source `article_json` were corrected to SYSOI's real models (multi-touch time-decay 180d + last-touch).
+- **Next:** populate SYSOI's `settings.factualGround` (now that it'll be obeyed); confirm the facts-UI writes to `factualGround` for every brand; consider a pre-publish fact-gate on the `compliance/precog` path.
+
+---
+
 ### 2026-06-12 (cont. 3) — Evening: docs race fixed, Opus truncation, UI copy, generation-surface sweep
 
 All merged to `development` same evening.

--- a/server.js
+++ b/server.js
@@ -4096,6 +4096,8 @@ ${mistakesRes.rows.length > 0 ? trimTo(mistakesRes.rows, 1500) : 'No mistakes lo
 
 CRITICAL: Factual Ground (if present above) is the source of truth for any claim about this company — use it verbatim and never contradict it. Brain patterns reinforce proven angles. Brain mistakes are what to avoid. These are real signals from published content performance — treat them as hard constraints on tone, angle, and format.
 
+GROUNDING (closed-world — applies even if Factual Ground is empty): ground every concrete claim about this company in the Brand Profile, Factual Ground, and briefs above. Do NOT introduce specifics that do not appear there — this includes prices or fees, named competitor products, named methodologies/models/frameworks, statistics or percentages, customer names, case studies, dates, credentials, or product/feature names. If a specific is not provided in the context above, omit it or speak generally — never invent one to sound authoritative. Never state a price as a bare number: always include its terms (what it covers and its conditions). Do not name, rank, compare against, or disparage specific competitor products.
+
 Return ONLY valid JSON matching the specified output format. No markdown, no code fences, no commentary.`;
 
     send('chunk', 'Brain loaded. Building article...');

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -667,6 +667,8 @@ BRAIN MISTAKES:
 ${trimTo(mistakesRes.rows, 1500)}
 
 IMPORTANT: Use the angle profile above to lock the persona, funnel position, content type, and E-E-A-T focus.
+
+GROUNDING (closed-world — applies even if Factual Ground is empty): ground every concrete claim about this company in the Brand Profile, Factual Ground, and briefs above. Do NOT introduce specifics that do not appear there — this includes prices or fees, named competitor products, named methodologies/models/frameworks, statistics or percentages, customer names, case studies, dates, credentials, or product/feature names. If a specific is not provided in the context above, omit it or speak generally — never invent one to sound authoritative. Never state a price as a bare number: always include its terms (what it covers and its conditions). Do not name, rank, compare against, or disparage specific competitor products.
 Return ONLY valid JSON matching the content generator output format.`;
 
       let fullText = '';


### PR DESCRIPTION
## Why
A published SYSOI article (`field-event-attribution…`) recommended an attribution model SYSOI **doesn't offer** (W-shaped position-based), **named a competitor** (Cometly), and stated **pricing without terms**. Tracing it showed this isn't a one-off — it's a structural hole in generation grounding:

1. The article faithfully echoed a **polluted brand profile** — `profile_data.voiceProfile` literally instructed *"the brand openly names competitors, publishes real prices"*, and pricing was baked in as bare numbers.
2. The strong **Factual Ground** guardrail (*"USE VERBATIM… NEVER invent"*) was **NULL for the SYSOI brand**, so it rendered nothing — inert.
3. Even when Factual Ground *is* populated, it only forbids **contradicting** stated facts. It does **not** stop the model from **introducing** specifics the facts are silent about. So the model invented W-shaped/Cometly from its training priors with nothing to stop it.

## What
Adds an **unconditional closed-world GROUNDING rule** to both article-generation user-prompts:
- `server.js` (`/api/content-generator/generate`)
- `src/server/routes/campaign.js` (per-angle campaign generation)

> *Ground every concrete claim in the Brand Profile / Factual Ground / briefs. Do NOT introduce specifics that don't appear there — prices/fees, named competitor products, named methodologies/models/frameworks, statistics, customer names, case studies, dates, credentials, or product/feature names. If a specific isn't provided, omit it or speak generally — never invent one. Never state a price as a bare number — always with its terms. Do not name, rank, compare against, or disparage specific competitor products.*

**Critically, it applies even when Factual Ground is empty** — which was the exact failing case. Brand-agnostic: every brand benefits.

## Test plan
- `node --check server.js` ✅ and `node --check src/server/routes/campaign.js` ✅
- On dev: regenerate the field-event article (or any topic that tempts pricing/competitor specifics) for a brand and confirm it no longer invents model names/competitors/bare prices.

## Done out-of-band (DB, already live)
- SYSOI brand `profile_data` de-polluted: removed the "names competitors" voice directive; pricing now carries its terms.
- The live article + Forge source `article_json` corrected to SYSOI's real models (multi-touch time-decay 180-day half-life + last-touch).

## Follow-ups (not in this PR)
- Populate SYSOI's `settings.factualGround` now that it'll be obeyed; confirm the facts-UI writes to `factualGround` for every brand; consider a pre-publish fact-gate on the `compliance/precog` path.

## Rollback
Revert the two prompt edits — additive prompt text only, no schema/dependency change.

https://claude.ai/code/session_014jDcELL1Di39aep1Fook7x

---
_Generated by [Claude Code](https://claude.ai/code/session_014jDcELL1Di39aep1Fook7x)_