### PR TITLE
fix(gsc): scheme-normalize GSC_REDIRECT_URI so a schemeless env value can't 400

### DIFF
--- a/server.js
+++ b/server.js
@@ -5533,13 +5533,23 @@ app.post('/api/webflow/select-target', requireAuth, async (req, res) => {
 // ── Google Search Console OAuth ──────────────────────────────────────────────
 
 // GET /api/gsc/auth — initiate OAuth flow
+// GSC OAuth redirect URI, scheme-normalized. Google rejects a schemeless
+// redirect_uri with "400 invalid_request" BEFORE the consent screen — exactly
+// what a GSC_REDIRECT_URI env value like "forgeintelligence.ai/auth/gsc/callback"
+// produces (2026-07-04 incident: the shared env group carried the prod host
+// without https://). Normalize here so an env typo degrades to a working URL.
+function gscRedirectUri() {
+  const raw = (process.env.GSC_REDIRECT_URI || 'https://dev.forgeintelligence.ai/auth/gsc/callback').trim();
+  return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+}
+
 app.get('/api/gsc/auth', (req, res) => {
   const clientId = process.env.GSC_CLIENT_ID;
   if (!clientId) return res.status(500).json({ error: 'GOOGLE_CLIENT_ID not configured' });
   const brandProfileId = req.query.state?.split('|')[0] || req.query.brandProfileId || 'system';
   const nonce = randomBytes(16).toString('hex');
   const state = `${brandProfileId}|${nonce}`;
-  const redirectUri = encodeURIComponent(process.env.GSC_REDIRECT_URI || 'https://dev.forgeintelligence.ai/auth/gsc/callback');
+  const redirectUri = encodeURIComponent(gscRedirectUri());
   const scope = encodeURIComponent('https://www.googleapis.com/auth/webmasters.readonly');
   const url = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scope}&state=${encodeURIComponent(state)}&access_type=offline&prompt=consent`;
   res.json({ authUrl: url });
@@ -5553,7 +5563,7 @@ app.get('/auth/gsc/callback', async (req, res) => {
   try {
     const clientId     = process.env.GSC_CLIENT_ID;
     const clientSecret = process.env.GSC_CLIENT_SECRET;
-    const redirectUri  = process.env.GSC_REDIRECT_URI || 'https://dev.forgeintelligence.ai/auth/gsc/callback';
+    const redirectUri  = gscRedirectUri();
 
     const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',


### PR DESCRIPTION
## Why

"Connect GSC" on prod failed with Google's `Error 400: invalid_request — redirect_uri=forgeintelligence.ai/auth/gsc/callback`. Root cause: the **shared FI env group** carried `GSC_REDIRECT_URI` **without the `https://` scheme**; Google rejects schemeless redirect URIs before the consent screen. Dev kept working because it has a correct service-level override.

## What

- **Env (already applied, single-key update):** env-group `GSC_REDIRECT_URI` → `https://forgeintelligence.ai/auth/gsc/callback`; Production redeployed to pick it up.
- **Code (this PR):** both the authorize route and the callback's token exchange read the URI through a new `gscRedirectUri()` helper that prepends `https://` when the scheme is missing — an env typo now degrades to a working URL instead of a Google 400. (The two must stay identical anyway — token exchange fails on mismatch — so centralizing also removes the duplicate.)

## Verification

- `node --check` clean; helper unit-smoked (schemeless → prefixed, already-https → unchanged).
- After the Production redeploy finishes: click **Connect GSC** on prod — Google should show the consent screen.

## Watch-for

If Google next throws `redirect_uri_mismatch` (a different error than this 400), the OAuth client in Google Cloud Console needs `https://forgeintelligence.ai/auth/gsc/callback` added to its **Authorized redirect URIs** — that list is console-side and I can't verify it from here.

## Rollback

Revert — the helper only changes behavior for malformed env values.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_