### PR TITLE
style(cards): kill 3px left-stripe → recolor the full 1px border

### DIFF
--- a/src/components/views/BrandProfile.css
+++ b/src/components/views/BrandProfile.css
@@ -465,20 +465,19 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 6px;
   padding: 20px 24px;
-  border-left: 3px solid var(--color-text-muted);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
 .gap-card.priority-high {
-  border-left-color: var(--color-accent);
+  border-color: var(--color-accent);
 }
 
 .gap-card.priority-medium {
-  border-left-color: var(--color-warning);
+  border-color: var(--color-warning);
 }
 
 .gap-card.priority-low {
-  border-left-color: var(--color-text-muted);
+  border-color: var(--color-text-muted);
 }
 
 .gap-header {

--- a/src/components/views/Strategy.css
+++ b/src/components/views/Strategy.css
@@ -111,15 +111,15 @@
 }
 
 .matrix-card.impact-high {
-  border-left: 3px solid var(--color-accent);
+  border: 1px solid var(--color-accent);
 }
 
 .matrix-card.impact-medium {
-  border-left: 3px solid var(--color-warning);
+  border: 1px solid var(--color-warning);
 }
 
 .matrix-card.impact-low {
-  border-left: 3px solid var(--color-text-muted);
+  border: 1px solid var(--color-text-muted);
 }
 
 .matrix-header {
@@ -340,11 +340,11 @@
 }
 
 .action-item.priority-high {
-  border-left: 3px solid var(--color-accent);
+  border: 1px solid var(--color-accent);
 }
 
 .action-item.priority-medium {
-  border-left: 3px solid var(--color-warning);
+  border: 1px solid var(--color-warning);
 }
 
 .action-number {

--- a/src/pages/AuthenticityEnricherPage.css
+++ b/src/pages/AuthenticityEnricherPage.css
@@ -260,10 +260,10 @@
   flex-direction: column;
   gap: 12px;
 }
-.geo-card.priority-high { border-left: 3px solid var(--color-accent); }
-.geo-card.priority-medium { border-left: 3px solid var(--color-warning); }
-.geo-card.priority-low { border-left: 3px solid var(--color-border); }
-.geo-card.competitor-gap { border-left: 3px solid var(--color-error); }
+.geo-card.priority-high { border: 1px solid var(--color-accent); }
+.geo-card.priority-medium { border: 1px solid var(--color-warning); }
+.geo-card.priority-low { border: 1px solid var(--color-border); }
+.geo-card.competitor-gap { border: 1px solid var(--color-error); }
 
 .geo-card-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
 .geo-topic { font-size: 14px; font-weight: 600; }

