### PR TITLE
chore(marketing): anti-AI copy pass + global card radius to 6px

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -15,21 +15,21 @@ const ArrowRightIcon = () => (
 
 const proofPoints = [
   {
-    date: 'May 7–8, 2026',
+    date: 'May 7-8, 2026',
     title: 'Google AI Mode citation',
-    body: 'Google AI Mode returned a definition of Forge Intelligence using Forge-coined vocabulary — context decay, Context Agent Architecture, context-first infrastructure. No paid placement. The output of a deliberate evidence chain Forge built and watched land through its own analytics.',
+    body: 'Google AI Mode returned a definition of Forge Intelligence using Forge-coined vocabulary: context decay, Context Agent Architecture, context-first infrastructure. No paid placement. The output of a deliberate evidence chain Forge built and watched land through its own analytics.',
   },
   {
     date: 'May 24, 2026',
     title: '100% Google Ads optimization score',
-    body: 'The Ads Generator’s first auto-built Search pack — headlines, descriptions, sitelinks, callouts, and match-typed keywords sourced from a single brain pass — hit a perfect 100% Google Ads optimization score on the Forge Intelligence account. Started at 99.9%, climbed to ceiling within hours of ad-rank scoring. No manual tuning.',
+    body: 'The Ads Generator’s first auto-built Search pack (headlines, descriptions, sitelinks, callouts, and match-typed keywords sourced from a single brain pass) hit a perfect 100% Google Ads optimization score on the Forge Intelligence account. Started at 99.9%, climbed to ceiling within hours of ad-rank scoring. No manual tuning.',
   },
 ];
 
 const principles = [
   {
     title: 'Intelligence is upstream of generation.',
-    body: 'AI content tools amplify whatever you feed them — including the absence of strategy. Without competitive intelligence, audience clarity, and a defensible positioning angle, generated content sounds exactly like every competitor’s generated content. Faster mediocrity isn’t a win.',
+    body: 'AI content tools amplify whatever you feed them, including the absence of strategy. Without competitive intelligence, audience clarity, and a defensible positioning angle, generated content sounds exactly like every competitor’s generated content. Faster mediocrity isn’t a win.',
   },
   {
     title: 'Architecture beats volume.',
@@ -64,7 +64,7 @@ export default function About() {
             The intelligence layer behind modern marketing.
           </h1>
           <p style={styles.subline}>
-            Forge Intelligence turns fragmented marketing activity into clear intelligence and confident action — a Context Agent Architecture built so every published asset makes the next one easier to brief, faster to write, and more likely to convert.
+            Forge Intelligence turns fragmented marketing activity into clear intelligence and confident action. It's a Context Agent Architecture built so every published asset makes the next one easier to brief, faster to write, and more likely to convert.
           </p>
         </section>
 
@@ -73,7 +73,7 @@ export default function About() {
           <h2 style={styles.sectionTitle}>Why Forge exists</h2>
           <div style={styles.problemCard}>
             <p style={styles.problemText}>
-              Every AI content tool on the market today solves for production volume. None solve for compounding content intelligence — the system getting measurably smarter and more commercially effective with every publish cycle. That’s the gap. That’s the product.
+              Every AI content tool on the market today solves for production volume. None solve for compounding content intelligence: the system getting measurably smarter and more commercially effective with every publish cycle. That’s the gap. That’s the product.
             </p>
             <p style={styles.problemPunch}>The bottleneck isn’t production. It’s intelligence.</p>
           </div>
@@ -115,12 +115,12 @@ export default function About() {
           <h2 style={styles.sectionTitle}>From the founder</h2>
           <div style={styles.founderCard}>
             <p style={styles.founderText}>
-              I spent a decade running content operations for mid-market B2B brands and agencies. The same pattern showed up every time: teams could produce content faster than they could think strategically about it. The bottleneck was never volume. It was the layer that should have been telling the team what to write, who to write for, and what evidence to bring — the layer no tool actually built.
+              I spent a decade running content operations for mid-market B2B brands and agencies. The same pattern showed up every time: teams could produce content faster than they could think strategically about it. The bottleneck was never volume. It was the layer that should have been telling the team what to write, who to write for, and what evidence to bring. No tool actually built that layer.
             </p>
             <p style={styles.founderText}>
-              Forge is the layer I wanted to buy and couldn’t. An 8-stage agent architecture that reads the brand site, maps the competitive landscape, finds the topical gaps, injects E-E-A-T proof, writes voice-matched content, runs it past a compliance gate, distributes it across the right surfaces, syncs the analytics back, and writes every pattern into a brain that compounds. Same loop your best in-house team would run — except it never sleeps, never forgets, and gets smarter every cycle.
+              Forge is the layer I wanted to buy and couldn’t. An 8-stage agent architecture that reads the brand site, maps the competitive landscape, finds the topical gaps, injects E-E-A-T proof, writes voice-matched content, runs it past a compliance gate, distributes it across the right surfaces, syncs the analytics back, and writes every pattern into a brain that compounds. Same loop your best in-house team would run, except it never sleeps, never forgets, and gets smarter every cycle.
             </p>
-            <p style={styles.founderSign}>— Brian, founder</p>
+            <p style={styles.founderSign}>Brian, founder</p>
           </div>
         </section>
 
@@ -253,7 +253,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   problemCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '32px',
     border: '1px solid rgba(255,255,255,0.05)',
   },
@@ -276,7 +276,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   gapCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '24px',
     border: '1px solid rgba(255,255,255,0.05)',
   },
@@ -299,7 +299,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   proofCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '24px',
     border: '1px solid rgba(255,255,255,0.05)',
   },
@@ -325,7 +325,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   founderCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '32px',
     border: '1px solid rgba(255,255,255,0.05)',
     maxWidth: '720px',

--- a/src/Faq.tsx
+++ b/src/Faq.tsx
@@ -23,7 +23,7 @@ const SECTIONS: Section[] = [
     faqs: [
       {
         q: "What's the difference between AI content generation and AI content intelligence?",
-        a: "AI content generation produces output. AI content intelligence builds the strategic worldview that makes the output worth producing. Generation tools take a prompt and write an article. Intelligence systems extract competitive gaps, audience blind spots, and topical whitespace first — then condition every word against that worldview. Forge inverts the order: intelligence is upstream of generation."
+        a: "AI content generation produces output. AI content intelligence builds the strategic worldview that makes the output worth producing. Generation tools take a prompt and write an article. Intelligence systems extract competitive gaps, audience blind spots, and topical whitespace first, then condition every word against that worldview. Forge inverts the order: intelligence is upstream of generation."
       },
       {
         q: "What is a Context Agent Architecture?",
@@ -31,35 +31,35 @@ const SECTIONS: Section[] = [
       },
       {
         q: "What is Generative Engine Optimization (GEO) and how is it different from SEO?",
-        a: "GEO optimizes content to be cited by AI engines like ChatGPT, Perplexity, and Gemini. SEO optimizes content to rank in search results. Different inputs, different ranking signals, different success metrics. SEO rewards keyword authority and backlinks. GEO rewards distinctive concepts, named frameworks, and citeable definitions that AI engines can attribute back to you. Same goal — visibility — different game."
+        a: "GEO optimizes content to be cited by AI engines like ChatGPT, Perplexity, and Gemini. SEO optimizes content to rank in search results. Different inputs, different ranking signals, different success metrics. SEO rewards keyword authority and backlinks. GEO rewards distinctive concepts, named frameworks, and citeable definitions that AI engines can attribute back to you. Same goal (visibility), different game."
       },
       {
         q: "What is Voice of Market and how is it different from Share of Voice?",
-        a: "Share of Voice measures how often your brand shows up versus competitors. It's a backward-looking scoreboard. Voice of Market measures the unspoken market tension no competitor has named yet — the strategic angle that hasn't been claimed. Share of voice tells you where you stand. Voice of market tells you where to attack. One is a metric. The other is an advantage."
+        a: "Share of Voice measures how often your brand shows up versus competitors. It's a backward-looking scoreboard. Voice of Market measures the unspoken market tension no competitor has named yet: the strategic angle that hasn't been claimed. Share of voice tells you where you stand. Voice of market tells you where to attack. One is a metric. The other is an advantage."
       },
       {
         q: "What does \"compounding\" mean in B2B content operations?",
-        a: "Compounding content operations get smarter every cycle through an explicit feedback loop. Performance data writes back into strategy via Brain Memory — the 8th and final agent in Forge's Context Agent Architecture. Patterns that worked become reusable templates. Mistakes get flagged and avoided. The system never starts from scratch. Every published article makes the next one easier to brief, faster to write, and more likely to convert."
+        a: "Compounding content operations get smarter every cycle through an explicit feedback loop. Performance data writes back into strategy via Brain Memory, the 8th and final agent in Forge's Context Agent Architecture. Patterns that worked become reusable templates. Mistakes get flagged and avoided. The system never starts from scratch. Every published article makes the next one easier to brief, faster to write, and more likely to convert."
       },
       {
         q: "What does it mean for an AI content tool to be stateful?",
-        a: "A stateful AI content tool remembers everything across sessions: brand voice rules, founder facts, competitive positioning, what content converted, what failed. In Forge's Context Agent Architecture this is implemented through Brain Memory — the 8th agent that writes patterns back after every cycle. Most AI tools are stateless: each session is a fresh prompt with no history. Stateful systems compound. Stateless ones repeat themselves."
+        a: "A stateful AI content tool remembers everything across sessions: brand voice rules, founder facts, competitive positioning, what content converted, what failed. In Forge's Context Agent Architecture this is implemented through Brain Memory, the 8th agent that writes patterns back after every cycle. Most AI tools are stateless: each session is a fresh prompt with no history. Stateful systems compound. Stateless ones repeat themselves."
       },
       {
         q: "What is brand brain memory in an AI content system?",
-        a: "Brand brain memory is the persistent intelligence layer that stores everything an AI content system has ever learned: voice rules, founder facts, positioning claims, performance patterns, competitive context. In Forge's Context Agent Architecture this layer is named Brain Memory — the 8th and final agent that writes patterns back after every cycle. Without it, the system restarts from zero each session. The brain is the moat — not the model."
+        a: "Brand brain memory is the persistent intelligence layer that stores everything an AI content system has ever learned: voice rules, founder facts, positioning claims, performance patterns, competitive context. In Forge's Context Agent Architecture this layer is named Brain Memory, the 8th and final agent that writes patterns back after every cycle. Without it, the system restarts from zero each session. The brain is the moat, not the model."
       },
       {
         q: "What is Brain Memory in Forge's pipeline?",
-        a: "Brain Memory is the 8th and final agent in Forge's Context Agent Architecture. After every published article, it extracts what worked (patterns) and what didn't (mistakes) from engagement data, AI citation hits, and human compliance edits — then writes both back into a per-brand brain. The next cycle's brief is conditioned by everything that happened in every prior cycle. By month 12 the brain is a proprietary asset; switching to a competitor means starting over with no learned context."
+        a: "Brain Memory is the 8th and final agent in Forge's Context Agent Architecture. After every published article, it extracts what worked (patterns) and what didn't (mistakes) from engagement data, AI citation hits, and human compliance edits, then writes both back into a per-brand brain. The next cycle's brief is conditioned by everything that happened in every prior cycle. By month 12 the brain is a proprietary asset; switching to a competitor means starting over with no learned context."
       },
       {
         q: "What does a Forge brand intelligence brief include?",
-        a: "Forge's brand intelligence brief is the output of Stages 1-3 of the pipeline: voice profile (tone, formality, signature phrases), personas with pain points and trigger events, competitive set with strategic moats and gap map, topical authority map ranked by AI citation probability, E-E-A-T injections (SME credentials, first-party evidence, author schema, FAQPage candidates), and per-section confidence scoring. It's a fully constructed competitive worldview compressed into a writeable artifact — not a topic and a few bullet points."
+        a: "Forge's brand intelligence brief is the output of Stages 1-3 of the pipeline: voice profile (tone, formality, signature phrases), personas with pain points and trigger events, competitive set with strategic moats and gap map, topical authority map ranked by AI citation probability, E-E-A-T injections (SME credentials, first-party evidence, author schema, FAQPage candidates), and per-section confidence scoring. It's a fully constructed competitive worldview compressed into a writeable artifact, not a topic and a few bullet points."
       },
       {
         q: "What is a citation heat map?",
-        a: "A citation heat map is a per-section, per-FAQ view of where AI engines actually pull from in your content corpus. It distinguishes prose authority — when engines cite specific paragraphs — from domain authority, when they cite the URL without quoting. It also surfaces FAQ ROI: which questions actually get picked up as AI answers and which ones engines ignore."
+        a: "A citation heat map is a per-section, per-FAQ view of where AI engines actually pull from in your content corpus. It distinguishes prose authority (when engines cite specific paragraphs) from domain authority, when they cite the URL without quoting. It also surfaces FAQ ROI: which questions actually get picked up as AI answers and which ones engines ignore."
       }
     ]
   },
@@ -69,7 +69,7 @@ const SECTIONS: Section[] = [
     faqs: [
       {
         q: "Why do AI content tools get worse the longer you use them?",
-        a: "Most don't get worse — they stay exactly the same. Every AI content tool is stateless. Each session starts from zero, with no memory of what worked, what failed, or what your competitive position looked like last quarter. Output gets repetitive because there's no compounding learning. Forge inverts that entirely with Brain Memory — the 8th agent in its Context Agent Architecture — writing performance patterns back into the brand profile after every cycle."
+        a: "Most don't get worse. They stay exactly the same. Every AI content tool is stateless. Each session starts from zero, with no memory of what worked, what failed, or what your competitive position looked like last quarter. Output gets repetitive because there's no compounding learning. Forge inverts that entirely with Brain Memory (the 8th agent in its Context Agent Architecture), writing performance patterns back into the brand profile after every cycle."
       },
       {
         q: "Why does AI content sound generic even when the brief is good?",
@@ -77,7 +77,7 @@ const SECTIONS: Section[] = [
       },
       {
         q: "Why isn't faster content faster ROI?",
-        a: "Content velocity only compounds when each piece adds intelligence to the next. Volume without intelligence produces faster mediocrity, not faster results. Ten articles that don't differentiate your positioning cost more than two that do — they consume editorial bandwidth, fragment topical authority, and train your audience to ignore you. Speed is a feature only after intelligence is solved."
+        a: "Content velocity only compounds when each piece adds intelligence to the next. Volume without intelligence produces faster mediocrity, not faster results. Ten articles that don't differentiate your positioning cost more than two that do: they consume editorial bandwidth, fragment topical authority, and train your audience to ignore you. Speed is a feature only after intelligence is solved."
       },
       {
         q: "What's the difference between AI content tools and AI content infrastructure?",
@@ -85,7 +85,7 @@ const SECTIONS: Section[] = [
       },
       {
         q: "What's the limit of agentic AI in content marketing?",
-        a: "Agents fail without state. Most agentic AI in content marketing chains together prompts but loses everything between sessions — every agent restarts the conversation. That's not autonomy, that's amnesia. Real agentic content systems require persistent memory across sequenced agents — the pattern Forge calls Context Agent Architecture. Without that scaffolding, agents produce coordinated mediocrity faster than humans can review it."
+        a: "Agents fail without state. Most agentic AI in content marketing chains together prompts but loses everything between sessions. Every agent restarts the conversation. That's not autonomy, that's amnesia. Real agentic content systems require persistent memory across sequenced agents, the pattern Forge calls Context Agent Architecture. Without that scaffolding, agents produce coordinated mediocrity faster than humans can review it."
       },
       {
         q: "What's the difference between content marketing and content intelligence operations?",
@@ -93,11 +93,11 @@ const SECTIONS: Section[] = [
       },
       {
         q: "Why does most AI-generated B2B content get ignored by AI engines?",
-        a: "AI engines cite content with distinctive concepts, named frameworks, and original definitions — content the engine can attribute back to a specific source. Most AI-generated B2B content has none of that. It paraphrases the same topics every competitor covers, with no original framework worth quoting. The fix isn't better prompts. It's a competitive worldview before generation, so the output contains things only your brand could have said."
+        a: "AI engines cite content with distinctive concepts, named frameworks, and original definitions, content the engine can attribute back to a specific source. Most AI-generated B2B content has none of that. It paraphrases the same topics every competitor covers, with no original framework worth quoting. The fix isn't better prompts. It's a competitive worldview before generation, so the output contains things only your brand could have said."
       },
       {
         q: "Why can't most AI content tools publish to custom-built websites?",
-        a: "Generation tools were built for a marketing-tool buying cycle: pick a tier, integrate with a fixed list of CMS platforms (WordPress, Webflow, Ghost), call it done. Custom-stack sites — Next.js, Astro, Vite, hand-rolled Express, Lovable builds — fall outside that integration matrix and get treated as edge cases. Forge ships the primitive that handles them: an authenticated webhook. Add a POST endpoint to your site, generate a Forge-issued bearer token, choose payload format (HTML, Markdown, or both), and every published article gets sent to your receiver. Your site decides storage and rendering. Copy-paste receivers for Node/Express + Postgres, Next.js App Router, and filesystem rebuilds are at /docs/my-website. Real-world setup runs under an hour per site. That's what content infrastructure looks like in practice — not another CMS picker."
+        a: "Generation tools were built for a marketing-tool buying cycle: pick a tier, integrate with a fixed list of CMS platforms (WordPress, Webflow, Ghost), call it done. Custom-stack sites (Next.js, Astro, Vite, hand-rolled Express, Lovable builds) fall outside that integration matrix and get treated as edge cases. Forge ships the primitive that handles them: an authenticated webhook. Add a POST endpoint to your site, generate a Forge-issued bearer token, choose payload format (HTML, Markdown, or both), and every published article gets sent to your receiver. Your site decides storage and rendering. Copy-paste receivers for Node/Express + Postgres, Next.js App Router, and filesystem rebuilds are at /docs/my-website. Real-world setup runs under an hour per site. That's what content infrastructure looks like in practice, not another CMS picker."
       }
     ]
   },
@@ -115,7 +115,7 @@ const SECTIONS: Section[] = [
       },
       {
         q: "When should you NOT use AI content generation?",
-        a: "When you don't have a competitive worldview to write from. AI content generation amplifies whatever you feed it — including the absence of strategy. Without competitive intelligence, audience clarity, and a defensible positioning angle, generated content sounds exactly like every competitor's generated content. The right move is to invest in intelligence first. Faster mediocrity isn't a win."
+        a: "When you don't have a competitive worldview to write from. AI content generation amplifies whatever you feed it, including the absence of strategy. Without competitive intelligence, audience clarity, and a defensible positioning angle, generated content sounds exactly like every competitor's generated content. The right move is to invest in intelligence first. Faster mediocrity isn't a win."
       },
       {
         q: "Why don't AI content tools learn from the content that converted?",
@@ -123,23 +123,23 @@ const SECTIONS: Section[] = [
       },
       {
         q: "How should mid-market B2B teams structure briefs for AI content generation?",
-        a: "The order matters. Competitive intelligence first — what gaps exist, where you have right-to-win. Topical territory second — what conversations you can claim that competitors can't. Voice rules third — how your brand sounds, what it never says. Topic and angle last. Most teams flip this: they start with the topic and bolt on context. The result is generic content with brand paint."
+        a: "The order matters. Competitive intelligence first: what gaps exist, where you have right-to-win. Topical territory second: what conversations you can claim that competitors can't. Voice rules third: how your brand sounds, what it never says. Topic and angle last. Most teams flip this: they start with the topic and bolt on context. The result is generic content with brand paint."
       },
       {
         q: "How do you assess if your B2B content team is AI-ready?",
-        a: "AI readiness for content teams isn't about whether the tools work — it's about whether your team has the upstream conditions to make AI output meaningful. Forge's five-dimension framework: brand intelligence depth, content brief discipline, performance feedback structure, voice rule clarity, and competitive worldview. Teams strong on all five get distinctive output from any AI model. Teams weak on any one dimension get generic content competitors could have written."
+        a: "AI readiness for content teams isn't about whether the tools work. It's about whether your team has the upstream conditions to make AI output meaningful. Forge's five-dimension framework: brand intelligence depth, content brief discipline, performance feedback structure, voice rule clarity, and competitive worldview. Teams strong on all five get distinctive output from any AI model. Teams weak on any one dimension get generic content competitors could have written."
       },
       {
         q: "How does Forge's 8-stage pipeline produce intelligence briefs?",
-        a: "Stages 1-3 produce the brief. Stage 1 (Context Hub) crawls the brand and the competitive set in parallel and extracts voice, personas, strategic moats. Stage 2 (GEO Strategist) maps topical authority gaps ranked by citation probability across ChatGPT, Perplexity, and Gemini. Stage 3 (Authenticity Enricher) injects E-E-A-T signals — SME credentials, first-party evidence, FAQPage schema, author schema — into the brief. Stages 4-8 then write, gate, publish, measure, and learn from the output. The brain compounds with every cycle, so the brief produced on cycle 50 is materially stronger than the brief on cycle 1."
+        a: "Stages 1-3 produce the brief. Stage 1 (Context Hub) crawls the brand and the competitive set in parallel and extracts voice, personas, strategic moats. Stage 2 (GEO Strategist) maps topical authority gaps ranked by citation probability across ChatGPT, Perplexity, and Gemini. Stage 3 (Authenticity Enricher) injects E-E-A-T signals (SME credentials, first-party evidence, FAQPage schema, author schema) into the brief. Stages 4-8 then write, gate, publish, measure, and learn from the output. The brain compounds with every cycle, so the brief produced on cycle 50 is materially stronger than the brief on cycle 1."
       },
       {
         q: "How does Forge extract competitive intelligence from a competitor website?",
-        a: "Forge's Context Hub runs a parallel crawl using Jina Reader as the primary content extractor with Bright Data Web Unlocker and Bright Data Scraping Browser as Tier 1→2 fallbacks for SPAs and bot-protected sites. Sitemap.xml-aware discovery with anchor-only link extraction keeps the crawl focused on substantive pages. The same pass that builds your brand profile maps the competitive set: voice, positioning, pricing posture, topical coverage gaps, persona language. Full competitive crawl finishes in 15-20 seconds parallel — versus the 60+ seconds the sequential approach took."
+        a: "Forge's Context Hub runs a parallel crawl using Jina Reader as the primary content extractor with Bright Data Web Unlocker and Bright Data Scraping Browser as Tier 1→2 fallbacks for SPAs and bot-protected sites. Sitemap.xml-aware discovery with anchor-only link extraction keeps the crawl focused on substantive pages. The same pass that builds your brand profile maps the competitive set: voice, positioning, pricing posture, topical coverage gaps, persona language. Full competitive crawl finishes in 15-20 seconds parallel, versus the 60+ seconds the sequential approach took."
       },
       {
         q: "Can you do B2B competitive analysis without manual research?",
-        a: "Yes — Forge's Context Hub does it as a side effect of Stage 1. The same crawl that builds your brand profile maps your competitive set: voice, positioning claims, pricing posture, topical coverage gaps, persona language, strategic moats. Output is a competitive worldview rendered in about 60 seconds, refreshed automatically every time the brand profile re-extracts. The 'competitive analysis project' that traditionally takes a senior strategist 2-3 weeks becomes a continuous background process the team never has to schedule."
+        a: "Yes. Forge's Context Hub does it as a side effect of Stage 1. The same crawl that builds your brand profile maps your competitive set: voice, positioning claims, pricing posture, topical coverage gaps, persona language, strategic moats. Output is a competitive worldview rendered in about 60 seconds, refreshed automatically every time the brand profile re-extracts. The 'competitive analysis project' that traditionally takes a senior strategist 2-3 weeks becomes a continuous background process the team never has to schedule."
       }
     ]
   }

--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -161,7 +161,7 @@ export default function Landing() {
           <p style={styles.eyebrow}>Brand Intelligence · Free Analysis</p>
           <h1 style={styles.headline}>The intelligence layer behind modern marketing.</h1>
           <p style={styles.subline}>
-            Drop your URL. Forge reads your brand the way a strategist would — voice, audience, competitive gaps — and gives you the intelligence brief in under 10 minutes. Free.
+            Drop your URL. Forge reads your brand the way a strategist would (voice, audience, competitive gaps) and gives you the intelligence brief in under 10 minutes. Free.
             <br /><br />
             Then unlock the full Forge pipeline free for 7 days. No credit card. Your brand profile stays saved when the trial ends.
           </p>
@@ -335,7 +335,7 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '16px 20px',
     background: 'rgba(53,99,255,0.08)',
     border: '1px solid rgba(53,99,255,0.2)',
-    borderRadius: '12px',
+    borderRadius: '6px',
   },
   returningDot: {
     width: '8px', height: '8px', borderRadius: '50%',

--- a/src/Product.tsx
+++ b/src/Product.tsx
@@ -20,8 +20,8 @@ const CheckIcon = () => (
 );
 
 const stages = [
-  { num: 1, name: 'Context Hub', desc: 'Brand voice, personas, competitive gaps — extracted from your site and your competitors\' sites in minutes, not months' },
-  { num: 2, name: 'GEO Strategy', desc: 'Citation gaps measured live against ChatGPT, Perplexity, Gemini, and Google AI Overviews — who AI cites today, and where you\'re invisible' },
+  { num: 1, name: 'Context Hub', desc: 'Brand voice, personas, competitive gaps, extracted from your site and your competitors\' sites in minutes, not months' },
+  { num: 2, name: 'GEO Strategy', desc: 'Citation gaps measured live against ChatGPT, Perplexity, Gemini, and Google AI Overviews: who AI cites today, and where you\'re invisible' },
   { num: 3, name: 'Authenticity', desc: 'E-E-A-T signals, SME hooks, first-person experience injection' },
   { num: 4, name: 'Generation', desc: 'Brain-informed content with confidence scoring per section' },
   { num: 5, name: 'Compliance', desc: 'Human gate with auto-learning from every edit' },
@@ -34,7 +34,7 @@ const personas = [
   {
     name: 'Strategic Sarah',
     role: 'VP of Marketing',
-    pain: 'Another AI tool promising magic — will this actually understand our brand\'s specific positioning, or just create more cleanup work?',
+    pain: 'Another AI tool promising magic. Will this actually understand our brand\'s specific positioning, or just create more cleanup work?',
     outcome: 'Scale content operations without proportional headcount growth. Own differentiated positioning before competitors claim key narratives.',
   },
   {
@@ -60,23 +60,23 @@ const gaps = [
   {
     title: 'Brand Context That Compounds',
     claim: 'Competitors require repeated context input or shallow brand profiles.',
-    ours: 'Deep contextual memory that compounds over time — largely unclaimed territory in the market.',
+    ours: 'Deep contextual memory that compounds over time, largely unclaimed territory in the market.',
   },
   {
     title: 'Competitive Intelligence Integration',
     claim: 'CI tools and content tools exist separately.',
-    ours: 'Competitor sites crawled, AI engines probed live — measured signals feed topic discovery and content generation directly. A significant white space.',
+    ours: 'Competitor sites crawled, AI engines probed live. Measured signals feed topic discovery and content generation directly. A significant white space.',
   },
   {
     title: 'Measured, Not Modeled',
     claim: 'Most GEO tools estimate your AI visibility from proxies.',
-    ours: 'Forge asks the actual engines. Real buyer questions, probed against ChatGPT, Perplexity, Gemini, and AI Overviews — your whitespace is observed, not imagined.',
+    ours: 'Forge asks the actual engines. Real buyer questions, probed against ChatGPT, Perplexity, Gemini, and AI Overviews. Your whitespace is observed, not imagined.',
   },
 ];
 
 const timeline = [
   { time: 'Day 1', state: 'Brain empty. Agents start from brand context only.' },
-  { time: 'Week 4', state: '10–15 patterns. Agents prefer proven structures.' },
+  { time: 'Week 4', state: '10-15 patterns. Agents prefer proven structures.' },
   { time: 'Month 3', state: '50+ patterns. Human edit rate drops 30%.' },
   { time: 'Month 6', state: 'Agents self-correct before human review.' },
   { time: 'Month 12', state: 'Brain is a proprietary asset. Switching means starting over.' },
@@ -114,9 +114,9 @@ export default function Product() {
         {/* Product Shot: Brand Profile */}
         <div style={styles.screenshotSection}>
           <div style={styles.screenshot}>
-            <img src="/1.png" alt="Forge Intelligence — Brand Profile with voice analysis and tone attributes" style={styles.screenshotImg} />
+            <img src="/1.png" alt="Forge Intelligence Brand Profile with voice analysis and tone attributes" style={styles.screenshotImg} />
           </div>
-          <p style={styles.screenshotCaption}>Your brand's voice, personas, and competitive position — extracted from your actual website in minutes.</p>
+          <p style={styles.screenshotCaption}>Your brand's voice, personas, and competitive position, extracted from your actual website in minutes.</p>
         </div>
 
         {/* The Problem */}
@@ -127,7 +127,7 @@ export default function Product() {
               Every AI content tool today solves for <strong>production volume</strong>.
             </p>
             <p style={styles.problemText}>
-              None solve for <strong style={{ color: '#3563FF' }}>compounding content intelligence</strong> — 
+              None solve for <strong style={{ color: '#3563FF' }}>compounding content intelligence</strong>,
               where the system gets measurably smarter and more commercially effective with every publish cycle.
             </p>
             <p style={styles.problemPunch}>That's the gap. That's the product.</p>
@@ -137,7 +137,7 @@ export default function Product() {
         {/* Competitive Whitespace */}
         <section style={styles.section}>
           <h2 style={styles.sectionTitle}>What We Own</h2>
-          <p style={styles.sectionSub}>Territory that's ours — not another "AI writing tool."</p>
+          <p style={styles.sectionSub}>Territory that's ours, not another "AI writing tool."</p>
           <div style={styles.gapsGrid}>
             {gaps.map((g) => (
               <div key={g.title} style={styles.gapCard}>
@@ -152,9 +152,9 @@ export default function Product() {
         {/* Product Shot: GEO Opportunity Scores */}
         <div style={styles.screenshotSection}>
           <div style={styles.screenshot}>
-            <img src="/2.png" alt="Publishing Queue — content preview with hero image and multi-channel distribution" style={styles.screenshotImg} />
+            <img src="/2.png" alt="Publishing Queue content preview with hero image and multi-channel distribution" style={styles.screenshotImg} />
           </div>
-          <p style={styles.screenshotCaption}>Preview, edit post copy, and publish to LinkedIn, X, Webflow, Ghost, or HubSpot — with UTM intelligence built in.</p>
+          <p style={styles.screenshotCaption}>Preview, edit post copy, and publish to LinkedIn, X, Webflow, Ghost, or HubSpot, with UTM intelligence built in.</p>
         </div>
 
         {/* Who This Is For */}
@@ -196,9 +196,9 @@ export default function Product() {
             Uncomment when public/4.png exists. */}
         {/* <div style={styles.screenshotSection}>
           <div style={styles.screenshot}>
-            <img src="/4.png" alt="Content Generator — brain-aware topic alignment check before generation" style={styles.screenshotImg} />
+            <img src="/4.png" alt="Content Generator: brain-aware topic alignment check before generation" style={styles.screenshotImg} />
           </div>
-          <p style={styles.screenshotCaption}>Citation probability scored across ChatGPT, Perplexity, AI Overviews, and Gemini — for every topic in your authority map.</p>
+          <p style={styles.screenshotCaption}>Citation probability scored across ChatGPT, Perplexity, AI Overviews, and Gemini, for every topic in your authority map.</p>
         </div> */}
 
         {/* The Brain */}
@@ -230,7 +230,7 @@ export default function Product() {
             Uncomment when public/5.png exists. */}
         {/* <div style={styles.screenshotSection}>
           <div style={styles.screenshot}>
-            <img src="/5.png" alt="Entity and Schema Map — competitor cited, you are not" style={styles.screenshotImg} />
+            <img src="/5.png" alt="Entity and Schema Map: competitor cited, you are not" style={styles.screenshotImg} />
           </div>
           <p style={styles.screenshotCaption}>Competitors cited. You're not. The Entity Map shows exactly where to inject structured data so AI systems find you.</p>
         </div> */}
@@ -266,9 +266,9 @@ export default function Product() {
         {/* Product Shot: Publishing Queue */}
         <div style={styles.screenshotSection}>
           <div style={styles.screenshot}>
-            <img src="/3.png" alt="GEO Opportunity Scores — ChatGPT, Perplexity, AI Overviews, Gemini citation probability" style={styles.screenshotImg} />
+            <img src="/3.png" alt="GEO Opportunity Scores: ChatGPT, Perplexity, AI Overviews, Gemini citation probability" style={styles.screenshotImg} />
           </div>
-          <p style={styles.screenshotCaption}>The Brain checks topic alignment before you spend a single token. 89% match — and it knows what mistakes to avoid.</p>
+          <p style={styles.screenshotCaption}>The Brain checks topic alignment before you spend a single token. 89% match, and it knows what mistakes to avoid.</p>
         </div>
 
         {/* Pricing */}
@@ -294,9 +294,9 @@ export default function Product() {
             Uncomment when public/6.png exists. */}
         {/* <div style={styles.screenshotSection}>
           <div style={styles.screenshot}>
-            <img src="/6.png" alt="Performance Dashboard — analytics, content decay, citation tracking" style={styles.screenshotImg} />
+            <img src="/6.png" alt="Performance Dashboard: analytics, content decay, citation tracking" style={styles.screenshotImg} />
           </div>
-          <p style={styles.screenshotCaption}>Real-time analytics across every channel. Content decay detection, citation tracking, and campaign attribution — all in one view.</p>
+          <p style={styles.screenshotCaption}>Real-time analytics across every channel. Content decay detection, citation tracking, and campaign attribution, all in one view.</p>
         </div> */}
 
         {/* CTA */}
@@ -424,7 +424,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   problemCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '32px',
     border: '1px solid rgba(255,255,255,0.05)',
   },
@@ -447,7 +447,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   gapCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '24px',
     border: '1px solid rgba(255,255,255,0.05)',
   },
@@ -476,7 +476,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   personaCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '24px',
     border: '1px solid rgba(255,255,255,0.05)',
   },
@@ -515,7 +515,7 @@ const styles: Record<string, React.CSSProperties> = {
     gap: '16px',
     padding: '20px',
     backgroundColor: '#1E293B',
-    borderRadius: '10px',
+    borderRadius: '6px',
     border: '1px solid rgba(255,255,255,0.05)',
   },
   stageNum: {
@@ -587,7 +587,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   moatCard: {
     backgroundColor: 'rgba(53,99,255,0.1)',
-    borderRadius: '10px',
+    borderRadius: '6px',
     padding: '24px',
     border: '1px solid rgba(53,99,255,0.2)',
     textAlign: 'center',
@@ -624,7 +624,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   pricingCard: {
     backgroundColor: '#1E293B',
-    borderRadius: '12px',
+    borderRadius: '6px',
     padding: '32px',
     border: '1px solid rgba(255,255,255,0.1)',
     textAlign: 'center',

--- a/src/index.css
+++ b/src/index.css
@@ -130,7 +130,7 @@ input, textarea, select {
 .card {
   background: var(--color-bg-card);
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-sm); /* 6px — global card radius */
   box-shadow: var(--shadow-card);
 }
 


### PR DESCRIPTION
## Why

Two marketing-site polish asks: run the same anti-AI filter we enforce on generated content over the public marketing copy, and tighten the global card radius to 6px.

## What

**1) Anti-AI pass** — applied the content pipeline's canonical "avoid the AI tells" filter (`src/agents/stage4_content_generator/system_prompt.md`) to Landing / Product / About / FAQ / WelcomePage:

- **Zero em/en dashes** (the absolute rule): every `—`/`–` in visible copy replaced with comma/colon/period/parens, numeric ranges hyphenated. ~57 sites cleared. Remaining dashes live only in `//` and `/* */` developer comments, which never render. Also cleaned the alt/caption strings inside Product's *deferred, commented-out* screenshot blocks so the tell can't return when those screenshots go live.
- **Soft tells** (escalating "not X. Y. Z." fragments, "it's not just X, it's Y", summative throat-clearing openers): audited across every page; each was already within the one-instance cap, so no rewrites needed. Meaning and brand voice preserved.

Five independent per-page passes (one subagent each), then centrally verified with a Unicode dash scan.

**2) Global card radius → 6px:**

- `.card` base class now uses `--radius-sm` (6px) instead of `--radius-lg` (12px) — covers the app/dashboard cards.
- Marketing pages bypass the token with inline styles, so card containers there were swept too: Landing `returningCard`; Product `problemCard/gapCard/personaCard/stageCard/moatCard/pricingCard`; About `problemCard/gapCard/proofCard/founderCard`. Buttons, pills, avatar dots, the CTA banner, and screenshot frames left at their own radii.

## Test plan

- `npx tsc --noEmit` — clean
- Unicode scan confirms zero em/en dashes in any rendered copy across all five pages
- Visual: `/`, `/product`, `/about`, `/faq` cards render at 6px

## Rollback

Single-commit revert; restores prior copy and 12px card radius.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_