### PR TITLE
fix(security): read PayPal secret from PAYPAL_API_KEY (follow-up to #413)

### DIFF
--- a/server.js
+++ b/server.js
@@ -7092,14 +7092,17 @@ app.get('/api/admin/deploys', requireAuth, async (req, res) => {
 // SECURITY: the capture happens client-side, so we CANNOT trust the browser's
 // word that money moved. We re-fetch the order from PayPal server-side and
 // confirm it's COMPLETED for >= $99 before unlocking. Without this, anyone could
-// POST a brandProfileId here and unlock for free. Requires PAYPAL_CLIENT_SECRET
-// (the client id falls back to the public one used by the SDK).
+// POST a brandProfileId here and unlock for free. Reads the REST app secret from
+// PAYPAL_API_KEY (the existing Forge env-group var; PAYPAL_CLIENT_SECRET also
+// accepted) + PAYPAL_CLIENT_ID; the client id falls back to the public SDK one.
 const PAYPAL_API_BASE = 'https://api-m.paypal.com';
 const PAYPAL_CLIENT_ID_FALLBACK = 'AV1QAbjyqG1YTRCWKXzWjZr1Ls7uNLRnk5SzoC-ajEb3rZaq5h58SCUoi9lcZgd9OCvJrM2WchL1om6l';
 
 async function verifyPayPalOrder(orderId, minAmount) {
   const clientId = process.env.PAYPAL_CLIENT_ID || PAYPAL_CLIENT_ID_FALLBACK;
-  const secret = process.env.PAYPAL_CLIENT_SECRET;
+  // The REST app secret is stored in the Forge env group as PAYPAL_API_KEY;
+  // PAYPAL_CLIENT_SECRET is accepted too if it's ever added under that name.
+  const secret = process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_API_KEY;
   if (!clientId || !secret) return { ok: false, reason: 'paypal_not_configured' };
   try {
     const basic = Buffer.from(`${clientId}:${secret}`).toString('base64');


### PR DESCRIPTION
## Why
Follow-up to #413. That hotfix read `process.env.PAYPAL_CLIENT_SECRET` — but Forge's linked env group actually stores the REST app secret under **`PAYPAL_API_KEY`** (alongside `PAYPAL_CLIENT_ID`); there is no `PAYPAL_CLIENT_SECRET`. So as merged, the verifier would find no secret, fail closed, and **block every Forge payment** on the next deploy.

(That `PAYPAL_API_KEY` was almost certainly the secret all along — it was just never used, because the old code never verified anything server-side.)

## What
`verifyPayPalOrder` now reads `process.env.PAYPAL_CLIENT_SECRET || process.env.PAYPAL_API_KEY`, and uses `PAYPAL_CLIENT_ID` from the group (fallback to the public SDK id). **Zero env changes needed** — it works against what's already there.

## ⚠️ One assumption to confirm
That **`PAYPAL_API_KEY` is the PayPal REST app Secret** paired with `PAYPAL_CLIENT_ID`. If it's some other PayPal credential, the real secret still needs to live under one of those two names. Easiest confirmation: after this deploys to dev, a real $99 unlock should succeed; if it 402s with reason `token_failed`, the value isn't the right secret.

## Test plan
- `node --check server.js` — clean.
- After dev deploy: real $99 capture unlocks; bogus `orderId` → 402.

## Rollback
Revert; but then #413's verifier can't find the secret and blocks payments — fix forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR)_