### PR TITLE
feat(billing): the 24h reaper — hard-delete expired unpaid previews (PR C)

### DIFF
--- a/server.js
+++ b/server.js
@@ -7617,6 +7617,61 @@ app.post('/api/admin/reset-brand-paid', async (req, res) => {
   }
 });
 
+// POST /api/cron/sweep-expired-previews — the 24h reaper.
+// Hard-deletes anonymous unpaid PREVIEW brands once their 24h window lapses, plus
+// their per-brand generated_content_<id> table — so a scan-and-abandon leaves no
+// data behind. Meant to be hit on a schedule (Render Cron Job) with the admin
+// password. Body: { adminPassword, dryRun?, limit? }.
+//
+// SAFE BY CONSTRUCTION — it ONLY touches brands that are ALL of:
+//   • unclaimed   (clerk_user_id IS NULL)
+//   • unpaid      (paid_at IS NULL AND is_paid = false)  ← paid brands are never reaped
+//   • expired     (expires_at < NOW())
+// A paid or claimed brand can never match, so the worst-case blast radius is an
+// abandoned anonymous preview. Use dryRun:true to preview the candidate set first.
+app.post('/api/cron/sweep-expired-previews', async (req, res) => {
+  const { adminPassword, dryRun, limit } = req.body || {};
+  if (adminPassword !== process.env.ADMIN_RELAY_PASSWORD) return res.status(403).json({ error: 'Forbidden' });
+  const batch = Math.min(Math.max(parseInt(limit, 10) || 500, 1), 2000);
+  try {
+    const candidates = await pool.query(
+      `SELECT id, brand_url FROM brand_profiles
+       WHERE is_active = true
+         AND clerk_user_id IS NULL
+         AND paid_at IS NULL
+         AND is_paid = false
+         AND expires_at IS NOT NULL
+         AND expires_at < NOW()
+       ORDER BY expires_at ASC
+       LIMIT $1`,
+      [batch]
+    );
+    if (dryRun) {
+      return res.json({ success: true, dryRun: true, candidates: candidates.rows.length, sample: candidates.rows.slice(0, 20) });
+    }
+    let deleted = 0;
+    const errors = [];
+    for (const row of candidates.rows) {
+      // safeId is the brand's own UUID with dashes→underscores (matches how the
+      // per-brand table was created); UUID-derived, so safe to interpolate.
+      const safeId = row.id.replace(/-/g, '_');
+      try {
+        await pool.query(`DROP TABLE IF EXISTS generated_content_${safeId}`);
+        await pool.query(`DELETE FROM promo_redemptions WHERE brand_profile_id = $1`, [row.id]).catch(() => {});
+        await pool.query(`DELETE FROM brand_profiles WHERE id = $1`, [row.id]);
+        deleted++;
+      } catch (e) {
+        errors.push({ id: row.id, error: e.message });
+        console.error('[REAPER] failed to delete expired preview', row.id, e.message);
+      }
+    }
+    console.log(`[REAPER] swept ${deleted}/${candidates.rows.length} expired previews (${errors.length} errors)`);
+    res.json({ success: true, deleted, attempted: candidates.rows.length, errors });
+  } catch(e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
 
 
 

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -159,6 +159,7 @@
   "POST /api/content/regenerate-image/:contentId",
   "POST /api/content/topic-check",
   "POST /api/context-hub/analyze",
+  "POST /api/cron/sweep-expired-previews",
   "POST /api/digest/send-all",
   "POST /api/digest/send/:brandProfileId",
   "POST /api/domain/check",


### PR DESCRIPTION
## Why
Final piece of the redesign (PR C). A scan creates a 24h **view-only preview**; this is the thing that makes it actually *"explode after 24 hours and delete their data."*

## What
- **`POST /api/cron/sweep-expired-previews`** (guarded by `adminPassword`, same as the other cron/admin endpoints). For each expired preview it **DROPs** the per-brand `generated_content_<id>` table, clears `promo_redemptions`, and **DELETEs** the `brand_profiles` row — gone completely.
- **Safe by construction.** The candidate query requires **all** of:
  - unclaimed — `clerk_user_id IS NULL`
  - unpaid — `paid_at IS NULL AND is_paid = false`  ← **paid brands are never reaped**
  - expired — `expires_at < NOW()`
  
  A paid or claimed brand can never match, so the worst case is an abandoned anonymous preview. The `paid_at` guard from PR B is what makes this safe.
- **`dryRun: true`** returns the candidate count + a 20-row sample **without deleting** — eyeball it before arming the schedule. Batched (default 500, cap 2000) with per-brand try/catch so one bad drop never aborts the run.

## ⚙️ Setup (you)
Add a **Render Cron Job** (hourly or daily) that POSTs `{ "adminPassword": "<ADMIN_RELAY_PASSWORD>" }` to `https://forgeintelligence.ai/api/cron/sweep-expired-previews`. **Run it once with `{ "dryRun": true }` first** to confirm the candidate set looks right before it deletes anything.

## Test plan
- `node --check server.js` — clean.
- On dev: `curl -XPOST .../api/cron/sweep-expired-previews -d '{"adminPassword":"…","dryRun":true}'` → confirms candidates; then a real run deletes only those.

## Rollback
Revert — the endpoint is new and only runs when called with the admin password; nothing invokes it until you wire the cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbuyVFeoo4mYTtV2b1SkWR)_