### PR TITLE
feat(billing): invert payment/auth — is_paid at Clerk signup, kill 7-day trial (PR B)

### DIFF
--- a/server.js
+++ b/server.js
@@ -6694,6 +6694,10 @@ pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS is_paid BOOLEAN 
   // redesign uses this as the "paid, may create a Clerk account" stamp — distinct
   // from is_paid (which the Clerk-account tether flips). NULL = unpaid preview.
   await pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS paid_at TIMESTAMPTZ`).catch(() => {});
+  // One-time backfill (idempotent): existing paid brands predate paid_at, so stamp
+  // them — otherwise the new tether gate (paid_at IS NOT NULL) would block a
+  // pre-deploy payer who hasn't claimed yet, and the 24h reaper would be ambiguous.
+  await pool.query(`UPDATE brand_profiles SET paid_at = COALESCE(paid_at, updated_at, NOW()) WHERE is_paid = true AND paid_at IS NULL`).catch(() => {});
   await pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS welcome_email_sent_at TIMESTAMPTZ`).catch(() => {});
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_bp_clerk ON brand_profiles(clerk_user_id)`).catch(() => {});
 pool.query(`ALTER TABLE brand_profiles ADD COLUMN IF NOT EXISTS onboard_session_id TEXT`).catch(() => {});
@@ -7166,8 +7170,11 @@ app.post('/api/onboard/paypal-success', async (req, res) => {
       return res.status(402).json({ error: msg, reason: verified.reason });
     }
 
+    // Payment verified → stamp paid_at (NOT is_paid). is_paid is flipped only when
+    // the buyer creates their Clerk account (the tether in /api/auth/me), so there's
+    // no access without an account. paid_at also exempts the brand from the 24h reaper.
     await pool.query(
-      `UPDATE brand_profiles SET is_paid = true, expires_at = NULL, updated_at = NOW() WHERE id = $1`,
+      `UPDATE brand_profiles SET paid_at = COALESCE(paid_at, NOW()), updated_at = NOW() WHERE id = $1`,
       [brandProfileId]
     );
     await pool.query(
@@ -7261,13 +7268,16 @@ app.get('/api/auth/me', requireAuth, async (req, res) => {
         [req.userId]
       );
       if (!existing.rows.length) {
+        // Tether ONLY a paid brand (paid_at set by PayPal/promo), and flip is_paid
+        // here — account creation is what grants access. An unpaid brand no-ops, so
+        // a Clerk account with no paid brand simply gets nothing.
         const tether1Res = await pool.query(
-          `UPDATE brand_profiles SET clerk_user_id = $1, trial_started_at = COALESCE(trial_started_at, NOW()), updated_at = NOW() WHERE id = $2 AND (clerk_user_id IS NULL) RETURNING brand_name`,
+          `UPDATE brand_profiles SET clerk_user_id = $1, is_paid = true, expires_at = NULL, updated_at = NOW() WHERE id = $2 AND clerk_user_id IS NULL AND paid_at IS NOT NULL RETURNING brand_name`,
           [req.userId, brandId]
         );
         if (tether1Res.rows.length > 0) {
-          console.log(`[AUTH] Tethered brand ${brandId} to user ${req.userId} (trial timer started)`);
-          // Fire-and-forget: trial welcome email (idempotency-guarded inside)
+          console.log(`[AUTH] Tethered PAID brand ${brandId} to user ${req.userId} — is_paid set`);
+          // Fire-and-forget: welcome email (idempotency-guarded inside)
           sendTrialWelcomeEmail(req.userId, tether1Res.rows[0].brand_name).catch(() => {});
         }
       }
@@ -7331,17 +7341,17 @@ app.get('/api/auth/me', requireAuth, async (req, res) => {
     // No tethered brand — only tether if brand_id explicitly provided (from GateModal/onboard flow)
     if (!result.rows.length && brandId) {
       const candidate = await pool.query(
-        `SELECT * FROM brand_profiles WHERE id = $1 AND (clerk_user_id IS NULL OR clerk_user_id = $2) AND is_active = true LIMIT 1`,
+        `SELECT * FROM brand_profiles WHERE id = $1 AND (clerk_user_id IS NULL OR clerk_user_id = $2) AND is_active = true AND paid_at IS NOT NULL LIMIT 1`,
         [brandId, req.userId]
       );
       if (candidate.rows.length) {
         await pool.query(
-          `UPDATE brand_profiles SET clerk_user_id = $1, trial_started_at = COALESCE(trial_started_at, NOW()), updated_at = NOW() WHERE id = $2`,
+          `UPDATE brand_profiles SET clerk_user_id = $1, is_paid = true, expires_at = NULL, updated_at = NOW() WHERE id = $2`,
           [req.userId, candidate.rows[0].id]
         );
         result = candidate;
-        console.log(`[AUTH] Tethered brand ${candidate.rows[0].id} to user ${req.userId} (trial timer started, explicit brand_id)`);
-        // Fire-and-forget: trial welcome email (idempotency-guarded inside)
+        console.log(`[AUTH] Tethered PAID brand ${candidate.rows[0].id} to user ${req.userId} — is_paid set`);
+        // Fire-and-forget: welcome email (idempotency-guarded inside)
         sendTrialWelcomeEmail(req.userId, candidate.rows[0].brand_name).catch(() => {});
       }
     }
@@ -7356,12 +7366,11 @@ app.get('/api/auth/me', requireAuth, async (req, res) => {
         id: b.id,
         brandName: b.brand_name || b.brand_url,
         brandUrl: b.brand_url,
-        // isPaid reflects EFFECTIVE access: true if paid OR trial active.
-        // FE pages keep checking isPaid via useApp() and get the right answer
-        // for both 'permanently paid' and 'trial-active' states.
-        isPaid: (b.is_paid || trialState.active) || false,
+        // Access = is_paid only. The old free-app trial (trialState.active) is
+        // removed: app access now requires a $99 payment (or promo) + a Clerk account.
+        isPaid: b.is_paid || false,
       })),
-      isPaid: isSuperAdmin || result.rows[0]?.is_paid || trialState.active || false,
+      isPaid: isSuperAdmin || result.rows[0]?.is_paid || false,
       trial: {
         active: trialState.active,
         eligible: trialState.eligible,
@@ -7410,10 +7419,11 @@ app.post('/api/promo/validate', softAuth, async (req, res) => {
   // No global fallback — brandProfileId must come from frontend or auth token
   // Without it, the promo validates but is_paid does NOT flip (logged as warning)
 
-  // Apply — mark brand as paid
+  // Apply — stamp paid_at (comped). Like PayPal, this does NOT grant access; the
+  // Clerk-account tether flips is_paid. So a promo still requires creating an account.
   if (promo.discount === 100 && brandProfileId) {
     await pool.query(
-      `UPDATE brand_profiles SET is_paid = true, expires_at = NULL, updated_at = NOW() WHERE id = $1`,
+      `UPDATE brand_profiles SET paid_at = COALESCE(paid_at, NOW()), updated_at = NOW() WHERE id = $1`,
       [brandProfileId]
     );
     // Log the redemption (audit trail; the table existed but was never written to).

--- a/src/components/GateModal.tsx
+++ b/src/components/GateModal.tsx
@@ -132,14 +132,14 @@ export default function GateModal({ featureName, onClose, brandProfileId, onUnlo
         <h2 className="gate-title">
           {trialExpired
             ? 'Your 7-day trial ended'
-            : (isSignedIn ? `${featureName} is locked` : 'Start your free 7-day trial')}
+            : (isSignedIn ? `${featureName} is locked` : 'Unlock the full suite')}
         </h2>
         <p className="gate-desc">
           {trialExpired
             ? 'Your full-access trial wrapped — keep going with the full Forge Intelligence suite for a one-time $99. Your brain stays exactly as you left it.'
             : (isSignedIn
                 ? 'Unlock the full Forge Intelligence suite — GEO Strategy, Content Generation, Publishing, Performance, and more — for a one-time $99.'
-                : `Sign up free to unlock the full Forge Intelligence suite for 7 days — ${featureName}, all stages, no payment required. Your brain stays saved.`)}
+                : `Unlock the full Forge Intelligence suite — ${featureName}, all stages — for a one-time $99. You'll create your account right after payment. Your brain stays saved.`)}
         </p>
 
         <ul className="gate-features">
