### PR TITLE
feat(disclosure): "AI illustration courtesy of fal.ai" credit on generated images

### DIFF
--- a/src/pages/PublicArticlePage.css
+++ b/src/pages/PublicArticlePage.css
@@ -430,3 +430,18 @@
 }
 .pa-faq-answer p { margin-bottom: 0.75rem; }
 .pa-faq-answer p:last-child { margin-bottom: 0; }
+
+/* AI-generation disclosure on the fal.ai-generated article hero
+   (EU AI Act Art. 50(4) human-visible disclosure leg). Sits above the
+   overlay, subtle bottom-right, non-interactive. */
+.pa-hero-credit {
+  position: absolute;
+  right: 14px;
+  bottom: 12px;
+  z-index: 2;
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.62);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+}

--- a/src/pages/PublicArticlePage.tsx
+++ b/src/pages/PublicArticlePage.tsx
@@ -288,6 +288,7 @@ export default function PublicArticlePage() {
         <div className="pa-hero-wrap">
           <img src={article.heroImageUrl} alt={article.title} className="pa-hero-img" />
           <div className="pa-hero-overlay" />
+          <span className="pa-hero-credit">AI illustration courtesy of fal.ai</span>
           <div className="pa-hero-content">
             {article.category && <div className="pa-eyebrow">{article.category}</div>}
             <h1 className="pa-title pa-title-over-hero">{article.title}</h1>

--- a/src/pages/SocialGeneratorPage.css
+++ b/src/pages/SocialGeneratorPage.css
@@ -1262,3 +1262,12 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* AI-generation disclosure under the fal.ai-generated square social image
+   (EU AI Act Art. 50(4) human-visible disclosure leg). */
+.sg-image-credit {
+  font-size: 10px;
+  color: var(--color-text-muted, #94A3B8);
+  letter-spacing: 0.02em;
+  padding: 4px 14px 0;
+}

--- a/src/pages/SocialGeneratorPage.tsx
+++ b/src/pages/SocialGeneratorPage.tsx
@@ -1019,6 +1019,10 @@ function PostCard({ post, authToken, xConnected, onUpdate }: { post: SocialPost;
         )}
       </div>
 
+      {post.image_url && (
+        <div className="sg-image-credit">AI illustration courtesy of fal.ai</div>
+      )}
+
       <div className="sg-post-body">
         {post.hook && <div className="sg-post-hook">{post.hook}</div>}
 


### PR DESCRIPTION
## Why

Forge generates hero (16:9) and social (1:1) images via **fal.ai Ideogram v2** (`src/server/images.js`) but displayed nothing crediting the AI generation. This adds the human-visible disclosure — the **Art. 50(4)** disclosure leg the EU AI Act memo flagged — matching the "Photo courtesy" posture already adopted elsewhere.

## What

- **Social Generator card:** small muted `AI illustration courtesy of fal.ai` line under the square social image (only rendered when an image is present).
- **Public article hero:** subtle bottom-right credit over the hero on the published article page — the public-facing surface that matters most for "content published to inform the public."

Reusable, tiny, non-interactive captions; new CSS in `SocialGeneratorPage.css` + `PublicArticlePage.css`.

## Scope / deliberate omissions

- **Machine-readable marking (Art. 50(2))** — C2PA Content Credentials / IPTC `digitalSourceType` embedded in the file — is a *separate* requirement a text credit doesn't satisfy. Still an open item in `EU-AI-ACT-RISK-MEMO.md`; a defensible park for brand illustration with no identifiable person.
- **Published X post text** — not modified. Appending the credit would eat the 280-char budget and change the copy; that's a product call, flagged not assumed.
- **Library/preview thumbnails** — credit lives on the full-size display surfaces, not every small thumbnail.

## Test plan

- `tsc --noEmit` clean · `vite build` succeeds · `vitest run` 199/199
- Visual: Social Generator (post cards with images) + a public `/articles/:slug` with a hero image

## Rollback

Single-commit revert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_