### PR TITLE
fix: use safeParseLLM for campaign arc JSON parsing

### DIFF
--- a/src/server/routes/social-generator.js
+++ b/src/server/routes/social-generator.js
@@ -454,62 +454,17 @@ OUTPUT ONLY valid JSON matching this schema exactly. No prose before or after.
 
     const msg = await anthropic.messages.create({
       model: 'claude-opus-4-6',
-      max_tokens: 4000,
+      max_tokens: 6000,
       messages: [{ role: 'user', content: prompt }]
     });
 
-    // Parse Claude's response. Strip code fences if present, then try direct
-    // parse first — normal case. Only if that fails, apply careful escaping
-    // INSIDE string values for bare control chars (the rare hardening case).
-    let raw = msg.content?.[0]?.text || '';
-    raw = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
-
+    const raw = msg.content?.[0]?.text || '';
     let parsed;
     try {
-      // First attempt: parse as-is. Claude's JSON is usually valid.
-      parsed = JSON.parse(raw);
-    } catch (firstErr) {
-      // Fallback: escape bare control chars but ONLY inside double-quoted
-      // string regions. The original blanket replace was destroying
-      // structural whitespace between tokens (\n between { and "key")
-      // and producing invalid JSON.
-      try {
-        let inString = false;
-        let escaped = false;
-        let out = '';
-        for (let i = 0; i < raw.length; i++) {
-          const ch = raw[i];
-          if (inString) {
-            if (escaped) {
-              out += ch;
-              escaped = false;
-            } else if (ch === '\\') {
-              out += ch;
-              escaped = true;
-            } else if (ch === '"') {
-              out += ch;
-              inString = false;
-            } else if (ch === '\n') {
-              out += '\\n';
-            } else if (ch === '\r') {
-              out += '\\r';
-            } else if (ch === '\t') {
-              out += '\\t';
-            } else if (ch.charCodeAt(0) < 0x20) {
-              // strip other control chars inside strings
-            } else {
-              out += ch;
-            }
-          } else {
-            if (ch === '"') inString = true;
-            out += ch;
-          }
-        }
-        parsed = JSON.parse(out);
-      } catch (secondErr) {
-        console.error('[REGEN-ARCS] JSON parse failed (both attempts):', firstErr.message, '/', secondErr.message, 'raw start:', raw.slice(0, 300));
-        return res.status(500).json({ success: false, error: 'Model returned invalid JSON. Please try again.' });
-      }
+      parsed = safeParseLLM(raw, 'object', 'regen-arcs');
+    } catch (parseErr) {
+      console.error('[REGEN-ARCS] JSON parse failed:', parseErr.message, 'raw start:', raw.slice(0, 300));
+      return res.status(500).json({ success: false, error: 'Model returned invalid JSON. Please try again.' });
     }
 
     const newArcs = parsed.campaignArcs || [];


### PR DESCRIPTION
## Why

Brian hit "Model returned invalid JSON. Please try again." twice in a row from the Social Generator — specifically from the **Regenerate Arcs** flow.

Root cause: `regenerate-arcs` had a hand-rolled 2-step JSON parser (fence-strip → `JSON.parse`, then char-by-char escape → `JSON.parse`). When Opus prefaced its response with any prose — "Here are your campaign arcs:" or similar — both steps failed because neither stripped preamble before parsing.

`safeParseLLM` (already imported) uses `extractJSON` as step 1, which depth-tracks `{ }` to extract the JSON object regardless of what's before or after it. Plus 4 more escalating recovery steps.

## What

- `regenerate-arcs`: replaced 51-line hand-rolled parse with a single `safeParseLLM(raw, 'object', 'regen-arcs')` call
- Bumped `max_tokens` 4000 → 6000 (3-5 verbose arcs with acts have comfortable headroom)

## Test plan

- 199/199 tests pass
- `node --check` clean
- Trigger "Regenerate Arcs" in the Social Generator — should survive any Opus preamble text without erroring

## Rollback

Revert this commit; the feature degrades to the previous 2-step parser behavior (same error rate as before).

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_