### PR TITLE
Fix TL;DR export styling + surface keyTakeaway for review

### DIFF
--- a/src/pages/ComplianceGatePage.tsx
+++ b/src/pages/ComplianceGatePage.tsx
@@ -46,6 +46,7 @@ interface Article {
     overallConfidence: number;
     brainMatchScore: number;
     metaDescription?: string;
+    keyTakeaway?: string;
     faqs?: Array<{ question: string; answer: string }>;
   };
   compliance_status: ComplianceStatus;
@@ -165,6 +166,9 @@ function ComplianceGateContent() {
   // FAQ edits — parallel structure to editedSections. Each FAQ entry can have its question
   // and/or answer overridden. Empty fields default to the LLM-generated original on submit.
   const [editedFaqs, setEditedFaqs] = useState<Record<number, { question?: string; answer?: string }>>({});
+  // Key Takeaway (TL;DR) edit — null = untouched (publish the original). Surfaced for
+  // review so the TL;DR stops shipping unreviewed; the edit flows to /approve.
+  const [editedKeyTakeaway, setEditedKeyTakeaway] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [critiqueLoading, setCritiqueLoading] = useState(false);
   const [submitLoading, setSubmitLoading] = useState(false);
@@ -389,6 +393,7 @@ function ComplianceGateContent() {
           reviewMode: mode,
           editedSections: edits,
           editedFaqs: faqEdits,
+          ...(editedKeyTakeaway !== null ? { keyTakeaway: editedKeyTakeaway } : {}),
           decisions
         })
       });
@@ -408,6 +413,7 @@ function ComplianceGateContent() {
   const selectArticle = (article: Article) => {
     setSelectedArticle(article);
     setReport(article.compliance_report || null);
+    setEditedKeyTakeaway(null); // reset per-article so a prior article's TL;DR edit doesn't carry
     if (article.compliance_report) setStep('review');
     // Restore any in-progress edits for this article from localStorage
     try {
@@ -606,6 +612,21 @@ function ComplianceGateContent() {
                 Green sections passed AI review — shown read-only, but you can still edit them before publishing. Yellow/red sections have flags that need your decision.
               </span>
             </div>
+
+            {/* Key Takeaway (TL;DR) — surfaced for review so it stops shipping
+                unreviewed. It renders at the top of every published export. */}
+            {(selectedArticle.article_json?.keyTakeaway || editedKeyTakeaway !== null) && (
+              <div style={{ margin: '0 0 18px', padding: '14px 16px', border: '1px solid var(--color-border, #2B2F36)', borderRadius: 10, background: 'var(--color-surface-2, rgba(255,255,255,0.03))' }}>
+                <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-muted)', marginBottom: 8 }}>TL;DR / Key Takeaway — review before publish</div>
+                <textarea
+                  value={editedKeyTakeaway ?? selectedArticle.article_json?.keyTakeaway ?? ''}
+                  onChange={e => setEditedKeyTakeaway(e.target.value)}
+                  rows={3}
+                  placeholder="This summary ships at the top of every published article. Edit it here before approving."
+                  style={{ width: '100%', resize: 'vertical', font: 'inherit', padding: '8px 10px', borderRadius: 8, border: '1px solid var(--color-border, #2B2F36)', background: 'var(--color-bg, #14171C)', color: 'var(--color-text, #F2EFE8)' }}
+                />
+              </div>
+            )}
 
             {/* Sections */}
             <div className="comp-sections">

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -922,14 +922,15 @@ export default function PublishingQueuePage() {
       })),
     };
 
