### PR TITLE
feat(context-hub): generate explicit brand messaging + protect it from truncation

### DIFF
--- a/src/server/routes/context-hub.js
+++ b/src/server/routes/context-hub.js
@@ -181,6 +181,14 @@ Return ONLY valid JSON (no markdown, no explanation, no newlines inside string v
     "visualStyle": "string — conservative descriptor since there's no site to inspect",
     "accentColor": "string — descriptor like 'deep indigo' or 'neutral slate', not a guessed hex"
   },
+  "messaging": {
+    "keyMessages": ["string — 4-6 core messages, each a full sentence in the brand's voice, grounded in the Founder Brief"],
+    "valueProps": ["string — 3-5 concrete, benefit-first value propositions drawn from the brief"],
+    "taglines": ["string — 2-4 on-brand tagline candidates"],
+    "boilerplate": "string — a 2-3 sentence 'about' paragraph in the brand's own voice",
+    "elevatorPitch": "string — one first-person paragraph: how the brand pitches itself in ~20 seconds",
+    "proofPoints": ["string — specific proof (metrics, customers, awards) ONLY if present in the Founder Brief; never invent"]
+  },
   "personas": [{
     "id": "string", "name": "string", "role": "string",
     "painPoints": ["string"], "triggers": ["string"],
@@ -202,7 +210,7 @@ Return ONLY valid JSON (no markdown, no explanation, no newlines inside string v
   "discoveredCompetitors": ["string — verbatim from founder's competitors list"],
   "marketCategory": "string"
 }
-Requirements: 5 toneAttributes, 2-3 personas, 0 thirdPartySignals (no website to inspect), 3-5 competitiveGaps (real missed opportunities), 1-4 strategicMoats (one per item in 'What we do NOT do'), 4-6 strategicRecommendations, 2-4 campaignArcs, 1 businessProfile (all fields required). Ground every field in the Founder Brief.`;
+Requirements: 5 toneAttributes, 2-3 personas, 0 thirdPartySignals (no website to inspect), 3-5 competitiveGaps (real missed opportunities), 1-4 strategicMoats (one per item in 'What we do NOT do'), 4-6 strategicRecommendations, 2-4 campaignArcs, 1 businessProfile (all fields required), and the messaging block (4-6 keyMessages, 3-5 valueProps, 2-4 taglines, boilerplate, elevatorPitch, and proofPoints ONLY where the brief supports them). Ground every field in the Founder Brief.`;
 
     let profileData;
     let lastErr;
@@ -210,7 +218,7 @@ Requirements: 5 toneAttributes, 2-3 personas, 0 thirdPartySignals (no website to
       try {
         const message = await anthropic.messages.create({
           model: 'claude-opus-4-8',
-          max_tokens: 8192,
+          max_tokens: 16000,
           messages: [{ role: 'user', content: prompt }]
         });
         const raw = message.content[0].text;
@@ -645,6 +653,14 @@ Return ONLY valid JSON (no markdown, no explanation, no newlines inside string v
     "visualStyle": "string — inferred from site aesthetic, e.g. \'dark editorial minimal\', \'bright human photography\', \'technical precision grids\', \'warm organic textures\'",
     "accentColor": "string — a plain-language descriptor only (e.g. \'deep indigo\', \'warm terracotta\'). Do NOT output a hex code: the real brand hex is measured from the live site and injected separately. Never guess a hex from text."
   },
+  "messaging": {
+    "keyMessages": ["string — 4-6 core messages the brand leads with, each a full sentence in the brand's own voice"],
+    "valueProps": ["string — 3-5 concrete, benefit-first value propositions; specific, never generic"],
+    "taglines": ["string — 2-4 on-brand tagline candidates (any real tagline on the site first, then sharp alternatives)"],
+    "boilerplate": "string — a 2-3 sentence 'about' paragraph in the brand's own voice, ready to paste",
+    "elevatorPitch": "string — one first-person paragraph: how the brand would pitch itself in ~20 seconds",
+    "proofPoints": ["string — specific credibility proof pulled from real site content: metrics, named customers, awards, scale, outcomes"]
+  },
   "personas": [{
     "id": "string", "name": "string", "role": "string",
     "painPoints": ["string"], "triggers": ["string"],
@@ -666,11 +682,11 @@ Return ONLY valid JSON (no markdown, no explanation, no newlines inside string v
   "discoveredCompetitors": ["string"],
   "marketCategory": "string"
 }
-Requirements: 5 toneAttributes, 2-3 personas, 4-6 thirdPartySignals, 3-5 competitiveGaps (ACTUAL missed opportunities, not strategic non-choices), 0-4 strategicMoats (include only if the brand explicitly states what they don't do as a strategy — some brands won't have any), 4-6 strategicRecommendations, 2-4 campaignArcs (each is a narrative series the brand could publish; focus on storylines that prove a thesis, challenge industry conventions, or crystallize the brand's worldview — not topic lists. Think of each arc as a season of television: a single argument told across multiple acts with payoff in the final act), 1 businessProfile (all fields required). Use the ICP and market context provided to make personas and gaps highly specific. For visualStyle and accentColor: infer carefully from the brand website design, color palette, imagery, and overall aesthetic — these feed directly into AI hero image generation and must reflect the real brand identity. For industry, positioning, and targetPersona: be specific and commercially precise, not generic.`;
+Requirements: 5 toneAttributes, 2-3 personas, 4-6 thirdPartySignals, 3-5 competitiveGaps (ACTUAL missed opportunities, not strategic non-choices), 0-4 strategicMoats (include only if the brand explicitly states what they don't do as a strategy — some brands won't have any), 4-6 strategicRecommendations, 2-4 campaignArcs (each is a narrative series the brand could publish; focus on storylines that prove a thesis, challenge industry conventions, or crystallize the brand's worldview — not topic lists. Think of each arc as a season of television: a single argument told across multiple acts with payoff in the final act), 1 businessProfile (all fields required). Use the ICP and market context provided to make personas and gaps highly specific. For visualStyle and accentColor: infer carefully from the brand website design, color palette, imagery, and overall aesthetic — these feed directly into AI hero image generation and must reflect the real brand identity. For industry, positioning, and targetPersona: be specific and commercially precise, not generic. For the messaging block: 4-6 keyMessages, 3-5 valueProps, 2-4 taglines, a boilerplate paragraph, an elevatorPitch, and 3-6 proofPoints — extract real proof from the site and NEVER fabricate metrics, customers, or awards.`;
 
     const message = await anthropic.messages.create({
       model: 'claude-opus-4-8',
-      max_tokens: 16384,
+      max_tokens: 32000,
       messages: [{ role: 'user', content: prompt }]
     });
 
@@ -716,7 +732,7 @@ Requirements: 5 toneAttributes, 2-3 personas, 4-6 thirdPartySignals, 3-5 competi
     for (let attempt = 0; attempt < 2; attempt++) {
       const msg = attempt === 0 ? message : await anthropic.messages.create({
         model: 'claude-opus-4-8',
-        max_tokens: 16384,
+        max_tokens: 32000,
         messages: [{ role: 'user', content: prompt }]
       });
       if (msg.stop_reason === 'max_tokens') {


### PR DESCRIPTION
## Why

The Stage-1 brand profile had **no dedicated messaging assets**. Key messages, value props, taglines, boilerplate, elevator pitch, and proof points only ever existed *implicitly* inside `voiceProfile.keyPhrases` / `positioning`. Downstream consumers — Pitch Box's RFP writer and the deck generator — therefore had thin customer messaging to draw on for storytelling. On top of that, the richest narrative fields (`campaignArcs`, `businessProfile`) sit at the **tail** of the requested JSON, so the `16384`-token ceiling could truncate them on richer brands (the salvage path `closeTruncatedJson` deliberately drops the incomplete trailing member).

## What

`src/server/routes/context-hub.js`, both generation prompts (website scan + Quick Start):

- **Add a `messaging` block** — `keyMessages`, `valueProps`, `taglines`, `boilerplate`, `elevatorPitch`, `proofPoints` — placed **right after `voiceProfile`** so a truncation can't reach it. `proofPoints` are instructed to be extracted from real content, **never fabricated** (Quick Start: only if the Founder Brief supports them).
- **Raise the output ceiling** so the story-heavy trailing fields survive: website `16384 → 32000`, Quick Start `8192 → 16000`.
- Requirements lines updated to specify the messaging counts.

Storage is full-fidelity JSONB (`brand_profiles.profile_data`), so the new block persists with **no migration**.

## Coupled change (must ship together)

Pitch Box's `compactBrandProfile` whitelist (in `ForgeOS` `apps/pitchbox`) currently copies only 8 fields and drops anything else — so it would silently discard this new `messaging` block. A companion PR widens that whitelist to pass `messaging` (+ `strategicMoats`, `discoveredCompetitors`) through to the RFP/pitch prompts.

## Test plan

- `node --check src/server/routes/context-hub.js` ✓ (template literals intact, both prompts valid)
- Live: re-run a brand scan (e.g. sysoi.ai) → confirm `profile_data.messaging` populated and campaignArcs no longer truncated. (Requires the live Anthropic key — not exercisable in the sandbox.)

## Rollback

Revert the commit — the field is additive and unread until a consumer opts in, so removing it is safe.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_