### PR TITLE
feat(billing): paid_at column + promo redemption logging (PR2 foundation)

### DIFF
--- a/server.js
+++ b/server.js
@@ -6690,6 +6690,10 @@ pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS expires_at TIMES
 pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS is_paid BOOLEAN DEFAULT false`).catch(() => {});
     await pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS clerk_user_id TEXT`).catch(() => {});
   await pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS trial_started_at TIMESTAMPTZ`).catch(() => {});
+  // paid_at: set when a PayPal capture / promo is verified. The payment/auth
+  // redesign uses this as the "paid, may create a Clerk account" stamp — distinct
+  // from is_paid (which the Clerk-account tether flips). NULL = unpaid preview.
+  await pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS paid_at TIMESTAMPTZ`).catch(() => {});
   await pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS welcome_email_sent_at TIMESTAMPTZ`).catch(() => {});
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_bp_clerk ON brand_profiles(clerk_user_id)`).catch(() => {});
 pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS onboard_session_id TEXT`).catch(() => {});
@@ -7412,6 +7416,14 @@ app.post('/api/promo/validate', softAuth, async (req, res) => {
       `UPDATE brand_profiles SET is_paid = true, expires_at = NULL, updated_at = NOW() WHERE id = $1`,
       [brandProfileId]
     );
+    // Log the redemption (audit trail; the table existed but was never written to).
+    // UNIQUE(code, brand_profile_id) makes a repeat redemption of the same code on
+    // the same brand a no-op.
+    await pool.query(
+      `INSERT INTO promo_redemptions (code, brand_profile_id) VALUES ($1, $2)
+       ON CONFLICT (code, brand_profile_id) DO NOTHING`,
+      [normalised, brandProfileId]
+    ).catch((e) => console.warn('[PROMO] redemption log failed:', e.message));
     console.log(`[PROMO] ${normalised} applied to brand ${brandProfileId} — ${promo.description}`);
   } else if (promo.discount === 100) {
     console.warn(`[PROMO] ${normalised} validated but no brandProfileId found — is_paid NOT set`);


### PR DESCRIPTION
## Why
Foundation for the payment/auth redesign (PR2). Two **safe, additive** changes that touch **no auth path** — so they can land while I build the riskier inversion as its own careful pass.

## What
- **`brand_profiles.paid_at`** (idempotent `ALTER`). The redesign uses this as the *"payment verified, may create a Clerk account"* stamp — distinct from `is_paid` (which the Clerk tether will flip). Unused until the inversion PR.
- **`/api/promo/validate` now logs to `promo_redemptions`** on a successful apply. That table was created long ago but **never written to** — which is exactly why your `FORGEFRIEND` redemption left no trace. `ON CONFLICT (code, brand_profile_id) DO NOTHING`. Otherwise unchanged.

## The redesign blueprint (locked with you) — for the follow-up PRs
Target: scan → **24h view-only preview** (Brand Profile + Strategy) → **hard-deleted after 24h**; **pay $99/promo → stamps `paid_at`, does NOT grant access**; **Clerk account creation → flips `is_paid`** (gated on `paid_at`); **no 7-day trial**.

- **PR B — the inversion (next, careful pass):** PayPal (`server.js` ~7170) + promo (~7416) stamp `paid_at` instead of `is_paid`; the tether (`/api/auth/me?brand_id=`, the **two overlapping handlers at ~7264 and ~7338** + super-admin ~7286) flips `is_paid` gated on `paid_at`; drop `trial.active` from the `isPaid` computation (~7362/7364) — this kills the 7-day free-app trial; remove the trial CTA in `GateModal.tsx`. **Migration note:** existing trial-only users lose access when `trial.active` is dropped; existing `is_paid=true` users are unaffected.
- **PR C — the reaper:** cron sweep hard-deleting unpaid/unclaimed brands past 24h + their `generated_content_<id>` tables.

I'm holding B and C out of this PR on purpose: it's production auth with no test harness and I can't run it live, and the overlapping tether handlers are exactly where a rushed edit regresses. Better to invert them deliberately than fast.

## Test plan
- `node --check server.js` — clean.
- `paid_at` is additive/unused; promo logging is additive (ON CONFLICT no-op on repeat).

## Rollback
Revert — both changes are additive, nothing depends on them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR)_