### PR TITLE
fix(publish): staged shadow rows can no longer hide a live post's URL

### DIFF
--- a/src/server/routes/publishing-publish.js
+++ b/src/server/routes/publishing-publish.js
@@ -1201,6 +1201,13 @@ ${canonicalNote}`,
     const persistResults = Object.fromEntries(
       Object.entries(results)
         .filter(([_ch, r]) => !r.skipped)
+        // A non-published result must never clobber an existing url-bearing
+        // entry. A concurrent duplicate publish can race past the
+        // alreadyPublished check, fail (Zernio duplicate rejection → legacy
+        // 'staged' path), and its staged/error shape would otherwise merge
+        // over the good result — wiping the View-post URL for a post that IS
+        // live (the 2026-07-09 LinkedIn shadow-row bug).
+        .filter(([ch, r]) => r.status === 'published' || !(item.publish_results?.[ch]?.url))
         .map(([ch, r]) => [
           ch,
           r.status === 'published'

--- a/src/server/routes/publishing-queue.js
+++ b/src/server/routes/publishing-queue.js
@@ -19,19 +19,30 @@ const router = express.Router();
 router.get('/sync/:queueItemId', requireAuth, async (req, res) => {
   const { queueItemId } = req.params;
   try {
-    // Only process the most recent log entry per channel — older entries are historical
+    // Only process the most representative log entry per channel. A real
+    // 'published' row always outranks a later staged/error attempt — a stray
+    // duplicate publish that lands on the "not yet authorized" path must not
+    // shadow the successful row (the shadow row is what made a live LinkedIn
+    // post lose its View-post link, 2026-07-09).
     const logRes = await pool.query(
       `SELECT DISTINCT ON (pl.channel) pl.*, pc.credentials
        FROM publish_log pl
        LEFT JOIN publishing_channels pc ON pc.brand_profile_id = pl.brand_profile_id AND pc.channel = pl.channel
        WHERE pl.queue_item_id = $1
-       ORDER BY pl.channel, pl.attempted_at DESC`,
+       ORDER BY pl.channel, (pl.status = 'published') DESC, pl.attempted_at DESC`,
       [queueItemId]
     );
     if (!logRes.rows.length) return res.json({ success: true, results: {} });
 
     const results = {};
     for (const row of logRes.rows) {
+      // A staged/error attempt never went live — there is nothing to check,
+      // and the `|| 'published'` default below would brand a non-event as
+      // Live. Report its stored state as-is and move on.
+      if (row.status !== 'published') {
+        results[row.channel] = { channel: row.channel, liveStatus: row.live_status || null };
+        continue;
+      }
       let liveStatus = row.live_status || 'published';
       const creds = row.credentials || {};
 
@@ -240,9 +251,11 @@ router.post('/republish', requireAuth, async (req, res) => {
 router.get('/log/:queueItemId', requireAuth, async (req, res) => {
   try {
     const logRes = await pool.query(
+      // Published rows outrank later staged/error attempts — same shadow-row
+      // guard as the sync endpoint (see comment there).
       `SELECT DISTINCT ON (channel) id, channel, status, live_status, published_url, error_message, attempted_at, last_synced_at
        FROM publish_log WHERE queue_item_id = $1
-       ORDER BY channel, attempted_at DESC`,
+       ORDER BY channel, (status = 'published') DESC, attempted_at DESC`,
       [req.params.queueItemId]
     );
     res.json({ success: true, log: logRes.rows });


### PR DESCRIPTION
## Why

The SYSOI article *"Duplicate Event Records Break Attribution Before the CRM Ever Sees Them"* showed **✓ Live for LinkedIn with no View-post link** — the post is genuinely live.

From `publish_log`: the real Zernio LinkedIn publish succeeded at 16:30:33 on 7/9 (URL + both IDs persisted). Six seconds later a **duplicate attempt** raced past the `alreadyPublished` check, failed on Zernio, fell through to the legacy path with no direct-API creds → wrote a `staged` shadow row ("LinkedIn not yet authorized"), `published_url: null`.

Three compounding defects turned that into the symptom:

1. **Newest-row-wins selection** — `/sync` and `/log` pick one row per channel by `attempted_at DESC`, so the staged shadow outranked the real published row.
2. **Sync branded it Live** — `row.live_status || 'published'` defaulted the never-published staged row to `published` and persisted it.
3. **persistResults clobbered the JSONB** — the staged (url-less) result merged over the good url-bearing `publish_results.linkedin` entry, killing the frontend's fallback URL too.

## What

- `publishing-queue.js` `/sync` + `/log`: `DISTINCT ON` orderings now rank `status = 'published'` rows above later staged/error attempts.
- `publishing-queue.js` `/sync`: non-published rows are reported as-is and skipped from live checks — no more `'published'` default for rows that never went live.
- `publishing-publish.js` `persistResults`: a non-published result never overwrites an existing url-bearing entry in `publish_results`.

## Data repair (already applied in prod)

- Deleted the junk staged LinkedIn log row (`f8e4efb0`) for queue item `ab47cf9f`.
- Restored `publish_results.linkedin` from the good log row (URL + `postId` + `zernioPostId`). The View-post link is back on the article now, pre-merge.

## Test plan

- `node --check` on both route files + `server.js` — clean.
- On dev after merge: the article's LinkedIn row shows ✓ Live **with** View post; Sync Status no longer flips staged rows to published.

## Rollback

Revert the commit — the data repair stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_