### PR TITLE
style(cards): finish the 6px sweep — all bespoke per-page card classes

### DIFF
--- a/src/components/NoBrandEmpty.css
+++ b/src/components/NoBrandEmpty.css
@@ -17,7 +17,7 @@
   text-align: center;
   background: var(--color-bg-card, #fff);
   border: 1px solid var(--color-border, #e2e8f0);
-  border-radius: 16px;
+  border-radius: 6px;
   padding: 48px 32px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
@@ -124,7 +124,7 @@
 
   .no-brand-empty-card {
     padding: 32px 20px;
-    border-radius: 12px;
+    border-radius: 6px;
   }
 
   .no-brand-empty-icon {

--- a/src/components/StatStrip.tsx
+++ b/src/components/StatStrip.tsx
@@ -43,7 +43,7 @@ export function StatStrip({ stats }: { stats: Stat[] }) {
         }
         .stat-card {
           background: var(--color-bg-card, #fff);
-          border-radius: 12px;
+          border-radius: 6px;
           box-shadow: 0 0 0 1px rgba(53, 99, 255, 0.07), 0 4px 16px rgba(53, 99, 255, 0.08);
           padding: 20px;
           display: flex;

--- a/src/components/views/ActiveRun.css
+++ b/src/components/views/ActiveRun.css
@@ -339,7 +339,7 @@
 .signal-card {
   background: var(--color-bg-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 18px 22px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 }

--- a/src/components/views/BrandProfile.css
+++ b/src/components/views/BrandProfile.css
@@ -180,7 +180,7 @@
 .key-phrases-card {
   background: var(--color-bg-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
+  border-radius: 6px;
   padding: 24px 28px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 }
@@ -217,7 +217,7 @@
 .attribute-card {
   background: var(--color-bg-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 20px 22px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 }
@@ -285,7 +285,7 @@
 .persona-card {
   background: var(--color-bg-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
+  border-radius: 6px;
   padding: 24px 28px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 }
@@ -463,7 +463,7 @@
 .gap-card {
   background: var(--color-bg-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
+  border-radius: 6px;
   padding: 20px 24px;
   border-left: 3px solid var(--color-text-muted);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
@@ -757,7 +757,7 @@
 .facts-card {
   background: var(--color-bg-elevated, rgba(255,255,255,0.03));
   border: 1px solid var(--color-border, rgba(255,255,255,0.08));
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 18px 20px;
 }
 .facts-card .card-title {

--- a/src/components/views/Strategy.css
+++ b/src/components/views/Strategy.css
@@ -99,7 +99,7 @@
 .matrix-card {
   background: var(--color-bg-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
+  border-radius: 6px;
   padding: 22px 24px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
   transition: all var(--transition-fast);
@@ -195,7 +195,7 @@
 .messaging-card {
   background: var(--color-bg-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
+  border-radius: 6px;
   padding: 22px 24px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -130,7 +130,7 @@ input, textarea, select {
 .card {
   background: var(--color-bg-card);
   border: none;
-  border-radius: var(--radius-sm); /* 6px — global card radius */
+  border-radius: 6px; /* 6px — global card radius */
   box-shadow: var(--shadow-card);
 }
 

--- a/src/pages/AdminPage.css
+++ b/src/pages/AdminPage.css
@@ -67,7 +67,7 @@
 .mc-status-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 16px 18px;
   display: flex;
   flex-direction: column;

--- a/src/pages/AuthenticityEnricherPage.css
+++ b/src/pages/AuthenticityEnricherPage.css
@@ -254,7 +254,7 @@
 .geo-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 20px;
   display: flex;
   flex-direction: column;
@@ -329,7 +329,7 @@
 .geo-brief-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 32px;
   display: flex;
   flex-direction: column;

--- a/src/pages/BrandSettingsPage.css
+++ b/src/pages/BrandSettingsPage.css
@@ -473,7 +473,7 @@
 .bs-billing-card {
   background: var(--color-bg-elevated);
   border: 1px solid var(--color-border-subtle);
-  border-radius: 12px;
+  border-radius: 6px;
   overflow: hidden;
 }
 .bs-billing-top {
@@ -588,7 +588,7 @@
   padding: 16px; margin-top: 12px;
   background: var(--color-bg-elevated, #f8fafc);
   border: 1px solid var(--color-border, #e2e8f0);
-  border-radius: 8px;
+  border-radius: 6px;
   position: relative;
 }
 .fg-author-remove {

--- a/src/pages/CampaignGeneratorPage.css
+++ b/src/pages/CampaignGeneratorPage.css
@@ -75,7 +75,7 @@
   background: var(--color-bg-card);
   border: none;
   box-shadow: var(--shadow-card);
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 16px;
   display: flex; flex-direction: column; gap: 10px;
 }
@@ -119,7 +119,7 @@
   background: var(--color-bg-card);
   border: none;
   box-shadow: var(--shadow-card);
-  border-radius: 10px; padding: 14px;
+  border-radius: 6px; padding: 14px;
   display: flex; flex-direction: column; gap: 8px;
   transition: border-color 0.2s, background 0.2s;
 }

--- a/src/pages/ComplianceGatePage.css
+++ b/src/pages/ComplianceGatePage.css
@@ -23,7 +23,7 @@
   flex: 1;
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   text-align: left;
   cursor: pointer;
   transition: border-color var(--transition-fast), background var(--transition-fast);
@@ -839,7 +839,7 @@
   padding: 16px;
   background: var(--color-bg-base, #f8fafc);
   border: 1px solid var(--color-border, #e2e8f0);
-  border-radius: 8px;
+  border-radius: 6px;
 }
 .comp-faq-label {
   font-size: 11px;

--- a/src/pages/ContentGeneratorPage.css
+++ b/src/pages/ContentGeneratorPage.css
@@ -395,7 +395,7 @@
   justify-content: space-between;
   gap: 12px;
   padding: 10px 14px;
-  border-radius: 8px;
+  border-radius: 6px;
   background: color-mix(in srgb, var(--color-accent) 8%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
   cursor: pointer;
@@ -695,7 +695,7 @@
   padding: 12px 14px;
   background: var(--color-bg-card, #ffffff);
   border: 1.5px solid var(--color-border, #e2e8f0);
-  border-radius: 10px;
+  border-radius: 6px;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/src/pages/ContentImportPage.css
+++ b/src/pages/ContentImportPage.css
@@ -6,7 +6,7 @@
 .ci-form-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 28px 32px;
   display: flex;
   flex-direction: column;

--- a/src/pages/ContentLibraryPage.css
+++ b/src/pages/ContentLibraryPage.css
@@ -105,7 +105,7 @@
 .cl-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   overflow: hidden;
   cursor: pointer;
   transition: transform var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
@@ -155,7 +155,7 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding: 3px 8px;
-  border-radius: 4px;
+  border-radius: 6px;
   color: #fff;
 }
 

--- a/src/pages/EmailCampaignPage.css
+++ b/src/pages/EmailCampaignPage.css
@@ -167,7 +167,7 @@
 /* ── Email Card ── */
 .ec-email-card {
   background: var(--color-bg-card); border: 1px solid var(--color-border);
-  border-radius: 10px; overflow: hidden;
+  border-radius: 6px; overflow: hidden;
 }
 .ec-email-card.open { border-color: var(--color-accent); }
 .ec-email-header {

--- a/src/pages/GeoStrategistPage.css
+++ b/src/pages/GeoStrategistPage.css
@@ -242,7 +242,7 @@
 .geo-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 20px;
   display: flex;
   flex-direction: column;
@@ -317,7 +317,7 @@
 .geo-brief-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 32px;
   display: flex;
   flex-direction: column;
@@ -466,7 +466,7 @@
   padding: 20px;
   background: var(--color-bg-card, #ffffff);
   border: 1px solid var(--color-border, #e2e8f0);
-  border-radius: 12px;
+  border-radius: 6px;
 }
 .brief-card-header {
   display: flex;

--- a/src/pages/IntegrationsPage.css
+++ b/src/pages/IntegrationsPage.css
@@ -41,7 +41,7 @@
 .int-channel-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   overflow: visible;
   transition: border-color var(--transition-fast);
 }

--- a/src/pages/PerformanceDashboardPage.css
+++ b/src/pages/PerformanceDashboardPage.css
@@ -180,7 +180,7 @@
     var(--color-bg-elevated) 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
 }
 
 /* ── KPI Cards ── */
@@ -193,7 +193,7 @@
 .perf-kpi-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 20px 20px 16px;
   display: flex;
   flex-direction: column;
@@ -278,7 +278,7 @@
 .perf-trend-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 20px 20px 12px;
   overflow: hidden;
   box-shadow: var(--shadow-sm);
@@ -469,7 +469,7 @@
 .perf-brain-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 20px;
   display: flex;
   flex-direction: column;
@@ -612,7 +612,7 @@
 .camp-analytics-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   overflow: hidden;
   box-shadow: var(--shadow-sm);
   transition: box-shadow var(--transition-normal);
@@ -1166,7 +1166,7 @@
 
 .perf-decay-card {
   padding: 14px 16px;
-  border-radius: var(--radius-md);
+  border-radius: 6px;
   border: 1px solid var(--color-border-subtle);
   background: var(--color-bg-elevated);
   display: flex;
@@ -1440,7 +1440,7 @@
 .perf-pred-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
+  border-radius: 6px;
   padding: 12px 16px;
   display: flex;
   flex-direction: column;
@@ -1831,7 +1831,7 @@
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
   border-left: 3px solid transparent;
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -1977,7 +1977,7 @@
 .brain-signal-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: 10px;
+  border-radius: 6px;
   padding: 16px 18px;
   display: flex;
   flex-direction: column;

--- a/src/pages/PublicArticlesLibraryPage.css
+++ b/src/pages/PublicArticlesLibraryPage.css
@@ -123,7 +123,7 @@
 .pal-card {
   background: rgba(255,255,255,0.03);
   border: 1px solid rgba(255,255,255,0.08);
-  border-radius: 12px;
+  border-radius: 6px;
   overflow: hidden;
   text-decoration: none;
   color: inherit;

--- a/src/pages/ReviewPage.css
+++ b/src/pages/ReviewPage.css
@@ -229,7 +229,7 @@
 .rv-done-card, .rv-error-card {
   background: #1E293B;
   border: 1px solid rgba(255,255,255,0.08);
-  border-radius: 16px;
+  border-radius: 6px;
   padding: 48px 40px;
   text-align: center;
   max-width: 440px;

--- a/src/pages/SocialGeneratorPage.css
+++ b/src/pages/SocialGeneratorPage.css
@@ -164,7 +164,7 @@
 .sg-input-card {
   background: var(--color-bg-card, #FFFFFF);
   border: 1px solid var(--color-border, #E2E8F0);
-  border-radius: 14px;
+  border-radius: 6px;
   padding: 24px;
   display: flex;
   flex-direction: column;
@@ -524,7 +524,7 @@
 .sg-post-card {
   background: var(--color-bg-card, #FFFFFF);
   border: 1px solid var(--color-border, #E2E8F0);
-  border-radius: 14px;
+  border-radius: 6px;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/src/pages/TopicQueuePage.css
+++ b/src/pages/TopicQueuePage.css
@@ -8,7 +8,7 @@
   align-items: flex-start;
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  border-radius: 6px;
   padding: 20px 24px;
   margin-bottom: 24px;
 }


### PR DESCRIPTION
## Why

The first radius change (#435) only took the shared `.card` token + the marketing-page inline cards to 6px. It **missed the bespoke per-screen card classes** in component CSS (and one in a `StatStrip` `<style>` block) — so dashboard cards like `.stat-card` (12px) and `.sg-input-card` (14px) were still rendering at the old radii. This is the "big ol' grep for card" that finishes the job.

## What

Swept **every** card-class `border-radius` to 6px: **45 rules across 22 files**. Covers hardcoded values (8/10/12/14/16px) and the `var(--radius-lg/md)` refs those card rules used:

`.stat-card`, `.sg-input-card`, `.perf-kpi-card` / `-trend-card` / `-decay-card` / `-pred-card` / `-brain-card` (×9 in Performance), `.geo-card`, `.persona-card`, `.gap-card`, `.matrix-card`, `.messaging-card`, `.cg-batch-card`, `.bs-billing-card`, `.fg-author-card`, `.ci-form-card`, `.no-brand-empty-card`, `.attribute-card`, `.facts-card`, `.signal-card`, `.brain-rule-card` / `-signal-card`, and more.

Only `border-radius` lines **inside a selector containing "card"** were touched — buttons, inputs, pills, avatars, modals, and the radius tokens themselves are untouched.

## Test plan

- `tsc --noEmit` clean
- `vite build` succeeds
- `vitest run` 199/199
- diff confirms every changed line is a card rule set to 6px

## Rollback

Single-commit revert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_