### PR TITLE
fix(remotion): defeat per-worker Fit measurement race (real shake fix)

### DIFF
--- a/remotion/src/DataReel.tsx
+++ b/remotion/src/DataReel.tsx
@@ -124,25 +124,39 @@ const useRise = (delay = 0, dist = 50) => {
 // (scrollWidth/Height, unaffected by the children's entrance transforms) and
 // shrinks if needed.
 //
-// The frame is held by delayRender until the scale is MEASURED AND COMMITTED —
-// continueRender fires in a separate effect gated on `scale`, NOT in the same
-// effect as setScale. Releasing in the same tick let renderMedia screenshot the
-// pre-scale (scale=1) frame on some frames and the scaled frame on others, so
-// the headline flickered between full and fitted size frame-to-frame (the
-// "shaking" glitch — most visible on the first scene's long headline).
+// The "shaking" glitch was a per-WORKER measurement race, not a release-timing
+// one. renderMedia/Lambda render frames across several concurrent browser
+// workers; consecutive frames land on alternating workers. A cold worker can
+// measure `scrollWidth` against not-yet-settled font layout and get a width a
+// hair different from a warm worker's — so the fitted scale differs per worker,
+// and the headline scales slightly bigger/smaller on ALTERNATING frames (the
+// vibration). Two defenses, both needed:
+//   1. Measure only AFTER `document.fonts.ready`, so every worker measures the
+//      same final glyph metrics (kills the cold-vs-warm split at the source).
+//   2. Quantize the fitted scale to 1% steps, so any residual sub-pixel width
+//      difference collapses to the SAME scale on every worker and every frame.
+// continueRender still fires only once the scale is committed.
 const Fit: React.FC<{ children: React.ReactNode; pad: number }> = ({ children, pad }) => {
   const { width, height } = useVideoConfig();
   const ref = React.useRef<HTMLDivElement>(null);
   const [scale, setScale] = React.useState<number | null>(null);
   const [handle] = React.useState(() => delayRender("fit-measure"));
   React.useEffect(() => {
-    const el = ref.current;
-    const s = el ? Math.min(1, (width - pad * 2) / el.scrollWidth, (height - pad * 2) / el.scrollHeight) : 1;
-    setScale(s > 0 && s < 0.999 ? s : 1);
-  }, [width, height, pad]);
-  React.useEffect(() => {
-    if (scale !== null) continueRender(handle);
-  }, [scale, handle]);
+    let done = false;
+    const measure = () => {
+      if (done) return;
+      done = true;
+      const el = ref.current;
+      const raw = el ? Math.min(1, (width - pad * 2) / el.scrollWidth, (height - pad * 2) / el.scrollHeight) : 1;
+      const s = raw >= 0.99 ? 1 : Math.round(raw * 100) / 100;
+      setScale(s);
+      continueRender(handle);
+    };
+    const fonts = (document as Document & { fonts?: { status: string; ready: Promise<unknown> } }).fonts;
+    if (fonts && fonts.status !== "loaded") void fonts.ready.then(measure);
+    else measure();
+    return () => { done = true; };
+  }, [width, height, pad, handle]);
   return (
     <div style={{ transform: `scale(${scale ?? 1})`, transformOrigin: "center center", display: "flex", justifyContent: "center", alignItems: "center" }}>
       <div ref={ref}>{children}</div>


### PR DESCRIPTION
## Why

PR #408 tried to fix the first-scene headline "shake" by splitting `continueRender` into its own effect (theory: `renderMedia` screenshotted pre- vs post-scale frames). **It didn't fix it.** A fresh kinetic-theme render of the SYSOI reel still vibrates.

## Root cause (measured, not theorized)

The shake is a **per-worker measurement race**, not release timing. Frames render across concurrent browser workers (`--concurrency` locally, many on Lambda) and consecutive frames land on alternating workers. A cold worker measures `scrollWidth` against not-yet-settled font layout and gets a width a hair different from a warm worker's → `Fit` computes a different scale per worker → the headline scales slightly bigger/smaller on **alternating frames**.

Pixel evidence on the deliverable render:
- At `--concurrency=2`, a **fully settled** headline (6s in, long past the entrance spring) alternates every frame between `W=933/H=259` and `W=929/H=258` — ~54,000 changed px/frame in a region that should be static.
- At `--concurrency=1`, the same region is a single state (0–1 px/frame). That's why the earlier "can't reproduce locally" conclusion happened — single-worker renders dodge the race.

## Fix

Two defenses in `Fit`, both needed:
1. **Measure only after `document.fonts.ready`** — every worker then measures the same final glyph metrics, killing the cold-vs-warm split at the source.
2. **Quantize the fitted scale to 1% steps** — collapses any residual sub-pixel width difference to the same scale on every worker/frame (the ~120px pad absorbs the <1% under-fit).

`continueRender` still fires once, after the scale is committed.

## Test plan

- `npx tsc --noEmit` in `remotion/` — clean.
- **old code @ `--concurrency=2`**: 2 distinct headline states, toggling per frame.
- **new code @ `--concurrency=2`** (frames 170–215): **1** state across all 46 frames — stable.
- Full reel re-rendered @ `--concurrency=1` for delivery: settled headline changes ~1px/frame (vs ~54k) — steady. (Delivered to the user.)

## Rollback

Revert the commit — change is isolated to the `Fit` component in `remotion/src/DataReel.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jDcELL1Di39aep1Fook7x

---
_Generated by [Claude Code](https://claude.ai/code/session_014jDcELL1Di39aep1Fook7x)_