-    // ── TL;DR / Key Takeaway block (Frank's other recurring ask — keyTakeaway was
-    //    generated but never rendered into the export). Sits right after the
-    //    back-link, before the body. Inline-styled so it renders standalone. ──
+    // ── TL;DR / Key Takeaway block. Class-only, NO inline styling — same contract as
+    //    the Site Template scraper (class names + DOM structure, no styling copied),
+    //    so the destination site's .article-tldr CSS owns the look. The old inline
+    //    indigo shipped an off-brand box that overrode the customer's stylesheet. ──
     const tldr = String(aj.keyTakeaway || '').trim();
     const tldrHtml = tldr ? `
-      <aside class="article-tldr" style="margin:1.5em 0;padding:1.25em 1.5em;border-left:4px solid #4F46E5;background:#f5f6ff;border-radius:8px">
-        <p style="margin:0 0 .4em;font-weight:700;text-transform:uppercase;letter-spacing:.08em;font-size:.78em;color:#4F46E5">TL;DR</p>
-        <p style="margin:0;line-height:1.6">${tldr.replace(/</g, '&lt;')}</p>
+      <aside class="article-tldr">
+        <p class="article-tldr-label">TL;DR</p>
+        <p class="article-tldr-body">${tldr.replace(/</g, '&lt;')}</p>
       </aside>` : '';
 
     return `<!-- Forge Intelligence content_id: ${item.content_id} | brand_id: ${item.brand_profile_id} | exported: ${new Date().toISOString()} -->
@@ -1039,6 +1040,8 @@ ${authorFooterHtml}
       });
     } else if (field === 'metaDescription') {
       updatedArticle.article_json = { ...updatedArticle.article_json, metaDescription: value };
+    } else if (field === 'keyTakeaway') {
+      updatedArticle.article_json = { ...updatedArticle.article_json, keyTakeaway: value };
     } else if (field === 'sectionHeading' && sectionIndex !== undefined) {
       const sections = [...(updatedArticle.article_json?.sections || [])];
       sections[sectionIndex] = { ...sections[sectionIndex], heading: value };
@@ -2254,6 +2257,24 @@ return (
                       </p>
                     )
                   )}
+                  {article?.article_json?.keyTakeaway ? (
+                    editingField === 'keyTakeaway' ? (
+                      <textarea
+                        className="pq-edit-inline pq-edit-meta"
+                        defaultValue={article.article_json.keyTakeaway}
+                        autoFocus
+                        rows={3}
+                        onBlur={e => saveArticleEdit('keyTakeaway', e.target.value)}
+                        onKeyDown={e => { if (e.key === 'Escape') setEditingField(null); }}
+                      />
+                    ) : (
+                      <aside className="article-tldr pq-editable" onClick={() => setEditingField('keyTakeaway')} title="Click to edit — this TL;DR ships at the top of every published article">
+                        <p className="article-tldr-label">TL;DR</p>
+                        <p className="article-tldr-body">{article.article_json.keyTakeaway}</p>
+                        <span className="pq-edit-hint">✎</span>
+                      </aside>
+                    )
+                  ) : null}
                   <div className="pq-preview-sections">
                     {sections.map((s: any, i: number) => (
                       <div key={i} className="pq-preview-section">

--- a/src/server/routes/compliance.js
+++ b/src/server/routes/compliance.js
@@ -473,7 +473,7 @@ router.post('/dismiss-flag', async (req, res) => {
 // POST approve — save human edits, write mistakes to brain, mark approved
 router.post('/approve', async (req, res) => {
   const startTime = Date.now();
-  const { brandProfileId, contentId, reviewMode, editedSections, decisions, editedFaqs } = req.body;
+  const { brandProfileId, contentId, reviewMode, editedSections, decisions, editedFaqs, keyTakeaway } = req.body;
   if (!brandProfileId || !contentId) return res.status(400).json({ error: 'brandProfileId and contentId required' });
   try {
     const safeId = brandProfileId.replace(/-/g, '_');
@@ -538,6 +538,22 @@ router.post('/approve', async (req, res) => {
           articleJson.faqs[edit.index] = { ...faq, question: newQ, answer: newA };
         }
       });
+    }
+
+    // Apply human edit to the Key Takeaway (TL;DR). It renders at the top of every
+    // published export but was never surfaced for review — now it is. Only write on
+    // an actual change; log the correction to the brain like section/FAQ edits.
+    if (typeof keyTakeaway === 'string' && keyTakeaway !== (articleJson.keyTakeaway || '')) {
+      pool.query(
+        `INSERT INTO brain_mistakes (brand_profile_id, mistake_type, description, human_feedback, severity)
+         VALUES ($1, 'human_edit', $2, $3, 'medium')`,
+        [
+          brandProfileId,
+          `Key Takeaway (TL;DR): human reviewer edited`,
+          `Avoid: "${(articleJson.keyTakeaway || '').substring(0, 200)}" — prefer: "${keyTakeaway.substring(0, 200)}"`
+        ]
+      ).catch(e => console.error('[COMPLIANCE] keyTakeaway mistake write error:', e.message));
+      articleJson.keyTakeaway = keyTakeaway;
     }
 
     // Handle red section decisions

--- a/src/server/routes/publishing-publish.js
+++ b/src/server/routes/publishing-publish.js
@@ -22,7 +22,11 @@ import { buildGhostJWT } from '../ghost.js';
 function tldrHtmlBlock(aj) {
   const t = String(aj?.keyTakeaway || '').trim();
   if (!t) return '';
-  return `<aside class="article-tldr" style="margin:1.5em 0;padding:1.25em 1.5em;border-left:4px solid #4F46E5;background:#f5f6ff;border-radius:8px"><p style="margin:0 0 .4em;font-weight:700;text-transform:uppercase;letter-spacing:.08em;font-size:.78em;color:#4F46E5">TL;DR</p><p style="margin:0;line-height:1.6">${t.replace(/</g, '&lt;')}</p></aside>\n`;
+  // Class-only, NO inline styling. The Site Template scraper's contract is "class
+  // names + DOM structure, no styling copied" — the destination site's own
+  // .article-tldr CSS owns the look. Inline styles here override that (inline beats
+  // class selectors) and shipped an off-brand indigo box onto a dark site.
+  return `<aside class="article-tldr"><p class="article-tldr-label">TL;DR</p><p class="article-tldr-body">${t.replace(/</g, '&lt;')}</p></aside>\n`;
 }
 function tldrMarkdownBlock(aj) {
   const t = String(aj?.keyTakeaway || '').trim();


### PR DESCRIPTION
## Why
Spot-checking a published SYSOI article surfaced two bugs in the Key Takeaway (TL;DR) path — same area, different failure modes.

### Bug 1 — styling (violated the Site Template scraper contract)
The TL;DR was the **only** block in Smart Export that hardcoded inline styles (`border-left:4px solid #4F46E5;background:#f5f6ff`). The Site Template scraper is class-names + DOM-structure only ("no styling copied") — every other block (`.article-body`, `.article-hero`, section `<h2>`/`<p>`) trusts the destination's CSS. Because **inline beats class selectors**, that indigo overrode the customer's own `.article-tldr` rule and shipped an off-brand box — on SYSOI's dark site, a near-white box (`#f5f6ff`) on near-black, illegible. The left-stripe also violates SYSOI's design language ("1px full border, never a left-edge stripe").

