### PR TITLE
fix(compliance): TL;DR review card wears the page theme, not dark-theme fallbacks

### DIFF
--- a/src/pages/ComplianceGatePage.css
+++ b/src/pages/ComplianceGatePage.css
@@ -886,3 +886,22 @@
     padding: 12px;
   }
 }
+
+/* TL;DR / Key Takeaway review card — page-native theme. (Replaced inline styles
+   whose dark-theme fallbacks — #14171C bg / #F2EFE8 text — rendered a black box
+   on the light UI because the var names they referenced don't exist here.) */
+.comp-tldr {
+  margin: 0 0 18px;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.comp-tldr-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary, var(--color-text-secondary));
+  padding: 12px 16px 0;
+}

--- a/src/pages/ComplianceGatePage.tsx
+++ b/src/pages/ComplianceGatePage.tsx
@@ -616,14 +616,14 @@ function ComplianceGateContent() {
             {/* Key Takeaway (TL;DR) — surfaced for review so it stops shipping
                 unreviewed. It renders at the top of every published export. */}
             {(selectedArticle.article_json?.keyTakeaway || editedKeyTakeaway !== null) && (
-              <div style={{ margin: '0 0 18px', padding: '14px 16px', border: '1px solid var(--color-border, #2B2F36)', borderRadius: 'var(--radius-sm)', background: 'var(--color-surface-2, rgba(255,255,255,0.03))' }}>
-                <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--color-text-muted)', marginBottom: 8 }}>TL;DR / Key Takeaway — review before publish</div>
+              <div className="comp-tldr">
+                <div className="comp-tldr-label">TL;DR / Key Takeaway — review before publish</div>
                 <textarea
+                  className="comp-section-edit"
                   value={editedKeyTakeaway ?? selectedArticle.article_json?.keyTakeaway ?? ''}
                   onChange={e => setEditedKeyTakeaway(e.target.value)}
                   rows={3}
                   placeholder="This summary ships at the top of every published article. Edit it here before approving."
-                  style={{ width: '100%', resize: 'vertical', font: 'inherit', padding: '8px 10px', borderRadius: 'var(--radius-sm)', border: '1px solid var(--color-border, #2B2F36)', background: 'var(--color-bg, #14171C)', color: 'var(--color-text, #F2EFE8)' }}
                 />
               </div>
             )}


### PR DESCRIPTION
## Why

The Key Takeaway block on the Compliance Gate renders as a **black box on the light UI** (Brian's screenshot). Cause: its inline styles referenced CSS vars that don't exist in the current token set (`--color-bg`, `--color-text`, `--color-border`, `--color-surface-2`), so their hardcoded **fallbacks — the old dark theme** (`#14171C` bg, `#F2EFE8` text) — always won.

## What

- Textarea reuses `.comp-section-edit` — the exact styling of every section editor on the page.
- Container is a new `.comp-tldr` card built from the page's own tokens (`--color-bg-card` / `--color-border-subtle` / `--radius-lg`), matching `.comp-section`.
- Zero behavior change — same edit state, same approve flow.

## Test plan

`npx tsc --noEmit` clean. Visual: open Compliance Gate on dev after deploy — the TL;DR card should match the section cards (white card, subtle border, standard editor field).

## Rollback

Revert — styling only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_