### PR TITLE
fix(scrape): stop hallucinated profiles when a site can't be read

### DIFF
--- a/src/components/views/BrandProfile.tsx
+++ b/src/components/views/BrandProfile.tsx
@@ -256,7 +256,7 @@ export function BrandProfile() {
           <div>
             <div style={{ fontSize: 13, fontWeight: 600, color: '#92400E', marginBottom: 4 }}>Limited website access</div>
             <div style={{ fontSize: 12, color: '#B45309', lineHeight: 1.5 }}>
-              We couldn't scrape your website content — it may be behind bot protection (Cloudflare, Akamai, etc.). This profile was built from search context only and may be less accurate.
+              We couldn't scrape your website content — it may be behind bot protection (Cloudflare, Akamai, etc.). Market-level fields were built from live web research, but the <strong>Voice Profile and Messaging are withheld</strong> — we won't invent a brand voice we haven't read.
               Use <strong>Re-analyze</strong> to retry, or provide additional context via the <strong>Audience Notes</strong> and <strong>Strategic Notes</strong> fields on the New Analysis page.
             </div>
           </div>

--- a/src/server/routes/context-hub.js
+++ b/src/server/routes/context-hub.js
@@ -476,8 +476,8 @@ router.post('/analyze', softAuth, async (req, res) => {
     const scraperSuccess = scrapedContent.length > 200;
     const siteContentSection = scraperSuccess
       ? `\n\nACTUAL WEBSITE CONTENT (scraped — use this as primary source, do NOT guess from domain name):\n${scrapedContent.slice(0, 100000)}`
-      : '';
-    if (!scraperSuccess) console.warn(`[Context Hub] ⚠️ SCRAPER FAILED for ${brandUrl} — Claude will guess from domain name + Sonar context only`);
+      : `\n\nNO WEBSITE CONTENT AVAILABLE — the site could not be scraped. You have ZERO knowledge of this brand's actual copy, tone, or claims. For every field that must be derived from the brand's own writing — voiceProfile.summary, toneAttributes, writingStyle, keyPhrases, visualStyle, and the ENTIRE messaging block (keyMessages, valueProps, taglines, boilerplate, elevatorPitch, proofPoints) — return an empty string or empty array. Do NOT invent a voice or messaging; a fabricated voice profile poisons every downstream content stage. Market-level fields (industry, positioning, targetPersona, personas, businessProfile, marketCategory, competitiveGaps) may still be inferred from the research context below.`;
+    if (!scraperSuccess) console.warn(`[Context Hub] ⚠️ SCRAPER FAILED for ${brandUrl} — voice/messaging will be withheld (insufficient data), market fields from Sonar context only`);
 
     // ── Visual capture — measure the brand's REAL accent color + logo ─────────
     // The text scrape strips all color, so accentColor used to be hallucinated
@@ -788,6 +788,32 @@ Requirements: 5 toneAttributes, 2-3 personas, 4-6 thirdPartySignals, 3-5 competi
     console.log(`[Context Hub] Complete — ${brandName} | Latency: ${latencyMs}ms | Competitors found: ${sonarCompetitors.length}`);
 
     profileData.scraperSuccess = scraperSuccess;
+
+    // ── Honesty enforcement: no site copy → no voice, no messaging ──────────
+    // The prompt already instructs the model to leave voice/messaging empty
+    // when the scrape failed, but enforcement is deterministic: blank every
+    // field that can only legitimately come from the brand's own writing, and
+    // stamp insufficientData so the UI can explain WHY the voice tab is empty.
+    // A fabricated voice profile is worse than none — it silently poisons the
+    // enricher, generator, and image prompts downstream. Market-level fields
+    // (industry/positioning/personas/businessProfile) survive: Sonar's live
+    // web research can ground those without reading the site.
+    if (!scraperSuccess) {
+      profileData.voiceProfile = {
+        ...(profileData.voiceProfile || {}),
+        summary: '',
+        toneAttributes: [],
+        writingStyle: '',
+        keyPhrases: [],
+        visualStyle: '',
+        insufficientData: true,
+      };
+      profileData.messaging = {
+        keyMessages: [], valueProps: [], taglines: [],
+        boilerplate: '', elevatorPitch: '', proofPoints: [],
+        insufficientData: true,
+      };
+    }
 
     // ── Inject measured visuals — overrides Claude's guessed accentColor ──────
     // accentColor/logo are now MEASURED from the live site, not inferred from

--- a/src/server/scrape.js
+++ b/src/server/scrape.js
@@ -69,15 +69,24 @@ async function _tryUnlocker(url, { format, timeout, country, caller, metadata })
     } finally { clearTimeout(tid); }
     const responseBody = await resp.text();
     const latencyMs = Date.now() - startTime;
+    // An HTTP 200 with an empty body is a FAILURE, not a success. Bright Data
+    // occasionally returns 200/0-bytes (seen on oooagency.com 2026-07-06);
+    // logging it as success:true both lied in scrape_log and — worse —
+    // prevented forgeScrape's auto mode from escalating to the browser tier
+    // (looksLikeSpaShell('') is false), so the whole scrape died silently.
+    const bodyOk = resp.ok && responseBody.trim().length > 0;
+    const failReason = !resp.ok
+      ? `HTTP ${resp.status}: ${responseBody.slice(0, 200)}`
+      : (bodyOk ? null : `HTTP ${resp.status} but empty body`);
     await _logScrape({
       url, source: 'brightdata_unlocker',
       status_code: resp.status, body_size: responseBody.length, latency_ms: latencyMs,
-      success: resp.ok, caller,
-      metadata: { ...(metadata ?? {}), body_sample: resp.ok ? responseBody.slice(0, 15000) : undefined },
-      error: resp.ok ? null : `HTTP ${resp.status}: ${responseBody.slice(0, 200)}`,
+      success: bodyOk, caller,
+      metadata: { ...(metadata ?? {}), body_sample: bodyOk ? responseBody.slice(0, 15000) : undefined },
+      error: failReason,
     });
-    if (!resp.ok) {
-      return { success: false, status: resp.status, html: null, source: 'brightdata_unlocker', latencyMs, error: `HTTP ${resp.status}: ${responseBody.slice(0, 200)}` };
+    if (!bodyOk) {
+      return { success: false, status: resp.status, html: null, source: 'brightdata_unlocker', latencyMs, error: failReason };
     }
     return { success: true, status: resp.status, html: responseBody, source: 'brightdata_unlocker', latencyMs, error: null };
   } catch (e) {
@@ -334,7 +343,13 @@ export async function forgeScrape(url, opts = {}) {
   // skips the shell-detection branch since the body is reformatted text,
   // not HTML.
   if (format !== 'raw') return unlockerResult;
-  const needsBrowser = !unlockerResult.success || looksLikeSpaShell(unlockerResult.html);
+  // Escalate on failure, SPA shell, OR a near-empty body — a "successful"
+  // fetch under 500 chars can't contain a real page and looksLikeSpaShell
+  // returns false for empty html, so it must be checked explicitly.
+  const needsBrowser = !unlockerResult.success
+    || !unlockerResult.html
+    || unlockerResult.html.trim().length < 500
+    || looksLikeSpaShell(unlockerResult.html);
   if (!needsBrowser) return unlockerResult;
 
   console.log(`[forgeScrape] Tier 1 ${unlockerResult.success ? 'returned shell' : 'failed'} for ${url} (caller=${caller}) — escalating to Scraping Browser`);
@@ -370,6 +385,91 @@ function htmlToMarkdown(html, url) {
   } catch {
     return '';
   }
+}
+
+// ── extractEmbeddedStateText — last-chance extraction for JS-state sites ────
+// Cargo Collective, Next/Nuxt exports, and similar builders ship the entire
+// page content inside an embedded JSON blob (window.__PRELOADED_STATE__ =
+// {...} or a <script type="application/json"> tag) with almost no semantic
+// DOM — Readability extracts 0 chars even though the raw HTML holds the full
+// site copy (oooagency.com, 2026-07-06: 81KB of HTML, all of it in
+// __PRELOADED_STATE__). This walks those blobs and harvests human-prose
+// strings so the brand profile is grounded in the brand's actual copy.
+
+// Balanced-brace scan: return the JSON object literal starting at html[start]
+// (which must be '{'), respecting string literals and escapes. Null if
+// unbalanced within the cap.
+function _sliceBalancedJson(html, start, cap = 2_000_000) {
+  let depth = 0, inStr = false, esc = false;
+  const end = Math.min(html.length, start + cap);
+  for (let i = start; i < end; i++) {
+    const c = html[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '{') depth++;
+    else if (c === '}') { depth--; if (depth === 0) return html.slice(start, i + 1); }
+  }
+  return null;
+}
+
+// Recursively collect prose-looking strings from a parsed JSON value.
+// Skips URLs/paths/colors/dates/identifiers; strips tags from HTML fragments
+// (builders store content as HTML strings inside the state).
+function _collectHumanStrings(node, out, seen, budget) {
+  if (budget.nodes-- <= 0 || budget.chars <= 0) return;
+  if (typeof node === 'string') {
+    let s = node.trim();
+    if (s.length < 20) return;
+    if (/^(https?:\/\/|\/\/|data:|#[0-9a-f]{3,8}$|[{[])/i.test(s)) return;
+    if (/^[\w.-]+\.(png|jpe?g|gif|svg|webp|css|js|woff2?)($|\?)/i.test(s)) return;
+    if (/^\d{4}-\d{2}-\d{2}/.test(s)) return;                 // ISO dates
+    if (/[{}]/.test(s) && /[:;]/.test(s)) return;              // inline CSS blobs
+    if (/<[a-z][^>]*>/i.test(s)) s = s.replace(/<[^>]+>/g, ' '); // strip HTML tags
+    s = s.replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/\s+/g, ' ').trim();
+    if (s.length < 20 || !s.includes(' ')) return;              // require multi-word prose
+    if (!/[a-z]{3}/i.test(s)) return;                           // require real words
+    if (seen.has(s)) return;
+    seen.add(s);
+    out.push(s);
+    budget.chars -= s.length;
+    return;
+  }
+  if (Array.isArray(node)) { for (const v of node) _collectHumanStrings(v, out, seen, budget); return; }
+  if (node && typeof node === 'object') { for (const v of Object.values(node)) _collectHumanStrings(v, out, seen, budget); }
+}
+
+export function extractEmbeddedStateText(html) {
+  if (!html || html.length < 500) return '';
+  const out = [];
+  const seen = new Set();
+  const budget = { nodes: 50_000, chars: 30_000 };
+  try {
+    // Pattern 1: window.__PRELOADED_STATE__ = {...} / __NEXT_DATA__ = {...} etc.
+    for (const m of html.matchAll(/(?:window\.)?__[A-Z][A-Z0-9_]+__\s*=\s*/g)) {
+      const at = m.index + m[0].length;
+      if (html[at] !== '{') continue;
+      const blob = _sliceBalancedJson(html, at);
+      if (!blob || blob.length < 1000) continue;
+      try { _collectHumanStrings(JSON.parse(blob), out, seen, budget); } catch { /* not clean JSON */ }
+      if (budget.chars <= 0) break;
+    }
+    // Pattern 2: <script type="application/json"> payloads (__NEXT_DATA__ style)
+    if (budget.chars > 0) {
+      for (const m of html.matchAll(/<script[^>]*type=["']application\/json["'][^>]*>([\s\S]*?)<\/script>/gi)) {
+        const raw = m[1].trim();
+        if (raw.length < 1000 || raw[0] !== '{') continue;
+        try { _collectHumanStrings(JSON.parse(raw), out, seen, budget); } catch { /* skip */ }
+        if (budget.chars <= 0) break;
+      }
+    }
+  } catch { /* extraction is best-effort */ }
+  const text = out.join('\n').trim();
+  return text.length >= 200 ? text : '';
 }
 
 export async function getBrandPageContent(url, { caller = 'context-hub', metadata = {}, jinaTimeout = 15000 } = {}) {
@@ -425,6 +525,13 @@ export async function getBrandPageContent(url, { caller = 'context-hub', metadat
   }
   const markdown = htmlToMarkdown(fetched.html, url);
   if (markdown.length < 200) {
+    // Tier C: embedded-JSON state extraction. Cargo/Next/Nuxt-style sites keep
+    // all page copy inside a preloaded-state blob that Readability can't see.
+    const embedded = extractEmbeddedStateText(fetched.html);
+    if (embedded) {
+      console.log(`[getBrandPageContent] Readability empty for ${url} — recovered ${embedded.length} chars from embedded JSON state`);
+      return { success: true, markdown: embedded, source: `${fetched.source}+embedded_json`, latencyMs: fetched.latencyMs, error: null };
+    }
     return { success: false, markdown: null, source: fetched.source, latencyMs: fetched.latencyMs, error: `Readability extracted ${markdown.length} chars (under threshold)` };
   }
   return { success: true, markdown, source: fetched.source, latencyMs: fetched.latencyMs, error: null };


### PR DESCRIPTION
## Why

`oooagency.com` (profile `72d4e2b7`) got a "Limited website access" banner **and** a fully-written voice profile — pure invention, since zero site copy was ever read. Root cause chain from `scrape_log`:

1. Jina timed out.
2. Bright Data Unlocker returned **HTTP 200 with a 0-byte body** — logged as `success: true`.
3. `looksLikeSpaShell('')` returns `false` for empty HTML, so `forgeScrape` auto mode **never escalated to the browser tier**.
4. Empty scrape → `scraperSuccess = false` → the pipeline still asked Opus for a voice profile "in the brand's own voice" — from nothing.

Bonus finding: the site isn't bot-protected at all. It's a Cargo Collective site — 81 KB of HTML with all content inside `__PRELOADED_STATE__`, which Readability can't see.

## What

**1. Scrape-tier honesty (`src/server/scrape.js`)**
- A 200 with an empty body now logs `success: false` (`HTTP 200 but empty body`) and returns failure → auto mode escalates to the Scraping Browser.
- `forgeScrape` also escalates on any body under 500 chars (empty HTML defeats the SPA-shell regex).

**2. Embedded-JSON extraction tier (`src/server/scrape.js`)**
- New `extractEmbeddedStateText()`: balanced-brace scan of `window.__*__ = {...}` assignments and `application/json` script tags, recursive prose harvest (URLs / CSS blobs / dates / identifiers / non-prose filtered, HTML fragments tag-stripped, node+char budgets).
- `getBrandPageContent` falls back to it when Readability extracts under 200 chars; source tagged `+embedded_json`.
- **Verified against the real captured oooagency.com HTML**: recovers 678 clean chars of their actual copy (LiveNation / Warner Music / Distortion Festival clients, services, founder).

**3. No fabricated voice (`context-hub.js` + `BrandProfile.tsx`)**
- On scrape failure the prompt now explicitly instructs empty voice/messaging fields, and the server **deterministically blanks** `voiceProfile` (summary/tone/style/phrases/visual) and the entire `messaging` block, stamping `insufficientData: true`. Market-level fields (industry, positioning, personas, businessProfile) survive — Sonar's live web research grounds those without site copy.
- Banner copy now says voice/messaging are **withheld**, not just "less accurate". `BuildWithPartnerButton` already gates on `voiceProfile.summary`, so downstream stages disable naturally.

## Test plan

- `node --check` on `server.js`, `scrape.js`, `context-hub.js` + `npx tsc --noEmit` — all clean.
- Extractor exercised against the real oooagency.com HTML (see above).
- On dev: Re-analyze oooagency.com → expect a real scrape this time (browser tier or embedded-JSON), `scraperSuccess: true`, and a voice profile grounded in their actual copy.

## Rollback

Revert the single commit — no schema changes, no env changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_