### PR TITLE
fix(geo): raise citation-probe timeout 30s → 60s (AI Overviews was aborting)

### DIFF
--- a/server.js
+++ b/server.js
@@ -9663,7 +9663,13 @@ app.post('/api/geo/track/:brandProfileId', async (req, res) => {
       const artParams = contentId ? [contentId] : [];
       const articlesRes = await pool.query(artQuery, artParams).catch(() => ({ rows: [] }));
 
-      const fetchWithTimeout = (url, opts, ms = 30000) => {
+      // 60s default: the AI Overviews engine reads Google's server-rendered
+      // overview through ValueSERP, which blocks until Google finishes rendering
+      // it — measured ~30s, landing right on the old 30s abort and firing
+      // "operation was aborted". The other engines (Perplexity/ChatGPT/Gemini)
+      // are fast and return well before this ceiling, so a generous cap only
+      // rescues the slow SERP path without penalizing them.
+      const fetchWithTimeout = (url, opts, ms = 60000) => {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), ms);
         return fetch(url, { ...opts, signal: controller.signal }).finally(() => clearTimeout(timer));


### PR DESCRIPTION
## Why

The `[GEO-AIOVERVIEWS] This operation was aborted` errors are a **timeout, not an auth failure.**

The AI Overviews engine reads Google's server-rendered overview through ValueSERP (`include_ai_overview=true`), which blocks until Google finishes rendering it. I timed a real call live: **HTTP 200, success, but 30,120ms** — right on the old 30s `AbortController` ceiling (`fetchWithTimeout`, line 9666). So the call actually succeeds, the abort just cuts it off a fraction too early and the result is dropped.

## What

Raise the shared `fetchWithTimeout` default from 30s → 60s. The other engines (Perplexity / ChatGPT / Gemini) return in well under a second and finish long before the ceiling, so the higher cap only rescues the slow SERP path and costs the fast ones nothing.

## ⚠️ Separate issue, NOT in this diff — Gemini needs a key

While diagnosing, I hit the Gemini engine live: `GEMINI_API_KEY` returns **HTTP 401 "invalid authentication credentials."** That's a *different* failure from the AI Overviews timeout, and it's env-side — almost certainly a casualty of the recent key rotation. **Action for Brian:** verify/replace `GEMINI_API_KEY` in the Render env group (single-key PATCH, never the bulk PUT). No code change fixes that.

(The `[AnalyticsResync] HTTP 403` lines in the same logs are a third, unrelated system — Zernio social-analytics sync — not GEO citations.)

## Test plan

- `node --check server.js` — clean
- `npx vitest run` — 199/199 pass
- Live measurement: ValueSERP AI-overview call = 30.1s (confirms the 30s abort), Gemini = 401 (confirms the key)

## Rollback

Revert this one-line default change to return to 30s.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_