### PR TITLE
chore(ai): swap Sonnet 4.6 → Sonnet 5 across all call sites

### DIFF
--- a/server.js
+++ b/server.js
@@ -3164,7 +3164,7 @@ Return empty arrays if not found. Be factual and accurate. When in doubt, return
     console.log('[ENRICH] Tool 2: E-E-A-T Confidence Scorer...');
 
     const scorerRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 4000,
       system: 'You are a JSON API. You must respond with valid JSON only — no markdown, no explanation, no code fences.',
       messages: [
@@ -3199,7 +3199,7 @@ Respond with this exact JSON structure:
     console.log('[ENRICH] Tool 3: Voice & Persona Injection Mapper...');
 
     const injectionRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 8096,
       system: 'You are a JSON API. You must respond with valid JSON only — no markdown, no explanation, no code fences.',
       messages: [
@@ -3229,7 +3229,7 @@ Respond with this exact JSON structure:
     console.log('[ENRICH] Tool 4: Enriched Brief Assembler...');
 
     const assemblerRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 8096,
       system: 'You are a JSON API. You must respond with valid JSON only — no markdown, no explanation, no code fences.',
       messages: [
@@ -3698,7 +3698,7 @@ Respond with ONLY valid JSON — no markdown, no code fences:
 }`;
 
     const pvaRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 6000,
       system: 'You are a JSON API. Respond with valid JSON only — no markdown, no explanation, no code fences.',
       messages: [{ role: 'user', content: pvaPrompt }]
@@ -3760,7 +3760,7 @@ Respond with ONLY valid JSON — no markdown, no code fences:
 }`;
 
     const flRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 6000,
       system: 'You are a JSON API. Respond with valid JSON only — no markdown, no explanation, no code fences.',
       messages: [{ role: 'user', content: faultLinesPrompt }]
@@ -4107,7 +4107,7 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
 
     let fullText = '';
     const stream = await client.messages.stream({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 12000,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }]
@@ -4458,7 +4458,7 @@ Return ONLY the JSON object specified in the system prompt.`;
 
     const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
     const aiRes = await client.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       // Bumped from 3000 → 4500 to fit expanded asset pack (sitelinks + callouts
       // + keywords nearly double the JSON payload vs RSA-only).
       max_tokens: 4500,
@@ -9070,7 +9070,7 @@ app.post('/api/geo/opportunities/build-briefs', requireAuth, express.json(), asy
 
       try {
         const briefRes = await anthropic.messages.create({
-          model: 'claude-sonnet-4-6',
+          model: 'claude-sonnet-5',
           max_tokens: 6144,
           messages: [{ role: 'user', content: `${dateContext()}
 
@@ -9241,7 +9241,7 @@ app.post('/api/geo/topic-brief/from-topic', requireAuth, express.json(), async (
     //    so output shape stays identical and downstream parsers don't drift.
     const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
     const briefRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 6144,
       messages: [{ role: 'user', content: `${dateContext()}
 
@@ -9562,7 +9562,7 @@ app.post('/api/geo/cold-scan', async (req, res) => {
 
     // 2. Infer the brand name + the brand-free buyer questions their category gets asked.
     const qRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 1200,
       messages: [{ role: 'user', content: `From this company's homepage, identify the brand name and write 10 natural questions a buyer or customer (B2B or consumer, whichever fits) would type into ChatGPT or Perplexity when researching this category — the questions where this company would WANT to be recommended. Do NOT mention the company's own name in any question (we are measuring unprompted visibility). Keep each question under 110 characters.
 

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -157,7 +157,7 @@ ${mistakesBlock}
 Return ONLY the JSON object.`;
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     max_tokens: 4096,
     system: systemPrompt,
     messages: [{ role: 'user', content: userPrompt }]
@@ -320,7 +320,7 @@ ${enrichedBrief ? trimTo(enrichedBrief, 4000) : 'Not available — infer from br
 Return ONLY valid JSON matching the output format. No markdown, no commentary.`;
 
     const message = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 4096,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }]
@@ -673,7 +673,7 @@ Return ONLY valid JSON matching the content generator output format.`;
 
       let fullText = '';
       const stream = await anthropic.messages.stream({
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-5',
         max_tokens: 16000,
         system: cgSystemPrompt,
         messages: [{ role: 'user', content: userPrompt }]

--- a/src/server/routes/compliance.js
+++ b/src/server/routes/compliance.js
@@ -80,7 +80,7 @@ router.post('/rewrite-section', async (req, res) => {
     }
 
     const response = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 1024,
       messages: [{ role: 'user', content: `You are an editorial AI. Rewrite the following article section to incorporate the editorial suggestion${source ? ' AND integrate the provided citation cleanly' : ''}. Preserve the author's voice and intent. Return only the rewritten section body — no commentary, no preamble, no labels.\n\n${voiceHint}\n\nORIGINAL SECTION:\n${sectionBody}\n\nEDITORIAL SUGGESTION:\n${suggestion}${citationBlock}\n\nREWRITTEN SECTION:` }]
     });
@@ -245,7 +245,7 @@ router.post('/verify-and-rewrite', async (req, res) => {
     }
 
     const response = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 1024,
       messages: [{ role: 'user', content: `You are an editorial AI. Rewrite the following article section to incorporate the editorial suggestion. ${mode === 'cited' ? 'A verified source has been provided — integrate it cleanly.' : 'No verified source was found — soften the claim instead of fabricating one.'} Preserve the author's voice and intent. Return only the rewritten section body — no commentary, no preamble, no labels.\n\n${voiceHint}\n\nSECTION HEADING: ${sectionHeading || 'Untitled'}\n\nORIGINAL SECTION:\n${sectionBody}\n\nFLAGGED CLAIM:\n"${claim}"\n\nEDITORIAL SUGGESTION:\n${suggestion}${citationBlock}\n\nREWRITTEN SECTION:` }]
     });
@@ -353,7 +353,7 @@ Return ONLY valid JSON in this exact structure:
         method: 'POST',
         headers: { 'x-api-key': process.env.ANTHROPIC_API_KEY, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
         body: JSON.stringify({
-          model: 'claude-sonnet-4-6',
+          model: 'claude-sonnet-5',
           max_tokens: 8192,
           system: systemPrompt,
           messages: [{ role: 'user', content: userContent }]

--- a/src/server/routes/content.js
+++ b/src/server/routes/content.js
@@ -345,7 +345,7 @@ Return ONLY valid JSON:
       method: 'POST',
       headers: { 'x-api-key': process.env.ANTHROPIC_API_KEY, 'anthropic-version': '2023-06-01', 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'claude-sonnet-4-6',
+        model: 'claude-sonnet-5',
         max_tokens: 4000,
         messages: [{ role: 'user', content: auditPrompt }]
       })

--- a/src/server/routes/geo-strategist.js
+++ b/src/server/routes/geo-strategist.js
@@ -163,7 +163,7 @@ ${strategicMoats.map(m => `- ${m.capability}${m.rationale ? ` (${String(m.ration
       const brandDomain = extractDomain(profile.brand_url || '');
       if (brandDomain) {
         const qRes = await anthropic.messages.create({
-          model: 'claude-sonnet-4-6',
+          model: 'claude-sonnet-5',
           max_tokens: 900,
           messages: [{ role: 'user', content: `Write 8 natural questions a buyer would type into ChatGPT or Perplexity when researching the category this brand sells into — the questions where the brand would WANT to be recommended. Do NOT mention the brand name in any question (we are measuring unprompted visibility). Keep each question under 110 characters.
 
@@ -211,7 +211,7 @@ MEASURED AI VISIBILITY (live probe of the real engines, run minutes ago — trea
     // ── Tool 1: Topical Authority Mapper ─────────────────────────────────────
     console.log('[GEO] Tool 1: Topical Authority Mapper...');
     const topicalRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 4000,
       messages: [{ role: 'user', content: `You are the Topical Authority Mapper for Forge Intelligence GEO Strategist.
 
@@ -249,7 +249,7 @@ Return ONLY the raw JSON array. No markdown. No backticks. No explanation. No ot
     // ── Tool 2: GEO Opportunity Scorer ────────────────────────────────────────
     console.log('[GEO] Tool 2: GEO Opportunity Scorer...');
     const scorerRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 3000,
       messages: [{ role: 'user', content: `You are the GEO Opportunity Scorer for Forge Intelligence.
 
@@ -285,7 +285,7 @@ Return ONLY a raw JSON array (no markdown, no explanation):
     // ── Tool 3: Entity & Schema Mapper ────────────────────────────────────────
     console.log('[GEO] Tool 3: Entity & Schema Mapper...');
     const entityRes = await anthropic.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 3000,
       messages: [{ role: 'user', content: `You are the Entity & Schema Mapper for Forge Intelligence.
 

--- a/src/server/routes/social-generator.js
+++ b/src/server/routes/social-generator.js
@@ -204,7 +204,7 @@ router.get('/generate', async (req, res) => {
     // Stream from Claude
     let fullText = '';
     const stream = await anthropic.messages.stream({
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       max_tokens: 4000,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }]

--- a/src/server/video.js
+++ b/src/server/video.js
@@ -315,7 +315,7 @@ export async function storyboardFromBrief({ brief, brandName, brandContext = '',
     ? `\n\nThe user UPLOADED real product screenshots for this video. You MUST include exactly one "screens" beat (the backend fills in their images); write the copy for it.`
     : '';
   const msg = await anthropic.messages.create({
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     max_tokens: 2500,
     messages: [{
       role: 'user',
@@ -430,7 +430,7 @@ Editing rules:
 - If the request cannot be honored as a video edit, return the original storyboard unchanged.
 - Output ONLY JSON: { "direction": {...}, "scenes": [ ... ] }`;
   const msg = await anthropic.messages.create({
-    model: 'claude-sonnet-4-6', max_tokens: 3000,
+    model: 'claude-sonnet-5', max_tokens: 3000,
     messages: [{ role: 'user', content: prompt }],
   });
   const parsed = safeParseLLM(msg?.content?.[0]?.text || '');
@@ -511,7 +511,7 @@ For each concept return:
 
 Output ONLY JSON: { "arcs": [ { "id":"kebab-name", "title", "angle", "length", "orientation", "brief" } ] }`;
   const msg = await anthropic.messages.create({
-    model: 'claude-sonnet-4-6', max_tokens: 3000,
+    model: 'claude-sonnet-5', max_tokens: 3000,
     messages: [{ role: 'user', content: prompt }],
   });
   const parsed = safeParseLLM(msg?.content?.[0]?.text || '');


### PR DESCRIPTION
## Why

Claude Sonnet 5 is more capable and agentic than Sonnet 4.6 at the same standing price ($3/$10 per M tokens), and discounted to $2/$10 through Aug 31. More power, same cost — no reason to stay on 4.6.

## What

Pure model-string swap: `claude-sonnet-4-6` → `claude-sonnet-5` at all **25** hard-coded call sites. No prompt, token-budget, or param changes.

| File | Sites | Surface |
|---|---|---|
| `server.js` | 10 | misc generators in the monolith |
| `src/server/routes/geo-strategist.js` | 4 | GEO strategist tools |
| `src/server/routes/compliance.js` | 3 | compliance gate scoring |
| `src/server/routes/campaign.js` | 3 | campaign planner |
| `src/server/video.js` | 3 | storyboard, refine guard, refine storyboard |
| `src/server/routes/content.js` | 1 | content generator |
| `src/server/routes/social-generator.js` | 1 | social posts (SSE generator) |

**Out of scope (left as-is):** 4× `claude-opus-4-6` and 20× `claude-haiku-4-5-20251001`. Those are deliberate tier choices, not part of this swap. Heads up that Opus 4.6 is also a stale id (Opus 4.8 is current) — separate decision if you want it bumped.

## Test plan

- `node --check` on all 7 backend files — clean
- `npx tsc --noEmit` — clean
- `npx vitest run` — 199/199 pass

## Rollback

Single-commit revert; every site flips back to `claude-sonnet-4-6`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_