### PR TITLE
chore(radius): Phase 2 — flatten Video Generator card corners

### DIFF
--- a/src/pages/VideoGeneratorPage.css
+++ b/src/pages/VideoGeneratorPage.css
@@ -22,7 +22,7 @@
 .vg-form {
   background: #FFFFFF;
   border: 1px solid #E2E8F0;
-  border-radius: 14px;
+  border-radius: var(--radius-sm);
   padding: 24px;
   display: flex;
   flex-direction: column;
@@ -120,7 +120,7 @@
   margin-top: 24px;
   background: #FFFFFF;
   border: 1px solid #E2E8F0;
-  border-radius: 14px;
+  border-radius: var(--radius-sm);
   padding: 24px;
 }
 .vg-stage { font-size: 15px; font-weight: 600; color: #0F172A; margin-bottom: 12px; }


### PR DESCRIPTION
## Why
Follow-up to the Phase 1 radius-litter sweep (PR #458). Brian handed over 14 "strategic" selectors he wanted flattened to the 6px token.

## What the audit found
Of the 14 selectors, **12 were already on `var(--radius-sm)` (6px)** — Phase 1 caught them:
`staleness-banner`, `analysis-form`, `brand-group`, `stat-item`, `facts-intro-banner`, `theme-item`, `geo-brief-empty`, `cg-batch-section`, `cg-batch-progress`, `camp-brand-display`, `ec-history-item`, and the `deploy-this-brain-heading` wrapper.

Two carry **no border-radius at all** (nothing to change):
- `category-title` — a heading with a bottom border only
- `deploy-this-brain-heading` — the `<h3>` id; its wrapping section already uses `var(--radius-sm)`

## The one real fix
`VideoGeneratorPage.css` escaped Phase 1's sweep. Two sibling cards were still at a hardcoded `14px`:
- `.vg-form` `14px` → `var(--radius-sm)`
- `.vg-job` `14px` → `var(--radius-sm)` (not on the list, but the same GPT litter on the same page — flattened so the page stays consistent)

The rest of that file's radii are legit exclusions (3px icon box, 999px pills/circle buttons) and left untouched.

## Test plan
- `npx tsc --noEmit` — clean
- `npm run build` — clean

## Rollback
Revert the two one-line CSS edits.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_