### PR TITLE
fix(remotion): stop first-scene copy shaking (Fit measure/continueRender race)

### DIFF
--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -10,6 +10,14 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-06-16 (later) — Remotion: fix first-scene "shaking" copy (Fit render race)
+
+The product-video copy shook / read as a rendering glitch on the first scene. Root cause in `remotion/src/DataReel.tsx`'s `Fit` component: it called `continueRender` in the **same effect** as `setScale`, so `renderMedia` screenshotted the pre-scale (`scale=1`) frame on some frames and the fitted (`scale<1`) frame on others → the headline flickered between full and fitted size frame-to-frame. Worst on scene 1 because its long headline is the one `Fit` actually scales down.
+
+- **Fix:** initialize `scale` to `null` and release the frame in a **separate effect gated on `scale`** — the delayRender holds until the scale is measured AND committed, so every captured frame is at the final scale. Also rounded `useRise`'s entrance `translateY` to whole pixels (sub-pixel text inside `Fit`'s `scale()` shimmers). `npx tsc --noEmit` clean. No behavior change for already-fitting scenes.
+
+---
+
 ### 2026-06-16 — Closed-world grounding guardrail (anti-confabulation)
 
 A published SYSOI article (`field-event-attribution…`) recommended an attribution model SYSOI doesn't offer (W-shaped), named a competitor (Cometly), and dumped pricing without terms. Root cause traced: the article faithfully echoed a **polluted brand profile** (`profile_data.voiceProfile` literally said *"openly names competitors, publishes real prices"*; pricing baked in bare), while the strong **Factual Ground** guardrail was **NULL for SYSOI** (so inert), and even when present it only says "don't *contradict*" — not closed-world.

--- a/remotion/src/DataReel.tsx
+++ b/remotion/src/DataReel.tsx
@@ -113,28 +113,38 @@ const useRise = (delay = 0, dist = 50) => {
   const { k } = useL();
   const T = useT();
   const s = spring({ frame: frame - delay, fps, config: T.springCfg });
-  return { opacity: Math.min(1, s), transform: `translateY(${interpolate(s, [0, 1], [dist * k, 0])}px)` };
+  // Round to whole pixels: a fractional translateY on text re-rasterizes the
+  // glyphs at sub-pixel positions each frame inside Fit's scale() wrapper, which
+  // shimmers. Whole-pixel steps are visually identical and jitter-free.
+  return { opacity: Math.min(1, s), transform: `translateY(${Math.round(interpolate(s, [0, 1], [dist * k, 0]))}px)` };
 };
 
 // Scale scene content DOWN to fit the safe area, so a long headline or a deck
 // scene with many items can never render out of frame. Measures natural size
-// (scrollWidth/Height, unaffected by the transform) once and shrinks if needed;
-// delayRender holds the frame until the measurement lands on Lambda.
+// (scrollWidth/Height, unaffected by the children's entrance transforms) and
+// shrinks if needed.
+//
+// The frame is held by delayRender until the scale is MEASURED AND COMMITTED —
+// continueRender fires in a separate effect gated on `scale`, NOT in the same
+// effect as setScale. Releasing in the same tick let renderMedia screenshot the
+// pre-scale (scale=1) frame on some frames and the scaled frame on others, so
+// the headline flickered between full and fitted size frame-to-frame (the
+// "shaking" glitch — most visible on the first scene's long headline).
 const Fit: React.FC<{ children: React.ReactNode; pad: number }> = ({ children, pad }) => {
   const { width, height } = useVideoConfig();
   const ref = React.useRef<HTMLDivElement>(null);
-  const [scale, setScale] = React.useState(1);
+  const [scale, setScale] = React.useState<number | null>(null);
   const [handle] = React.useState(() => delayRender("fit-measure"));
   React.useEffect(() => {
     const el = ref.current;
-    if (el) {
-      const s = Math.min(1, (width - pad * 2) / el.scrollWidth, (height - pad * 2) / el.scrollHeight);
-      if (s > 0 && s < 0.999) setScale(s);
-    }
-    continueRender(handle);
-  }, [handle, width, height, pad]);
+    const s = el ? Math.min(1, (width - pad * 2) / el.scrollWidth, (height - pad * 2) / el.scrollHeight) : 1;
+    setScale(s > 0 && s < 0.999 ? s : 1);
+  }, [width, height, pad]);
+  React.useEffect(() => {
+    if (scale !== null) continueRender(handle);
+  }, [scale, handle]);
   return (
-    <div style={{ transform: `scale(${scale})`, transformOrigin: "center center", display: "flex", justifyContent: "center", alignItems: "center" }}>
+    <div style={{ transform: `scale(${scale ?? 1})`, transformOrigin: "center center", display: "flex", justifyContent: "center", alignItems: "center" }}>
       <div ref={ref}>{children}</div>
     </div>
   );


### PR DESCRIPTION
## Why
The product video's copy **shook on the first scene** — hard to watch, looked like a rendering glitch (and it is — it only shows in the rendered MP4, not the Studio preview).

## Root cause
`remotion/src/DataReel.tsx`'s **`Fit`** component (which scales long content down to the safe area) called `continueRender` in the **same effect** as `setScale`:
```js
useEffect(() => { ...; if (s < 0.999) setScale(s); continueRender(handle); }, [...]);
```
`continueRender` releases the frame for screenshotting, but `setScale` is an async state update. So `renderMedia` could capture the **pre-scale (`scale=1`)** frame on some frames and the **fitted (`scale<1`)** frame on others → the headline flickered between full size and fitted size frame-to-frame. Worst on scene 1 because its long headline is the one `Fit` actually scales down.

## Fix
- Initialize `scale` to `null` and release the held frame in a **separate effect gated on `scale`** — `delayRender` now holds the frame until the scale is measured **and committed**, so every captured frame is at the final scale. No more flicker.
- Rounded `useRise`'s entrance `translateY` to whole pixels — a fractional `translateY` on text re-rasterizes glyphs at sub-pixel positions inside `Fit`'s `scale()` wrapper (shimmer). Whole-pixel steps are visually identical and jitter-free.

## Test plan
- `npx tsc --noEmit` clean.
- **Re-render the video** (or the affected first scene) and confirm the copy is steady — no size flicker on the headline, no sub-pixel shimmer on the entrance.
- Scenes that already fit (`scale=1`) are unchanged.

## Rollback
Revert the two edits in `DataReel.tsx` — isolated to the `Fit` component + the `useRise` helper.

https://claude.ai/code/session_014jDcELL1Di39aep1Fook7x

---
_Generated by [Claude Code](https://claude.ai/code/session_014jDcELL1Di39aep1Fook7x)_