Now class-only, consistent with the rest of the export:
```html
<aside class="article-tldr"><p class="article-tldr-label">TL;DR</p><p class="article-tldr-body">…</p></aside>
```
Fixed in **both** copies that had drifted into existence — `tldrHtmlBlock()` (`publishing-publish.js`) and `buildHTML()` (`PublishingQueuePage.tsx`).

### Bug 2 — governance (TL;DR shipped unreviewed/unpreviewed)
`keyTakeaway` is rendered into every published export but was surfaced in **neither** the Compliance Gate editor **nor** the Publishing preview (both render `sections[]` only). So the TL;DR — including, in the article that surfaced this, a factual overclaim — shipped without ever passing a human's eyes. Now:
- **Publishing preview** renders an editable TL;DR above the sections.
- **Compliance Gate** shows an editable TL;DR field above the sections; the edit flows through `/approve`, which persists it and logs the correction to `brain_mistakes` exactly like section/FAQ edits.

## What changed
- `src/server/routes/publishing-publish.js` — `tldrHtmlBlock()` → class-only.
- `src/pages/PublishingQueuePage.tsx` — `buildHTML()` TL;DR → class-only; editable TL;DR in preview; `saveArticleEdit('keyTakeaway')`.
- `src/pages/ComplianceGatePage.tsx` — editable TL;DR review field; `editedKeyTakeaway` state → `/approve`.
- `src/server/routes/compliance.js` — `/approve` accepts + persists `keyTakeaway`, logs the edit to the brain.

## Test plan
- `node --check` clean on both backend files.
- `npx tsc --noEmit`: **zero new errors** introduced (the only mentions of the edited `.tsx` files are pre-existing CSS-side-effect-import warnings that exist identically on `development`; the build runs through Vite).
- Manual: open the Gate on an article with a `keyTakeaway` → the TL;DR field appears, edits persist on approve; Publishing preview shows + edits the TL;DR; exported HTML's `<aside class="article-tldr">` carries no inline styles.

## Pairs with
SYSOI `public/marketing.css` adds the `.article-tldr` rule the export now relies on (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuB7uHgLJexFbcyVFWaRrK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuB7uHgLJexFbcyVFWaRrK)_