--- a/src/pages/ComplianceGatePage.css
+++ b/src/pages/ComplianceGatePage.css
@@ -813,7 +813,7 @@
   padding: 24px;
   background: var(--color-bg-card, #fff);
   border: 1px solid var(--color-border, #e2e8f0);
-  border-left: 3px solid var(--color-accent, #4F46E5);
+  border: 1px solid var(--color-accent, #4F46E5);
   border-radius: 12px;
 }
 .comp-faqs-header {

--- a/src/pages/ContentGeneratorPage.css
+++ b/src/pages/ContentGeneratorPage.css
@@ -54,7 +54,7 @@
 .cg-section {
   background: var(--color-bg-elevated);
   border: 1px solid var(--color-bg-card);
-  border-left: 3px solid #3563FF;
+  border: 1px solid #3563FF;
   border-radius: 10px;
   padding: 20px 24px;
   display: flex;

--- a/src/pages/ContentImportPage.css
+++ b/src/pages/ContentImportPage.css
@@ -226,7 +226,7 @@
   padding: 8px 12px;
   background: rgba(245,158,11,0.07);
   border-radius: 6px;
-  border-left: 3px solid #F59E0B;
+  border: 1px solid #F59E0B;
 }
 
 .ci-suggestions { display: flex; flex-direction: column; gap: 8px; }
@@ -238,7 +238,7 @@
   padding: 8px 12px;
   background: rgba(53,99,255,0.06);
   border-radius: 6px;
-  border-left: 3px solid var(--color-accent);
+  border: 1px solid var(--color-accent);
 }
 
 /* Actions */

--- a/src/pages/GeoStrategistPage.css
+++ b/src/pages/GeoStrategistPage.css
@@ -248,10 +248,10 @@
   flex-direction: column;
   gap: 12px;
 }
-.geo-card.priority-high { border-left: 3px solid var(--color-accent); }
-.geo-card.priority-medium { border-left: 3px solid var(--color-warning); }
-.geo-card.priority-low { border-left: 3px solid var(--color-border); }
-.geo-card.competitor-gap { border-left: 3px solid var(--color-error); }
+.geo-card.priority-high { border: 1px solid var(--color-accent); }
+.geo-card.priority-medium { border: 1px solid var(--color-warning); }
+.geo-card.priority-low { border: 1px solid var(--color-border); }
+.geo-card.competitor-gap { border: 1px solid var(--color-error); }
 
 .geo-card-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
 .geo-topic { font-size: 14px; font-weight: 600; }

--- a/src/pages/PerformanceDashboardPage.css
+++ b/src/pages/PerformanceDashboardPage.css
@@ -1690,7 +1690,7 @@
   max-width: 100%;
 }
 .perf-pattern-correction {
-  border-left: 3px solid #EAB308 !important;
+  border: 1px solid #EAB308 !important;
   background: rgba(234, 179, 8, 0.04) !important;
 }
 
@@ -1830,7 +1830,6 @@
 .brain-rule-card {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
-  border-left: 3px solid transparent;
   border-radius: 6px;
   padding: 16px;
   display: flex;
@@ -1839,8 +1838,8 @@
   transition: box-shadow var(--transition-fast);
 }
 .brain-rule-card:hover { box-shadow: 0 2px 8px var(--color-bg-elevated); }
-.brain-rule-avoid { border-left-color: #F59E0B; }
-.brain-rule-do { border-left-color: var(--color-accent); }
+.brain-rule-avoid { border-color: #F59E0B; }
+.brain-rule-do { border-color: var(--color-accent); }
 
 .brain-rule-header {
   display: flex;


### PR DESCRIPTION
## Why

The 3px colored `border-left` stripe on cards is the exact "left-edge stripe" the design system says not to use. Kill it; where a card carries a color, make the **whole** 1px border that color.

## What

Every card already had a base `border: 1px solid <subtle>`; the 3px `border-left` just thickened/colored the left edge as a severity/priority indicator. Converted across **8 files**:

- **Modifier stripes** → the whole `border-left: 3px solid X` becomes `border: 1px solid X`: `.matrix-card.impact-*`, `.action-item.priority-*`, `.geo-card.priority-*`/`.competitor-gap` (×2 pages), `.ci-flag`, `.ci-suggestion`, `.cg-section`, `.comp-faqs-block`, `.perf-pattern-correction`.
- **Base-stripe cards** (`.gap-card`, `.brain-rule-card`) → dropped the base `border-left` stripe (keeps the subtle base border) and switched the color modifiers from `border-left-color` to `border-color`, so the full border recolors.

### Left untouched on purpose (not card color-stripes)
2px accents — sidebar nav active-indicator, `.brief-h2` headings, `.camp-angle-hook` / `.sg-arc-active-hint` / `.cg-sme-hook` accents — the TopBar divider, and the **public-blog editorial styling** (`DocsPage` blockquote, `PublicArticlePage` section headings + TL;DR). Those are deliberate, different patterns.

## ⚠️ Judgment calls to eyeball

A few converted selectors aren't literally named `*-card` but carry the same 3px-left-color pattern: `.cg-section`, `.comp-faqs-block`, and `.perf-pattern-correction` (this last one keeps `!important`). They now get a full 1px colored border. If any of those read as "too heavy" boxed, say so and I'll revert just that one.

## Test plan

- `tsc --noEmit` clean · `vite build` succeeds · `vitest run` 199/199
- Visual QA on Strategy, Records/Brand Profile, GEO Strategist, Authenticity Enricher, Performance (brain rules), Content Import, Compliance cards

## Rollback

Single-commit revert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_