@@ -155,38 +155,9 @@ export default function GateModal({ featureName, onClose, brandProfileId, onUnlo
           ))}
         </ul>
 
-        {!isSignedIn && !trialExpired && (
-          <button
-            type="button"
-            onClick={() => {
-              if (brandProfileId) localStorage.setItem('forge_pending_brand_id', brandProfileId);
-              window.location.href = `${CLERK_SIGNUP_URL}?redirect_url=${encodeURIComponent(window.location.href)}`;
-            }}
-            style={{
-              width: '100%',
-              padding: '14px 20px',
-              background: '#3563FF',
-              border: 'none',
-              borderRadius: 10,
-              color: '#FFFFFF',
-              fontSize: '0.95rem',
-              fontWeight: 600,
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-              marginBottom: 8,
-              letterSpacing: '0.01em',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 8,
-            }}
-          >
-            Start your free 7-day trial →
-          </button>
-        )}
         <div className="gate-price-row">
           <span className="gate-price">$99</span>
-          <span className="gate-price-note">{!isSignedIn && !trialExpired ? 'or skip the trial — unlock permanently' : 'one-time · full suite · brain saved permanently'}</span>
+          <span className="gate-price-note">one-time · full suite · brain saved permanently</span>
         </div>
 
         {/* Promo code — persistent, always visible so users know it's available */}
@@ -226,7 +197,7 @@ export default function GateModal({ featureName, onClose, brandProfileId, onUnlo
         {ppError && <div className="gate-error">{ppError}</div>}
         <div id="forge-gate-paypal" />
 
-        <p className="gate-caption">{!isSignedIn && !trialExpired ? 'Your free brand brief stays. Sign up unlocks 7 days of full access.' : 'Your free brand brief stays. Payment unlocks all features.'}</p>
+        <p className="gate-caption">Your free brand brief stays. Payment unlocks all features.</p>
         <p style={{ marginTop: 14, fontSize: '0.7rem', color: '#64748B', textAlign: 'center', lineHeight: 1.6 }}>
           By clicking "Pay Now," you agree to our{" "}
           <a href="/terms" target="_blank" rel="noopener noreferrer" style={{ color: '#7C8DB5', textDecoration: 'underline' }}>Terms of Service</a>{" "}and{" "}


### PR DESCRIPTION
## Why
The core of the redesign (PR B). **Payment/promo no longer grant access — creating a Clerk account does.** And the **7-day full-app free trial** — the real "Clerk account without paying" path you flagged — is removed.

## Server (`server.js`)
- **PayPal `paypal-success` + promo `validate`** now stamp **`paid_at`** (NOT `is_paid`). `paid_at` = "payment verified, may create an account"; it also exempts the brand from the upcoming 24h reaper.
- **`/api/auth/me` tether** (both regular-user handlers ~7271 / ~7345): tether **only a paid brand** (`AND paid_at IS NOT NULL`) and flip `is_paid` + clear `expires_at` **there**. An unpaid brand no-ops → a Clerk account with no paid brand simply gets no access (*gate-at-access*, your pick). Super-admin claim path unchanged.
- **`isPaid` drops `trialState.active`** → access = `is_paid` (or super-admin). This kills the free-app trial.
- **Idempotent backfill:** existing `is_paid=true` brands get `paid_at = updated_at`, so a pre-deploy payer who hasn't claimed yet can still claim (and isn't reaper-ambiguous).

## Frontend (`GateModal.tsx`)
- Removed the **"Start your free 7-day trial →"** button (the no-payment route to Clerk).
- De-trialed the copy: anonymous users now see "pay $99 / promo to unlock; create your account right after payment." The post-payment `handleUnlocked → Clerk` redirect is unchanged.

## ⚠️ Migration effect (intended, per "kill the trial")
Any **existing user currently on an active trial** (`is_paid=false`, trial active) **loses access on deploy.** Existing `is_paid=true` users are unaffected (the backfill keeps them claimable). If you have real active-trial users right now, that's the trade — flag me if you want a grace path.

## Not in this PR
- **PR C — the 24h reaper** (cron hard-delete of unpaid/unclaimed brands + their `generated_content_*` tables).
- The trial apparatus (`getUserTrialState`, the `trial` object in `/api/auth/me`) is left in place but **vestigial** — it no longer grants access — to avoid breaking the FE that reads it. A later cleanup can rip it out.

## Test plan
- `node --check server.js` — clean.
- Frontend typecheck via **CI** (local `node_modules` absent → a local `tsc` is all "can't find react" noise). The FE change is removal + string simplification; no new types/props.
- **On dev, verify:** scan → can view Brand Profile/Strategy, app features gated → pay $99 → redirect to Clerk → account creation flips `is_paid` → access. A direct Clerk signup with **no paid brand → no access**.

## Rollback
Revert. `paid_at` writes + the backfill are additive; reverting restores the prior (trial-granting) behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR)_