### PR TITLE
feat(strategy): Brand Intelligence UI — 6-tab workspace + public brief (PR 2/2)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -201,6 +201,7 @@ const NAV_ROUTES: Partial<Record<ViewType, string>> = {
   'video-generator':      '/app/video-generator',
   'ads-generator':        '/app/ads-generator',
   'compliance-gate':      '/app/compliance-gate',
+  'strategy-intel':       '/app/strategy-intel',
   'integrations':         '/app/integrations',
   'publishing-queue':     '/app/publishing-queue',
   'performance':          '/app/performance',
@@ -235,6 +236,7 @@ const settingsNavItems = [
 
 const topNavItems: TopNavItem[] = [
   { id: 'geo-strategist',        label: 'GEO Strategist',        icon: 'zap',        href: '/app/geo-strategist' },
+  { id: 'strategy-intel',        label: 'Brand Intelligence',    icon: 'compass',    href: '/app/strategy-intel' },
   { id: 'authenticity-enricher', label: 'Authenticity Enricher', icon: 'shieldCheck',href: '/app/authenticity-enricher' },
   { id: 'content-generator',     label: 'Content Generator',     icon: 'fileText',   href: '/app/content-generator' },
   { id: 'campaign-generator',    label: 'Campaign Generator',    icon: 'layers',     href: '/app/campaign-generator' },

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -49,6 +49,7 @@ const viewTitles: Record<string, string> = {
   'strategy': 'Strategy',
   'brain-history': 'Brain History',
   'geo-strategist': 'GEO Strategist',
+  'strategy-intel': 'Brand Intelligence',
   'authenticity-enricher': 'Authenticity Enricher',
   'content-generator': 'Content Generator',
   'ads-generator': 'Ads Generator',
@@ -56,6 +57,7 @@ const viewTitles: Record<string, string> = {
 
 const pathTitles: Record<string, string> = {
   '/app/geo-strategist':         'GEO Strategist',
+  '/app/strategy-intel':         'Brand Intelligence',
   '/app/authenticity-enricher':  'Authenticity Enricher',
   '/app/content-generator':      'Content Generator',
   '/app/social-generator':       'Social Generator',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,8 @@ import SocialGeneratorPage from './pages/SocialGeneratorPage';
 import VideoGeneratorPage from './pages/VideoGeneratorPage';
 import AdsGeneratorPage from './pages/AdsGeneratorPage';
 import ComplianceGatePage from './pages/ComplianceGatePage';
+import StrategyIntelPage from './pages/StrategyIntelPage';
+import BrandIntelligenceBriefPage from './pages/BrandIntelligenceBriefPage';
 import IntegrationsPage from './pages/IntegrationsPage';
 import PublishingQueuePage from './pages/PublishingQueuePage';
 import CalendarPage from './pages/CalendarPage';
@@ -151,6 +153,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/app/ads-generator" element={<AppProvider><AdsGeneratorPage /></AppProvider>} />
         <Route path="/app/email-campaign" element={<AppProvider><EmailCampaignPage /></AppProvider>} />
         <Route path="/app/compliance-gate" element={<AppProvider><ComplianceGatePage /></AppProvider>} />
+        <Route path="/app/strategy-intel" element={<AppProvider><StrategyIntelPage /></AppProvider>} />
         <Route path="/app/integrations" element={<AppProvider><IntegrationsPage /></AppProvider>} />
         <Route path="/app/publishing-queue" element={<AppProvider><PublishingQueuePage /></AppProvider>} />
         <Route path="/app/calendar" element={<AppProvider><CalendarPage /></AppProvider>} />
@@ -170,6 +173,8 @@ createRoot(document.getElementById('root')!).render(
 
         {/* External review page — no AppProvider, no auth */}
         <Route path="/review/:token" element={<ReviewPage />} />
+        {/* Public token-gated Brand Intelligence brief — no AppProvider, no auth (board share link) */}
+        <Route path="/brand-intelligence/:token" element={<BrandIntelligenceBriefPage />} />
 
         {/* Legacy redirects — keep old paths working during transition */}
         <Route path="/context-hub/*" element={<Navigate to="/app/context-hub" replace />} />

--- a/src/pages/BrandIntelligenceBriefPage.css
+++ b/src/pages/BrandIntelligenceBriefPage.css
@@ -1,0 +1,422 @@
+/* Brand Intelligence Brief — Public Shareable Document */
+
+.bi-brief {
+  min-height: 100vh;
+  background: #0a0c10;
+  color: #e2e8f0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+/* Hero */
+.bi-brief-hero {
+  padding: 80px 24px 60px;
+  background: linear-gradient(180deg, rgba(53, 99, 255, 0.1) 0%, rgba(10, 12, 16, 0) 100%);
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.bi-brief-hero-inner {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.bi-brief-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #3563ff;
+  margin-bottom: 16px;
+}
+.bi-brief-brand {
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #ffffff;
+  margin: 0 0 12px;
+  line-height: 1.15;
+}
+.bi-brief-date {
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+/* Body */
+.bi-brief-body {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 24px 80px;
+}
+
+/* Sections */
+.bi-section {
+  padding: 48px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.bi-section:last-child { border-bottom: none; }
+.bi-section-num {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #3563ff;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+}
+.bi-section-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0 0 6px;
+}
+.bi-section-desc {
+  font-size: 0.88rem;
+  color: #64748b;
+  margin: 0 0 24px;
+}
+
+/* Cards */
+.bi-card {
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 10px;
+  margin-bottom: 14px;
+  overflow: hidden;
+}
+.bi-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 16px 18px;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.bi-card-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  line-height: 1.4;
+}
+.bi-card-body {
+  padding: 16px 18px;
+}
+.bi-card-body p {
+  font-size: 0.85rem;
+  color: #cbd5e1;
+  line-height: 1.6;
+  margin: 0 0 14px;
+}
+.bi-card-body p:last-child { margin-bottom: 0; }
+
+/* Labels */
+.bi-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+  margin-bottom: 4px;
+  margin-top: 14px;
+}
+.bi-label:first-child { margin-top: 0; }
+.bi-label-purple { color: #8b5cf6; }
+
+/* Scores + severity */
+.bi-score {
+  font-size: 0.78rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.bi-severity {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.bi-type {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  text-transform: capitalize;
+}
+.bi-quote {
+  font-size: 0.85rem;
+  color: #f1f5f9;
+  font-style: italic;
+  padding: 10px 14px;
+  background: rgba(255,255,255,0.03);
+  border-left: 2px solid #3563ff;
+  border-radius: 0 6px 6px 0;
+  margin-bottom: 12px;
+}
+.bi-highlight {
+  color: #f1f5f9 !important;
+  font-weight: 500;
+}
+.bi-role {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  font-style: italic;
+  margin-bottom: 10px;
+}
+
+/* Competitor grouping */
+.bi-comp-group {
+  margin-bottom: 24px;
+}
+.bi-comp-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #94a3b8;
+  margin-bottom: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+/* Pivot */
+.bi-pivot-statement {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  line-height: 1.45;
+  padding: 24px;
+  background: linear-gradient(135deg, rgba(53, 99, 255, 0.15), rgba(139, 92, 246, 0.1));
+  border: 1px solid rgba(53, 99, 255, 0.25);
+  border-radius: 12px;
+  margin: 20px 0 24px;
+}
+.bi-pivot-fromto {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.bi-pivot-from, .bi-pivot-to {
+  flex: 1;
+  padding: 16px;
+  border-radius: 10px;
+}
+.bi-pivot-from {
+  background: rgba(239, 68, 68, 0.06);
+  border: 1px solid rgba(239, 68, 68, 0.15);
+}
+.bi-pivot-to {
+  background: rgba(20, 184, 166, 0.06);
+  border: 1px solid rgba(20, 184, 166, 0.15);
+}
+.bi-fromto-label {
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 6px;
+}
+.bi-pivot-from .bi-fromto-label { color: #ef4444; }
+.bi-pivot-to .bi-fromto-label { color: #14b8a6; }
+.bi-fromto-text {
+  font-size: 0.85rem;
+  color: #e2e8f0;
+  line-height: 1.5;
+}
+.bi-pivot-arrow {
+  display: flex;
+  align-items: center;
+  font-size: 1.4rem;
+  color: #475569;
+  flex-shrink: 0;
+}
+.bi-subsection {
+  padding: 16px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.bi-subsection p {
+  font-size: 0.85rem;
+  color: #cbd5e1;
+  line-height: 1.6;
+  margin: 6px 0 0;
+}
+.bi-stop {
+  background: rgba(239, 68, 68, 0.04);
+  border: 1px solid rgba(239, 68, 68, 0.1);
+  border-radius: 10px;
+  padding: 16px;
+  margin: 14px 0;
+}
+.bi-stop .bi-label { color: #ef4444; }
+.bi-board-slide {
+  padding: 24px;
+  background: linear-gradient(135deg, rgba(53, 99, 255, 0.12), rgba(20, 184, 166, 0.08));
+  border: 1px solid rgba(53, 99, 255, 0.2);
+  border-radius: 12px;
+  margin-top: 20px;
+}
+.bi-board-slide .bi-label { color: #3563ff; }
+.bi-board-slide p {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #f1f5f9;
+  line-height: 1.7;
+  margin: 8px 0 0;
+}
+
+/* Moves */
+.bi-move {
+  display: flex;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+.bi-move:last-child { border-bottom: none; }
+.bi-move-num {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(53, 99, 255, 0.12);
+  color: #3563ff;
+  font-weight: 700;
+  font-size: 0.78rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+.bi-move-body { flex: 1; }
+.bi-move-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  margin-bottom: 3px;
+}
+.bi-move-rationale {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  line-height: 1.45;
+  margin-bottom: 3px;
+}
+.bi-move-outcome {
+  font-size: 0.8rem;
+  color: #14b8a6;
+  line-height: 1.45;
+}
+
+/* Whitespace bars */
+.bi-ws-meta {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  margin-bottom: 14px;
+}
+.bi-ws-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+.bi-ws-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.bi-ws-bar-label {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  width: 80px;
+  flex-shrink: 0;
+}
+.bi-ws-bar {
+  flex: 1;
+  height: 5px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.bi-ws-bar-fill {
+  height: 100%;
+  background: #3563ff;
+  border-radius: 3px;
+}
+.bi-ws-bar-val {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #e2e8f0;
+  width: 22px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Footer */
+.bi-brief-footer {
+  padding: 40px 24px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  text-align: center;
+}
+.bi-brief-footer-inner {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.bi-brief-footer-mark {
+  font-size: 0.82rem;
+  color: #64748b;
+}
+.bi-brief-footer-mark a {
+  color: #3563ff;
+  text-decoration: none;
+  font-weight: 600;
+}
+.bi-brief-footer-mark a:hover { text-decoration: underline; }
+.bi-brief-footer-sub {
+  font-size: 0.72rem;
+  color: #475569;
+  margin-top: 4px;
+}
+
+/* Loading + error states */
+.bi-brief-loading, .bi-brief-error {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #0a0c10;
+  color: #e2e8f0;
+  font-family: 'Inter', system-ui, sans-serif;
+  text-align: center;
+  padding: 2rem;
+}
+.bi-brief-loading-text {
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+.bi-brief-error-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.bi-brief-error-text {
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .bi-brief-brand { font-size: 1.6rem; }
+  .bi-pivot-fromto { flex-direction: column; }
+  .bi-pivot-arrow { transform: rotate(90deg); justify-content: center; }
+}
+
+/* Confidential banner */
+.bi-brief-confidential {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  text-align: center;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.06);
+  border-bottom: 1px solid rgba(239, 68, 68, 0.12);
+  padding: 10px 24px;
+}
+
+/* Copyright */
+.bi-brief-copyright {
+  font-size: 0.65rem;
+  color: #475569;
+  margin-top: 16px;
+  line-height: 1.6;
+  max-width: 560px;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/pages/BrandIntelligenceBriefPage.tsx
+++ b/src/pages/BrandIntelligenceBriefPage.tsx
@@ -1,0 +1,278 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import './BrandIntelligenceBriefPage.css';
+
+export default function BrandIntelligenceBriefPage() {
+  const { token } = useParams<{ token: string }>();
+  const [brief, setBrief] = useState<any>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`/api/strategy/brief/${token}`)
+      .then(r => r.json())
+      .then(d => {
+        if (d.success) setBrief(d);
+        else setError(d.error || 'Brief not found');
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  if (loading) return (
+    <div className="bi-brief-loading">
+      <div className="bi-brief-loading-text">Loading intelligence brief...</div>
+    </div>
+  );
+
+  if (error) return (
+    <div className="bi-brief-error">
+      <div className="bi-brief-error-title">{error === 'This brief link has been revoked' ? 'Brief Revoked' : 'Brief Not Found'}</div>
+      <div className="bi-brief-error-text">{error}</div>
+    </div>
+  );
+
+  if (!brief) return null;
+
+  const pivot = brief.pivot;
+  const gaps = brief.gapMap || [];
+  const competitors = brief.competitors || [];
+  const blindSpots = brief.blindSpots || [];
+  const whitespace = brief.whitespace || [];
+  const updatedDate = new Date(brief.updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  const severityColor = (s: string) => s === 'high' ? '#ef4444' : s === 'medium' ? '#f5b942' : '#94a3b8';
+  const scoreColor = (s: number) => s >= 75 ? '#14b8a6' : s >= 50 ? '#f5b942' : '#ef4444';
+
+  return (
+    <div className="bi-brief">
+      {/* Confidential banner */}
+      <div className="bi-brief-confidential">CONFIDENTIAL — Prepared exclusively for {brief.brandName}. Do not distribute without authorization.</div>
+
+      {/* Hero */}
+      <header className="bi-brief-hero">
+        <div className="bi-brief-hero-inner">
+          <div className="bi-brief-eyebrow">Brand Intelligence Brief</div>
+          <h1 className="bi-brief-brand">{brief.brandName}</h1>
+          <div className="bi-brief-date">Updated {updatedDate}</div>
+        </div>
+      </header>
+
+      <div className="bi-brief-body">
+
+        {/* ═══ POSITIONING PIVOT ═══ */}
+        {pivot && (
+          <section className="bi-section">
+            <div className="bi-section-num">01</div>
+            <h2 className="bi-section-title">Recommended Positioning Pivot</h2>
+
+            <div className="bi-pivot-statement">{pivot.pivotStatement}</div>
+
+            <div className="bi-pivot-fromto">
+              <div className="bi-pivot-from">
+                <div className="bi-fromto-label">FROM</div>
+                <div className="bi-fromto-text">{pivot.fromTo?.from}</div>
+              </div>
+              <div className="bi-pivot-arrow">→</div>
+              <div className="bi-pivot-to">
+                <div className="bi-fromto-label">TO</div>
+                <div className="bi-fromto-text">{pivot.fromTo?.to}</div>
+              </div>
+            </div>
+
+            <div className="bi-subsection">
+              <div className="bi-label">Why Now</div>
+              <p>{pivot.whyNow}</p>
+            </div>
+
+            {pivot.threeMovesIn90Days && (
+              <div className="bi-subsection">
+                <div className="bi-label">Three Moves in 90 Days</div>
+                {pivot.threeMovesIn90Days.map((m: any, i: number) => (
+                  <div key={i} className="bi-move">
+                    <div className="bi-move-num">{i + 1}</div>
+                    <div className="bi-move-body">
+                      <div className="bi-move-title">{m.move}</div>
+                      <div className="bi-move-rationale">{m.rationale}</div>
+                      <div className="bi-move-outcome">{m.outcome}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {pivot.whatToStopDoing && (
+              <div className="bi-subsection bi-stop">
+                <div className="bi-label">Stop Doing</div>
+                <p>{pivot.whatToStopDoing}</p>
+              </div>
+            )}
+
+            <div className="bi-board-slide">
+              <div className="bi-label">The Board Slide</div>
+              <p>{pivot.boardSlide}</p>
+            </div>
+          </section>
+        )}
+
+        {/* ═══ GAP MAP ═══ */}
+        {gaps.length > 0 && (
+          <section className="bi-section">
+            <div className="bi-section-num">02</div>
+            <h2 className="bi-section-title">Competitive Gap Map</h2>
+            <p className="bi-section-desc">Undefended market positions ranked by opportunity.</p>
+            {gaps.map((g: any, i: number) => (
+              <div key={i} className="bi-card">
+                <div className="bi-card-header">
+                  <div className="bi-card-title">{g.position}</div>
+                  <span className="bi-score" style={{ color: scoreColor(g.opportunityScore) }}>{g.opportunityScore}/100</span>
+                </div>
+                <div className="bi-card-body">
+                  <p>{g.currentState}</p>
+                  <div className="bi-label">Board Implication</div>
+                  <p className="bi-highlight">{g.boardImplication}</p>
+                  <div className="bi-label">Attack Vector</div>
+                  <p>{g.attackVector}</p>
+                </div>
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ═══ VULNERABILITIES ═══ */}
+        {competitors.length > 0 && competitors.some((c: any) => c.pva?.length > 0) && (
+          <section className="bi-section">
+            <div className="bi-section-num">03</div>
+            <h2 className="bi-section-title">Positioning Vulnerabilities</h2>
+            <p className="bi-section-desc">Competitor claims that are overexposed or unsubstantiated.</p>
+            {competitors.filter((c: any) => c.pva?.length > 0).map((comp: any, ci: number) => (
+              <div key={ci} className="bi-comp-group">
+                <div className="bi-comp-name">{comp.name}</div>
+                {comp.pva.map((v: any, vi: number) => (
+                  <div key={vi} className="bi-card">
+                    <div className="bi-card-header">
+                      <span className="bi-severity" style={{ color: severityColor(v.severity) }}>{v.severity?.toUpperCase()}</span>
+                      <span className="bi-type">{v.type?.replace(/_/g, ' ')}</span>
+                    </div>
+                    <div className="bi-card-body">
+                      <div className="bi-quote">"{v.claim}"</div>
+                      <p>{v.evidence}</p>
+                      <div className="bi-label">Strategic Opening</div>
+                      <p>{v.vulnerability}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ═══ FAULT LINES ═══ */}
+        {competitors.length > 0 && competitors.some((c: any) => c.faultLines?.length > 0) && (
+          <section className="bi-section">
+            <div className="bi-section-num">04</div>
+            <h2 className="bi-section-title">Messaging Fault Lines</h2>
+            <p className="bi-section-desc">Exact competitor language and differentiation angles.</p>
+            {competitors.filter((c: any) => c.faultLines?.length > 0).map((comp: any, ci: number) => (
+              <div key={ci} className="bi-comp-group">
+                <div className="bi-comp-name">{comp.name}</div>
+                {comp.faultLines.map((fl: any, fi: number) => (
+                  <div key={fi} className="bi-card">
+                    <div className="bi-card-header">
+                      <span className="bi-severity" style={{ color: fl.priority === 'high' ? '#3563ff' : fl.priority === 'medium' ? '#8b5cf6' : '#94a3b8' }}>{fl.priority?.toUpperCase()}</span>
+                    </div>
+                    <div className="bi-card-body">
+                      <div className="bi-quote">"{fl.theirLanguage}"</div>
+                      <p>{fl.frequency}</p>
+                      <div className="bi-label">Differentiation Angle</div>
+                      <p>{fl.differentiationAngle}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ═══ BLIND SPOTS ═══ */}
+        {blindSpots.length > 0 && (
+          <section className="bi-section">
+            <div className="bi-section-num">05</div>
+            <h2 className="bi-section-title">Audience Blind Spots</h2>
+            <p className="bi-section-desc">Buyer personas the market is ignoring.</p>
+            {blindSpots.map((s: any, i: number) => (
+              <div key={i} className="bi-card">
+                <div className="bi-card-header">
+                  <div className="bi-card-title">{s.persona}</div>
+                  <span className="bi-score" style={{ color: s.opportunitySize === 'large' ? '#14b8a6' : s.opportunitySize === 'medium' ? '#f5b942' : '#94a3b8' }}>{s.opportunitySize?.toUpperCase()}</span>
+                </div>
+                <div className="bi-card-body">
+                  <div className="bi-role">{s.role}</div>
+                  <p>{s.whyBlind}</p>
+                  <div className="bi-label">Board Implication</div>
+                  <p className="bi-highlight">{s.boardImplication}</p>
+                  <div className="bi-label">Activation Play</div>
+                  <p>{s.activationPlay}</p>
+                  {s.experientialPlay && (
+                    <>
+                      <div className="bi-label bi-label-purple">Experiential Play</div>
+                      <p>{s.experientialPlay}</p>
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ═══ WHITESPACE ═══ */}
+        {whitespace.length > 0 && (
+          <section className="bi-section">
+            <div className="bi-section-num">06</div>
+            <h2 className="bi-section-title">Topical Authority Whitespace</h2>
+            <p className="bi-section-desc">Conversations this brand is invisible in.</p>
+            {whitespace.map((t: any, i: number) => {
+              const pb = t.platformBreakdown || {};
+              return (
+                <div key={i} className="bi-card">
+                  <div className="bi-card-header">
+                    <div className="bi-card-title">{t.narrative}</div>
+                    <span className="bi-score" style={{ color: t.brandVisibility <= 30 ? '#ef4444' : t.brandVisibility <= 55 ? '#f5b942' : '#94a3b8' }}>Visibility: {t.brandVisibility}/100</span>
+                  </div>
+                  <div className="bi-card-body">
+                    <div className="bi-ws-meta">Controlled by {t.controlledBy} · Reclaim: {t.reclaimDifficulty}{t.quickWin ? ' · ⚡ Quick Win' : ''}</div>
+                    <div className="bi-ws-bars">
+                      {['chatgpt', 'perplexity', 'gemini', 'aiOverviews'].map(p => (
+                        <div key={p} className="bi-ws-bar-row">
+                          <span className="bi-ws-bar-label">{p === 'aiOverviews' ? 'AI Overviews' : p.charAt(0).toUpperCase() + p.slice(1)}</span>
+                          <div className="bi-ws-bar"><div className="bi-ws-bar-fill" style={{ width: `${pb[p] || 0}%` }} /></div>
+                          <span className="bi-ws-bar-val">{pb[p] || 0}</span>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="bi-label">Cost of Invisibility</div>
+                    <p>{t.invisibilityCost}</p>
+                    <div className="bi-label">Board Implication</div>
+                    <p className="bi-highlight">{t.boardImplication}</p>
+                    <div className="bi-label">90-Day Play</div>
+                    <p>{t.ninetyDayPlay}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+        )}
+      </div>
+
+      {/* Forge footer */}
+      <footer className="bi-brief-footer">
+        <div className="bi-brief-footer-inner">
+          <div className="bi-brief-footer-mark">Intelligence compiled by <a href="https://forgeintelligence.ai" target="_blank" rel="noopener">Forge Intelligence</a></div>
+          <div className="bi-brief-footer-sub">Context-based brand intelligence that compounds.</div>
+          <div className="bi-brief-copyright">&copy; {new Date().getFullYear()} Sandbox Group LLC. All rights reserved. This document contains proprietary competitive intelligence and is intended solely for the authorized recipient. Unauthorized reproduction or distribution is prohibited.</div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/StrategyIntelPage.css
+++ b/src/pages/StrategyIntelPage.css
@@ -6,29 +6,29 @@
 
 .si-btn-primary, .si-btn-secondary {
   display: inline-flex; align-items: center; gap: 6px; height: 36px; padding: 0 20px;
-  font-size: 0.8rem; font-weight: 600; border-radius: var(--radius-sm); cursor: pointer; border: none; white-space: nowrap;
+  font-size: 0.8rem; font-weight: 600; border-radius: 8px; cursor: pointer; border: none; white-space: nowrap;
 }
 .si-btn-primary { background: var(--color-accent); color: #fff; }
 .si-btn-primary:hover { opacity: 0.9; }
 .si-btn-secondary { background: transparent; color: var(--color-text-muted); border: 1px solid var(--color-border); }
 .si-btn-secondary:hover { color: var(--color-text-primary); border-color: var(--color-border); }
 
-.si-progress { background: var(--color-accent-muted); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm); padding: 16px 20px; margin-bottom: 20px; }
+.si-progress { background: var(--color-accent-muted); border: 1px solid var(--color-border-subtle); border-radius: 10px; padding: 16px 20px; margin-bottom: 20px; }
 .si-progress-title { font-size: 0.85rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; }
 .si-progress-line { font-size: 0.75rem; color: var(--color-text-muted); padding: 2px 0; }
 .si-progress-spinner { width: 16px; height: 16px; border: 2px solid var(--color-accent-muted); border-top-color: var(--color-accent); border-radius: 50%; animation: si-spin 0.8s linear infinite; margin-top: 8px; }
 @keyframes si-spin { to { transform: rotate(360deg); } }
 
-.si-error { background: var(--color-error-muted); border: 1px solid rgba(220,38,38,0.2); border-radius: var(--radius-sm); padding: 12px 16px; color: var(--color-error); font-size: 0.8rem; margin-bottom: 16px; }
+.si-error { background: var(--color-error-muted); border: 1px solid rgba(220,38,38,0.2); border-radius: 8px; padding: 12px 16px; color: var(--color-error); font-size: 0.8rem; margin-bottom: 16px; }
 
-.si-tabs { display: flex; gap: 4px; margin-bottom: 20px; background: var(--color-bg-elevated); border-radius: var(--radius-sm); padding: 4px; }
-.si-tab { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px; height: 36px; font-size: 0.8rem; font-weight: 500; color: var(--color-text-muted); background: transparent; border: none; border-radius: var(--radius-sm); cursor: pointer; }
+.si-tabs { display: flex; gap: 4px; margin-bottom: 20px; background: var(--color-bg-elevated); border-radius: 10px; padding: 4px; }
+.si-tab { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px; height: 36px; font-size: 0.8rem; font-weight: 500; color: var(--color-text-muted); background: transparent; border: none; border-radius: 8px; cursor: pointer; }
 .si-tab.active { background: var(--color-bg-card); color: var(--color-text-primary); font-weight: 600; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
 .si-tab-count { font-size: 0.7rem; background: var(--color-bg-hover); padding: 1px 7px; border-radius: 99px; }
 .si-tab.active .si-tab-count { background: var(--color-accent-muted); color: var(--color-accent); }
 
 .si-competitors { display: flex; flex-direction: column; gap: 12px; }
-.si-comp-card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-sm); overflow: hidden; }
+.si-comp-card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 10px; overflow: hidden; }
 .si-comp-header { display: flex; justify-content: space-between; align-items: center; width: 100%; padding: 14px 18px; background: transparent; border: none; color: var(--color-text-primary); cursor: pointer; text-align: left; }
 .si-comp-header:hover { background: var(--color-bg-hover); }
 .si-comp-name { font-size: 0.95rem; font-weight: 600; }
@@ -37,7 +37,7 @@
 .si-comp-count { font-size: 0.7rem; color: var(--color-accent); font-weight: 500; }
 
 .si-items { padding: 0 18px 16px; display: flex; flex-direction: column; gap: 12px; }
-.si-item { background: var(--color-bg-elevated); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm); padding: 14px 16px; }
+.si-item { background: var(--color-bg-elevated); border: 1px solid var(--color-border-subtle); border-radius: 8px; padding: 14px 16px; }
 .si-item-header { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
 .si-severity { font-size: 0.65rem; font-weight: 700; letter-spacing: 0.05em; }
 .si-type { font-size: 0.65rem; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
@@ -54,37 +54,485 @@
 .si-empty-title { font-size: 1.1rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; }
 .si-empty-body { font-size: 0.85rem; color: var(--color-text-muted); max-width: 480px; margin: 0 auto 20px; line-height: 1.5; }
 
-/* ── Mobile (<=768px) ──────────────────────────────────────────────────────
-   Strategy Intel mobile rules. Page had ZERO breakpoints. */
-@media (max-width: 768px) {
-  /* Header (title left, actions right) → stack column */
-  .si-header {
-    flex-direction: column;
-    gap: 12px;
-    margin-bottom: 20px;
-  }
+/* Gap Map */
+.si-gap-position {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #e2e8f0);
+  line-height: 1.4;
+}
+.si-gap-score {
+  font-size: 0.8rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.si-gap-section {
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.si-gap-section:last-child { border-bottom: none; }
+.si-gap-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #94a3b8);
+  margin-bottom: 4px;
+}
+.si-gap-text {
+  font-size: 0.85rem;
+  color: var(--color-text-primary, #e2e8f0);
+  line-height: 1.55;
+}
+.si-gap-board {
+  background: rgba(53, 99, 255, 0.06);
+  border: 1px solid rgba(53, 99, 255, 0.12);
+  border-radius: 8px;
+  padding: 12px;
+  margin: 8px 0;
+}
+.si-gap-board .si-gap-label {
+  color: #3563ff;
+}
 
-  /* Header actions row → full-width column buttons */
-  .si-header-actions {
-    flex-direction: column;
-    width: 100%;
-    gap: 8px;
-  }
-  .si-header-actions > * {
-    width: 100%;
-  }
+/* Tab disabled + soon badge */
+.si-tab-disabled {
+  opacity: 0.45;
+  cursor: default !important;
+}
+.si-tab-soon {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-left: 4px;
+}
 
-  /* Competitor header (logo + name + signals) wraps */
-  .si-comp-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 12px 14px;
-  }
+/* Tab icon alignment */
+.si-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
 
-  /* Item header (signal + date + source) wraps */
-  .si-item-header {
-    flex-wrap: wrap;
-    gap: 6px;
-  }
+/* Blind Spots */
+.si-blind-role {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #94a3b8);
+  font-style: italic;
+}
+
+/* Whitespace */
+.si-ws-controller {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #94a3b8);
+}
+.si-ws-platforms {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.si-ws-platform {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.si-ws-plat-name {
+  font-size: 0.72rem;
+  color: var(--color-text-muted, #94a3b8);
+  width: 80px;
+  flex-shrink: 0;
+}
+.si-ws-bar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.si-ws-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+.si-ws-plat-score {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #e2e8f0);
+  width: 24px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.si-ws-qw {
+  font-size: 0.75rem;
+  margin-left: 8px;
+}
+
+.si-gap-experiential {
+  background: rgba(139, 92, 246, 0.06);
+  border: 1px solid rgba(139, 92, 246, 0.12);
+  border-radius: 8px;
+  padding: 12px;
+  margin: 8px 0;
+}
+.si-gap-experiential .si-gap-label {
+  color: #8b5cf6;
+}
+
+/* Positioning Pivot */
+.si-pivot {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.si-pivot-statement {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #1e293b;
+  line-height: 1.4;
+  padding: 24px;
+  background: linear-gradient(135deg, #c7d7ff, #ddd6fe);
+  border: 1px solid rgba(53, 99, 255, 0.3);
+  border-radius: 12px;
+}
+.si-pivot-fromto {
+  display: flex;
+  align-items: stretch;
+  gap: 16px;
+}
+.si-pivot-from, .si-pivot-to {
+  flex: 1;
+  padding: 16px;
+  border-radius: 10px;
+}
+.si-pivot-from {
+  background: rgba(239, 68, 68, 0.06);
+  border: 1px solid rgba(239, 68, 68, 0.15);
+}
+.si-pivot-to {
+  background: rgba(20, 184, 166, 0.06);
+  border: 1px solid rgba(20, 184, 166, 0.15);
+}
+.si-pivot-fromto-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 6px;
+}
+.si-pivot-from .si-pivot-fromto-label { color: #ef4444; }
+.si-pivot-to .si-pivot-fromto-label { color: #14b8a6; }
+.si-pivot-fromto-text {
+  font-size: 0.88rem;
+  color: var(--color-text-primary, #e2e8f0);
+  line-height: 1.5;
+}
+.si-pivot-arrow {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  color: var(--color-text-muted, #94a3b8);
+  flex-shrink: 0;
+}
+.si-pivot-section {
+  padding: 16px;
+  background: var(--color-bg-card, #12141a);
+  border: 1px solid var(--color-border, rgba(255,255,255,0.06));
+  border-radius: 10px;
+}
+.si-pivot-evidence {
+  padding: 16px;
+  background: var(--color-bg-card, #12141a);
+  border: 1px solid var(--color-border, rgba(255,255,255,0.06));
+  border-radius: 10px;
+}
+.si-pivot-evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 10px;
+}
+.si-pivot-ev-card {
+  padding: 12px;
+  background: rgba(255,255,255,0.02);
+  border: 1px solid rgba(255,255,255,0.05);
+  border-radius: 8px;
+}
+.si-pivot-ev-dim {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #3563ff;
+  margin-bottom: 6px;
+}
+.si-pivot-ev-text {
+  font-size: 0.8rem;
+  color: var(--color-text-primary, #e2e8f0);
+  line-height: 1.5;
+}
+.si-pivot-moves {
+  padding: 16px;
+  background: var(--color-bg-card, #12141a);
+  border: 1px solid var(--color-border, rgba(255,255,255,0.06));
+  border-radius: 10px;
+}
+.si-pivot-move {
+  display: flex;
+  gap: 14px;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.si-pivot-move:last-child { border-bottom: none; }
+.si-pivot-move-num {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(53, 99, 255, 0.12);
+  color: #3563ff;
+  font-weight: 700;
+  font-size: 0.8rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.si-pivot-move-body {
+  flex: 1;
+  min-width: 0;
+}
+.si-pivot-move-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #e2e8f0);
+  margin-bottom: 4px;
+}
+.si-pivot-move-rationale {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #94a3b8);
+  margin-bottom: 4px;
+  line-height: 1.45;
+}
+.si-pivot-move-outcome {
+  font-size: 0.8rem;
+  color: #14b8a6;
+  line-height: 1.45;
+}
+.si-pivot-stop {
+  padding: 16px;
+  background: rgba(239, 68, 68, 0.04);
+  border: 1px solid rgba(239, 68, 68, 0.12);
+  border-radius: 10px;
+}
+.si-pivot-stop .si-gap-label {
+  color: #ef4444;
+}
+.si-pivot-board {
+  padding: 24px;
+  background: linear-gradient(135deg, #c7d7ff, #ccfbf1);
+  border: 1px solid rgba(53, 99, 255, 0.25);
+  border-radius: 12px;
+}
+.si-pivot-board .si-gap-label {
+  color: #1e40af;
+  font-size: 0.72rem;
+  margin-bottom: 10px;
+}
+.si-pivot-board-text {
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: #1e293b;
+  line-height: 1.7;
+}
+
+/* Share button + banner */
+.si-btn-share {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 14px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: #3563ff;
+  border: 1px solid #3563ff;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.si-btn-share:hover { opacity: 0.85; }
+.si-btn-share:disabled { opacity: 0.5; cursor: default; }
+.si-share-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  background: rgba(20, 184, 166, 0.08);
+  border: 1px solid rgba(20, 184, 166, 0.2);
+  border-radius: 8px;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-bottom: 8px;
+}
+.si-share-banner a {
+  color: #14b8a6;
+  text-decoration: none;
+  font-weight: 500;
+  word-break: break-all;
+}
+.si-share-banner a:hover { text-decoration: underline; }
+.si-share-dismiss {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: #64748b;
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+/* Compliance gate */
+.si-btn-compliance {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 14px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #f5b942;
+  background: rgba(245, 185, 66, 0.08);
+  border: 1px solid rgba(245, 185, 66, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.si-btn-compliance:hover { background: rgba(245, 185, 66, 0.14); }
+
+.si-btn-compliance-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 14px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid rgba(255,255,255,0.1);
+  color: #e2e8f0;
+  transition: background 0.15s;
+}
+.si-btn-compliance-status:hover { background: rgba(255,255,255,0.04); }
+
+/* Compliance panel */
+.si-compliance-panel {
+  background: var(--color-bg-card, #12141a);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 12px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+.si-compliance-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  flex-wrap: wrap;
+}
+.si-compliance-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #e2e8f0);
+}
+.si-compliance-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+.si-compliance-stat {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+.si-compliance-verified { color: #14b8a6; background: rgba(20, 184, 166, 0.1); }
+.si-compliance-inferred { color: #f5b942; background: rgba(245, 185, 66, 0.1); }
+.si-compliance-unverified { color: #ef4444; background: rgba(239, 68, 68, 0.1); }
+.si-compliance-pass {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted, #94a3b8);
+  margin-left: auto;
+}
+.si-compliance-close {
+  background: none;
+  border: none;
+  color: #64748b;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+/* Findings */
+.si-compliance-findings {
+  max-height: 480px;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+.si-compliance-finding {
+  padding: 12px 18px;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+.si-compliance-finding:last-child { border-bottom: none; }
+.si-compliance-finding-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.si-compliance-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 4px;
+}
+.si-badge-verified { color: #14b8a6; background: rgba(20, 184, 166, 0.1); }
+.si-badge-inferred { color: #f5b942; background: rgba(245, 185, 66, 0.1); }
+.si-badge-unverified { color: #ef4444; background: rgba(239, 68, 68, 0.1); }
+.si-compliance-deliverable {
+  font-size: 0.7rem;
+  color: #64748b;
+  text-transform: capitalize;
+}
+.si-compliance-claim {
+  font-size: 0.82rem;
+  color: var(--color-text-primary, #e2e8f0);
+  line-height: 1.5;
+  margin-bottom: 6px;
+  font-style: italic;
+}
+.si-compliance-source {
+  font-size: 0.75rem;
+  color: #14b8a6;
+  margin-bottom: 3px;
+}
+.si-compliance-issue {
+  font-size: 0.75rem;
+  color: #ef4444;
+  margin-bottom: 3px;
+}
+.si-compliance-rec {
+  font-size: 0.75rem;
+  color: #f5b942;
 }

--- a/src/pages/StrategyIntelPage.tsx
+++ b/src/pages/StrategyIntelPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { AppShell } from '../layouts/AppShell';
 import { useApp } from '../context/AppContext';
+import { Target, Map, Eye, MessageSquare, Compass, ArrowRight, Share2 } from 'lucide-react';
 import './StrategyIntelPage.css';
 
 interface Vulnerability {
@@ -28,20 +29,112 @@ interface CompetitorIntel {
   createdAt?: string;
 }
 
+interface GapItem {
+  position: string;
+  opportunityScore: number;
+  currentState: string;
+  evidence: { geo: string | null; pva: string | null; faultLines: string | null };
+  rightToWin: string;
+  boardImplication: string;
+  attackVector: string;
+}
+
+interface BlindSpot {
+  persona: string;
+  role: string;
+  whyBlind: string;
+  evidence: { competitorGap: string | null; topicalSignal: string | null; marketTrend: string | null };
+  opportunitySize: string;
+  rightToServe: string;
+  activationPlay: string;
+  experientialPlay?: string;
+  boardImplication: string;
+}
+
+interface Territory {
+  narrative: string;
+  controlledBy: string;
+  brandVisibility: number;
+  platformBreakdown: { chatgpt: number; perplexity: number; gemini: number; aiOverviews: number };
+  invisibilityCost: string;
+  narrativeControl: string;
+  reclaimDifficulty: string;
+  quickWin: boolean;
+  ninetyDayPlay: string;
+  boardImplication: string;
+}
+
+interface PivotMove {
+  move: string;
+  rationale: string;
+  outcome: string;
+}
+
+interface Pivot {
+  pivotStatement: string;
+  fromTo: { from: string; to: string };
+  whyNow: string;
+  convergenceEvidence: {
+    gapMap: string;
+    pva: string;
+    faultLines: string;
+    blindSpots: string;
+    whitespace: string;
+  };
+  threeMovesIn90Days: PivotMove[];
+  whatToStopDoing: string;
+  boardSlide: string;
+}
+
+type TabId = 'gap_map' | 'pva' | 'blind_spots' | 'faultlines' | 'whitespace' | 'pivot';
+
+const TABS: { id: TabId; label: string; icon: any; ready: boolean }[] = [
+  { id: 'gap_map', label: 'Gap Map', icon: Map, ready: true },
+  { id: 'pva', label: 'Vulnerabilities', icon: Target, ready: true },
+  { id: 'faultlines', label: 'Fault Lines', icon: MessageSquare, ready: true },
+  { id: 'blind_spots', label: 'Blind Spots', icon: Eye, ready: true },
+  { id: 'whitespace', label: 'Whitespace', icon: Compass, ready: true },
+  { id: 'pivot', label: 'Positioning Pivot', icon: ArrowRight, ready: true },
+];
+
 export default function StrategyIntelPage() {
   const { setCurrentView, activeBrand, authToken } = useApp();
+  const [activeTab, setActiveTab] = useState<TabId>('gap_map');
+
+  // PVA + Fault Lines state
   const [competitors, setCompetitors] = useState<CompetitorIntel[]>([]);
+  const [expandedComp, setExpandedComp] = useState<string | null>(null);
+
+  // Gap Map state
+  const [gaps, setGaps] = useState<GapItem[]>([]);
+  const [expandedGap, setExpandedGap] = useState<number | null>(null);
+
+  // Blind Spots state
+  const [blindSpots, setBlindSpots] = useState<BlindSpot[]>([]);
+  const [expandedSpot, setExpandedSpot] = useState<number | null>(null);
+
+  // Whitespace state
+  const [territories, setTerritories] = useState<Territory[]>([]);
+  const [expandedTerritory, setExpandedTerritory] = useState<number | null>(null);
+
+  // Pivot state
+  const [pivot, setPivot] = useState<Pivot | null>(null);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [sharing, setSharing] = useState(false);
+  const [complianceReport, setComplianceReport] = useState<any>(null);
+  const [complianceRunning, setComplianceRunning] = useState(false);
+  const [complianceExpanded, setComplianceExpanded] = useState(false);
+
+  // Shared
   const [isRunning, setIsRunning] = useState(false);
   const [progress, setProgress] = useState<string[]>([]);
   const [error, setError] = useState('');
-  const [activeTab, setActiveTab] = useState<'pva' | 'faultlines'>('pva');
-  const [expandedComp, setExpandedComp] = useState<string | null>(null);
 
   const brandProfileId = activeBrand?.id || localStorage.getItem('forge_active_brand_id') || '';
 
   useEffect(() => { setCurrentView('strategy-intel'); }, []);
 
-  // Load cached results on mount
+  // Load cached PVA/Fault Lines
   useEffect(() => {
     if (!brandProfileId || !authToken) return;
     fetch(`/api/strategy/competitive-intel/${brandProfileId}`, {
@@ -52,35 +145,74 @@ export default function StrategyIntelPage() {
       .catch(() => {});
   }, [brandProfileId, authToken]);
 
-  const runAnalysis = async (force = false) => {
-    if (!brandProfileId) return;
-    setIsRunning(true);
-    setError('');
-    setProgress([]);
-    setCompetitors([]);
+  // Load cached Gap Map
+  useEffect(() => {
+    if (!brandProfileId || !authToken) return;
+    fetch(`/api/strategy/gap-map/${brandProfileId}`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+      .then(r => r.json())
+      .then(d => { if (d.success && d.gaps?.length) setGaps(d.gaps); })
+      .catch(() => {});
+  }, [brandProfileId, authToken]);
 
+  // Load cached Blind Spots
+  useEffect(() => {
+    if (!brandProfileId || !authToken) return;
+    fetch(`/api/strategy/blind-spots/${brandProfileId}`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+      .then(r => r.json())
+      .then(d => { if (d.success && d.blindSpots?.length) setBlindSpots(d.blindSpots); })
+      .catch(() => {});
+  }, [brandProfileId, authToken]);
+
+  // Load cached Whitespace
+  useEffect(() => {
+    if (!brandProfileId || !authToken) return;
+    fetch(`/api/strategy/whitespace/${brandProfileId}`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+      .then(r => r.json())
+      .then(d => { if (d.success && d.territories?.length) setTerritories(d.territories); })
+      .catch(() => {});
+  }, [brandProfileId, authToken]);
+
+  // Load cached Compliance
+  useEffect(() => {
+    if (!brandProfileId || !authToken) return;
+    fetch(`/api/strategy/compliance/${brandProfileId}`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+      .then(r => r.json())
+      .then(d => { if (d.success && d.report) setComplianceReport(d.report); })
+      .catch(() => {});
+  }, [brandProfileId, authToken]);
+
+  // Load cached Pivot
+  useEffect(() => {
+    if (!brandProfileId || !authToken) return;
+    fetch(`/api/strategy/pivot/${brandProfileId}`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+      .then(r => r.json())
+      .then(d => { if (d.success && d.pivot) setPivot(d.pivot); })
+      .catch(() => {});
+  }, [brandProfileId, authToken]);
+
+  // Run PVA + Fault Lines
+  const runCompetitiveIntel = async (force = false) => {
+    if (!brandProfileId) return;
+    setIsRunning(true); setError(''); setProgress([]); setCompetitors([]);
     try {
       const response = await fetch(`/api/strategy/competitive-intel/${brandProfileId}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(authToken ? { 'Authorization': `Bearer ${authToken}` } : {}),
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ force })
       });
-      // 401 = token expired/missing. Surface clearly instead of silently draining an empty body.
-      if (response.status === 401) {
-        throw new Error('Your session expired. Refresh the page and try again.');
-      }
-      if (!response.ok && response.status !== 200) {
-        const errBody = await response.text().catch(() => '');
-        throw new Error(`Server returned ${response.status}: ${errBody.slice(0, 200) || 'no body'}`);
-      }
-
       const reader = response.body?.getReader();
       const decoder = new TextDecoder();
       let buf = '';
-
       if (reader) {
         while (true) {
           const { done, value } = await reader.read();
@@ -92,55 +224,351 @@ export default function StrategyIntelPage() {
             if (!part.startsWith('data: ')) continue;
             try {
               const evt = JSON.parse(part.slice(6));
-              if (evt.type === 'progress' || evt.type === 'detail') {
-                setProgress(prev => [...prev, evt.detail]);
-              } else if (evt.type === 'result') {
-                setCompetitors(evt.competitors || []);
-              } else if (evt.type === 'error') {
-                throw new Error(evt.error);
-              }
-            } catch (pe: any) {
-              if (pe.message && !pe.message.includes('JSON')) throw pe;
-            }
+              if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
+              else if (evt.type === 'result') setCompetitors(evt.competitors || []);
+              else if (evt.type === 'error') throw new Error(evt.error);
+            } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
           }
         }
       }
-    } catch (e: any) {
-      setError(e.message);
-    } finally {
-      setIsRunning(false);
-    }
+    } catch (e: any) { setError(e.message); }
+    finally { setIsRunning(false); }
+  };
+
+  // Run Gap Map
+  const runGapMap = async (force = false) => {
+    if (!brandProfileId) return;
+    setIsRunning(true); setError(''); setProgress([]); setGaps([]);
+    try {
+      const response = await fetch(`/api/strategy/gap-map/${brandProfileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force })
+      });
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const parts = buf.split('\n');
+          buf = parts.pop() || '';
+          for (const part of parts) {
+            if (!part.startsWith('data: ')) continue;
+            try {
+              const evt = JSON.parse(part.slice(6));
+              if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
+              else if (evt.type === 'result') setGaps(evt.gaps || []);
+              else if (evt.type === 'error') throw new Error(evt.error);
+            } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
+          }
+        }
+      }
+    } catch (e: any) { setError(e.message); }
+    finally { setIsRunning(false); }
+  };
+
+  // Run Blind Spots
+  const runBlindSpots = async (force = false) => {
+    if (!brandProfileId) return;
+    setIsRunning(true); setError(''); setProgress([]); setBlindSpots([]);
+    try {
+      const response = await fetch(`/api/strategy/blind-spots/${brandProfileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force })
+      });
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const parts = buf.split('\n');
+          buf = parts.pop() || '';
+          for (const part of parts) {
+            if (!part.startsWith('data: ')) continue;
+            try {
+              const evt = JSON.parse(part.slice(6));
+              if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
+              else if (evt.type === 'result') setBlindSpots(evt.blindSpots || []);
+              else if (evt.type === 'error') throw new Error(evt.error);
+            } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
+          }
+        }
+      }
+    } catch (e: any) { setError(e.message); }
+    finally { setIsRunning(false); }
+  };
+
+  // Run Whitespace
+  const runWhitespace = async (force = false) => {
+    if (!brandProfileId) return;
+    setIsRunning(true); setError(''); setProgress([]); setTerritories([]);
+    try {
+      const response = await fetch(`/api/strategy/whitespace/${brandProfileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force })
+      });
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const parts = buf.split('\n');
+          buf = parts.pop() || '';
+          for (const part of parts) {
+            if (!part.startsWith('data: ')) continue;
+            try {
+              const evt = JSON.parse(part.slice(6));
+              if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
+              else if (evt.type === 'result') setTerritories(evt.territories || []);
+              else if (evt.type === 'error') throw new Error(evt.error);
+            } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
+          }
+        }
+      }
+    } catch (e: any) { setError(e.message); }
+    finally { setIsRunning(false); }
+  };
+
+  // Run Pivot
+  const runPivot = async (force = false) => {
+    if (!brandProfileId) return;
+    setIsRunning(true); setError(''); setProgress([]); setPivot(null);
+    try {
+      const response = await fetch(`/api/strategy/pivot/${brandProfileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force })
+      });
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const parts = buf.split('\n');
+          buf = parts.pop() || '';
+          for (const part of parts) {
+            if (!part.startsWith('data: ')) continue;
+            try {
+              const evt = JSON.parse(part.slice(6));
+              if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
+              else if (evt.type === 'result') setPivot(evt.pivot || null);
+              else if (evt.type === 'error') throw new Error(evt.error);
+            } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
+          }
+        }
+      }
+    } catch (e: any) { setError(e.message); }
+    finally { setIsRunning(false); }
+  };
+
+  const runCompliance = async () => {
+    if (!brandProfileId || complianceRunning) return;
+    setComplianceRunning(true); setError(''); setProgress([]);
+    try {
+      const response = await fetch(`/api/strategy/compliance/${brandProfileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const parts = buf.split('\n');
+          buf = parts.pop() || '';
+          for (const part of parts) {
+            if (!part.startsWith('data: ')) continue;
+            try {
+              const evt = JSON.parse(part.slice(6));
+              if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
+              else if (evt.type === 'result') { setComplianceReport(evt.report); setComplianceExpanded(true); }
+              else if (evt.type === 'error') throw new Error(evt.error);
+            } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
+          }
+        }
+      }
+    } catch (e: any) { setError(e.message); }
+    finally { setComplianceRunning(false); }
+  };
+
+  const createShareLink = async () => {
+    if (!brandProfileId || sharing) return;
+    setSharing(true);
+    try {
+      const res = await fetch(`/api/strategy/share/${brandProfileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      const d = await res.json();
+      if (d.success && d.url) {
+        setShareUrl(d.url);
+        navigator.clipboard.writeText(d.url).catch(() => {});
+        window.open(d.url, '_blank');
+      } else {
+        setError(d.error || 'Failed to create share link');
+      }
+    } catch (e: any) { setError(e.message || 'Failed to create share link'); }
+    finally { setSharing(false); }
   };
 
   const severityColor = (s: string) => s === 'high' ? '#ef4444' : s === 'medium' ? '#f5b942' : '#94a3b8';
   const priorityColor = (p: string) => p === 'high' ? '#3563ff' : p === 'medium' ? '#8b5cf6' : '#94a3b8';
+  const scoreColor = (s: number) => s >= 75 ? '#14b8a6' : s >= 50 ? '#f5b942' : '#ef4444';
+
+  const runAction = activeTab === 'gap_map' ? runGapMap
+    : activeTab === 'blind_spots' ? runBlindSpots
+    : activeTab === 'whitespace' ? runWhitespace
+    : activeTab === 'pivot' ? runPivot
+    : (activeTab === 'pva' || activeTab === 'faultlines') ? runCompetitiveIntel
+    : null;
+
+  const hasData = activeTab === 'gap_map' ? gaps.length > 0
+    : activeTab === 'blind_spots' ? blindSpots.length > 0
+    : activeTab === 'whitespace' ? territories.length > 0
+    : activeTab === 'pivot' ? !!pivot
+    : (activeTab === 'pva' || activeTab === 'faultlines') ? competitors.length > 0
+    : false;
+
+  const tabMeta = TABS.find(t => t.id === activeTab);
 
   return (
     <AppShell>
       <div className="si-page">
         <div className="si-header">
           <div>
-            <h1 className="si-title">Competitive Intelligence</h1>
-            <p className="si-sub">Positioning Vulnerability Analysis + Messaging Fault Lines</p>
+            <h1 className="si-title">Brand Intelligence</h1>
+            <p className="si-sub">Board-ready competitive intelligence across six dimensions</p>
           </div>
           <div className="si-header-actions">
-            {competitors.length > 0 && !isRunning && (
-              <button className="si-btn-secondary" onClick={() => runAnalysis(true)}>
+            {hasData && !isRunning && runAction && (
+              <button className="si-btn-secondary" onClick={() => runAction(true)}>
                 Re-analyze
               </button>
             )}
-            {competitors.length === 0 && !isRunning && (
-              <button className="si-btn-primary" onClick={() => runAnalysis(false)}>
-                Run Competitive Intelligence
+            {!hasData && !isRunning && runAction && (
+              <button className="si-btn-primary" onClick={() => runAction(false)}>
+                Run {tabMeta?.label || 'Analysis'}
               </button>
             )}
+            {(gaps.length > 0 || competitors.length > 0 || blindSpots.length > 0) && !isRunning && !complianceRunning && (
+              <>
+                {!complianceReport && (
+                  <button className="si-btn-compliance" onClick={runCompliance}>
+                    Run Compliance Check
+                  </button>
+                )}
+                {complianceReport && (
+                  <>
+                    <button className="si-btn-compliance-status" onClick={() => setComplianceExpanded(!complianceExpanded)}>
+                      {complianceReport.summary?.unverified > 0
+                        ? `⚠ ${complianceReport.summary.unverified} Unverified`
+                        : `✓ ${complianceReport.summary?.passRate || 'Passed'}`
+                      }
+                    </button>
+                    <button className="si-btn-compliance" onClick={runCompliance}>
+                      Re-check
+                    </button>
+                  </>
+                )}
+                <button className="si-btn-share" onClick={createShareLink} disabled={sharing || !complianceReport}>
+                  <Share2 size={13} /> {sharing ? 'Creating...' : 'Share Brief'}
+                </button>
+              </>
+            )}
           </div>
+        </div>
+        {shareUrl && (
+          <div className="si-share-banner">
+            <span>Link copied to clipboard:</span>
+            <a href={shareUrl} target="_blank" rel="noopener">{shareUrl}</a>
+            <button className="si-share-dismiss" onClick={() => setShareUrl(null)}>×</button>
+          </div>
+        )}
+
+        {/* Compliance report */}
+        {complianceExpanded && complianceReport && (
+          <div className="si-compliance-panel">
+            <div className="si-compliance-header">
+              <div className="si-compliance-title">Compliance Audit</div>
+              <div className="si-compliance-summary">
+                <span className="si-compliance-stat si-compliance-verified">{complianceReport.summary?.verified || 0} Verified</span>
+                <span className="si-compliance-stat si-compliance-inferred">{complianceReport.summary?.inferred || 0} Inferred</span>
+                <span className="si-compliance-stat si-compliance-unverified">{complianceReport.summary?.unverified || 0} Unverified</span>
+                <span className="si-compliance-pass">Pass rate: {complianceReport.summary?.passRate || '—'}</span>
+              </div>
+              <button className="si-compliance-close" onClick={() => setComplianceExpanded(false)}>×</button>
+            </div>
+            <div className="si-compliance-findings">
+              {(complianceReport.findings || []).map((f: any, i: number) => (
+                <div key={i} className={`si-compliance-finding si-compliance-${f.status}`}>
+                  <div className="si-compliance-finding-header">
+                    <span className={`si-compliance-badge si-badge-${f.status}`}>
+                      {f.status === 'verified' ? '✓' : f.status === 'inferred' ? '~' : '✕'} {f.status}
+                    </span>
+                    <span className="si-compliance-deliverable">{f.deliverable?.replace(/_/g, ' ')}</span>
+                  </div>
+                  <div className="si-compliance-claim">"{f.claim}"</div>
+                  {f.source && <div className="si-compliance-source">Source: {f.source}</div>}
+                  {f.issue && <div className="si-compliance-issue">{f.issue}</div>}
+                  {f.recommendation && <div className="si-compliance-rec">Fix: {f.recommendation}</div>}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Tab bar */}
+        <div className="si-tabs">
+          {TABS.map(tab => (
+            <button
+              key={tab.id}
+              className={`si-tab ${activeTab === tab.id ? 'active' : ''} ${!tab.ready ? 'si-tab-disabled' : ''}`}
+              onClick={() => tab.ready && setActiveTab(tab.id)}
+              title={!tab.ready ? 'Coming soon' : undefined}
+            >
+              <tab.icon size={13} />
+              {tab.label}
+              {!tab.ready && <span className="si-tab-soon">soon</span>}
+              {tab.id === 'gap_map' && gaps.length > 0 && (
+                <span className="si-tab-count">{gaps.length}</span>
+              )}
+              {tab.id === 'blind_spots' && blindSpots.length > 0 && (
+                <span className="si-tab-count">{blindSpots.length}</span>
+              )}
+              {tab.id === 'whitespace' && territories.length > 0 && (
+                <span className="si-tab-count">{territories.length}</span>
+              )}
+              {tab.id === 'pva' && competitors.length > 0 && (
+                <span className="si-tab-count">{competitors.reduce((s, c) => s + (c.pva?.length || 0), 0)}</span>
+              )}
+              {tab.id === 'faultlines' && competitors.length > 0 && (
+                <span className="si-tab-count">{competitors.reduce((s, c) => s + (c.faultLines?.length || 0), 0)}</span>
+              )}
+            </button>
+          ))}
         </div>
 
         {/* Progress feed */}
         {isRunning && (
           <div className="si-progress">
-            <div className="si-progress-title">Analyzing competitors...</div>
+            <div className="si-progress-title">Analyzing...</div>
             {progress.map((msg, i) => (
               <div key={i} className="si-progress-line">{msg}</div>
             ))}
@@ -150,111 +578,386 @@ export default function StrategyIntelPage() {
 
         {error && <div className="si-error">{error}</div>}
 
-        {/* Results */}
-        {competitors.length > 0 && !isRunning && (
-          <>
-            {/* Tab switcher */}
-            <div className="si-tabs">
-              <button
-                className={`si-tab ${activeTab === 'pva' ? 'active' : ''}`}
-                onClick={() => setActiveTab('pva')}
-              >
-                Vulnerabilities
-                <span className="si-tab-count">
-                  {competitors.reduce((sum, c) => sum + (c.pva?.length || 0), 0)}
-                </span>
-              </button>
-              <button
-                className={`si-tab ${activeTab === 'faultlines' ? 'active' : ''}`}
-                onClick={() => setActiveTab('faultlines')}
-              >
-                Fault Lines
-                <span className="si-tab-count">
-                  {competitors.reduce((sum, c) => sum + (c.faultLines?.length || 0), 0)}
-                </span>
-              </button>
-            </div>
-
-            {/* Competitor cards */}
-            <div className="si-competitors">
-              {competitors.map(comp => {
-                const items = activeTab === 'pva' ? comp.pva : comp.faultLines;
-                const isExpanded = expandedComp === comp.url || competitors.length <= 2;
-                return (
-                  <div key={comp.url} className="si-comp-card">
-                    <button
-                      className="si-comp-header"
-                      onClick={() => setExpandedComp(expandedComp === comp.url ? null : comp.url)}
-                    >
-                      <div className="si-comp-name">{comp.name}</div>
-                      <div className="si-comp-meta">
-                        <span className="si-comp-url">{comp.url.replace(/https?:\/\/(www\.)?/, '')}</span>
-                        <span className="si-comp-count">
-                          {items?.length || 0} {activeTab === 'pva' ? 'vulnerabilities' : 'fault lines'}
-                        </span>
-                      </div>
-                    </button>
-
-                    {isExpanded && activeTab === 'pva' && (
-                      <div className="si-items">
-                        {(comp.pva || []).map((v, i) => (
-                          <div key={i} className="si-item">
-                            <div className="si-item-header">
-                              <span className="si-severity" style={{ color: severityColor(v.severity) }}>
-                                {v.severity?.toUpperCase()}
-                              </span>
-                              <span className="si-type">{v.type?.replace(/_/g, ' ')}</span>
-                            </div>
-                            <div className="si-claim">"{v.claim}"</div>
-                            <div className="si-evidence">{v.evidence}</div>
-                            <div className="si-vuln-label">Strategic Opening:</div>
-                            <div className="si-vulnerability">{v.vulnerability}</div>
+        {/* ═══ GAP MAP TAB ═══ */}
+        {activeTab === 'gap_map' && !isRunning && gaps.length > 0 && (
+          <div className="si-competitors">
+            {gaps.map((gap, i) => {
+              const isExpanded = expandedGap === i;
+              return (
+                <div key={i} className="si-comp-card">
+                  <button className="si-comp-header" onClick={() => setExpandedGap(isExpanded ? null : i)}>
+                    <div className="si-gap-position">{gap.position}</div>
+                    <div className="si-comp-meta">
+                      <span className="si-gap-score" style={{ color: scoreColor(gap.opportunityScore) }}>
+                        {gap.opportunityScore}/100
+                      </span>
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="si-items">
+                      <div className="si-item">
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Current State</div>
+                          <div className="si-gap-text">{gap.currentState}</div>
+                        </div>
+                        {gap.evidence.geo && (
+                          <div className="si-gap-section">
+                            <div className="si-gap-label">GEO Signal</div>
+                            <div className="si-gap-text">{gap.evidence.geo}</div>
                           </div>
-                        ))}
-                        {(!comp.pva || comp.pva.length === 0) && (
-                          <div className="si-empty">No vulnerabilities identified for this competitor.</div>
                         )}
-                      </div>
-                    )}
-
-                    {isExpanded && activeTab === 'faultlines' && (
-                      <div className="si-items">
-                        {(comp.faultLines || []).map((fl, i) => (
-                          <div key={i} className="si-item">
-                            <div className="si-item-header">
-                              <span className="si-severity" style={{ color: priorityColor(fl.priority) }}>
-                                {fl.priority?.toUpperCase()}
-                              </span>
-                            </div>
-                            <div className="si-their-lang">"{fl.theirLanguage}"</div>
-                            <div className="si-frequency">{fl.frequency}</div>
-                            {fl.context && <div className="si-context">{fl.context}</div>}
-                            <div className="si-diff-label">Differentiation Angle:</div>
-                            <div className="si-diff-angle">{fl.differentiationAngle}</div>
+                        {gap.evidence.pva && (
+                          <div className="si-gap-section">
+                            <div className="si-gap-label">Vulnerability Signal</div>
+                            <div className="si-gap-text">{gap.evidence.pva}</div>
                           </div>
-                        ))}
-                        {(!comp.faultLines || comp.faultLines.length === 0) && (
-                          <div className="si-empty">No fault lines mapped for this competitor.</div>
                         )}
+                        {gap.evidence.faultLines && (
+                          <div className="si-gap-section">
+                            <div className="si-gap-label">Messaging Signal</div>
+                            <div className="si-gap-text">{gap.evidence.faultLines}</div>
+                          </div>
+                        )}
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Right to Win</div>
+                          <div className="si-gap-text">{gap.rightToWin}</div>
+                        </div>
+                        <div className="si-gap-section si-gap-board">
+                          <div className="si-gap-label">Board Implication</div>
+                          <div className="si-gap-text">{gap.boardImplication}</div>
+                        </div>
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Attack Vector</div>
+                          <div className="si-gap-text">{gap.attackVector}</div>
+                        </div>
                       </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         )}
 
-        {/* Empty state */}
-        {competitors.length === 0 && !isRunning && !error && (
-          <div className="si-empty-state">
-            <div className="si-empty-title">No competitive intelligence yet</div>
-            <div className="si-empty-body">
-              Forge will scrape your competitors' public positioning pages, identify vulnerabilities in their claims,
-              and map the exact language they use so you can differentiate against it.
+        {/* ═══ PVA TAB ═══ */}
+        {activeTab === 'pva' && !isRunning && competitors.length > 0 && (
+          <div className="si-competitors">
+            {competitors.map(comp => {
+              const isExpanded = expandedComp === comp.url || competitors.length <= 2;
+              return (
+                <div key={comp.url} className="si-comp-card">
+                  <button className="si-comp-header" onClick={() => setExpandedComp(expandedComp === comp.url ? null : comp.url)}>
+                    <div className="si-comp-name">{comp.name}</div>
+                    <div className="si-comp-meta">
+                      <span className="si-comp-url">{comp.url.replace(/https?:\/\/(www\.)?/, '')}</span>
+                      <span className="si-comp-count">{comp.pva?.length || 0} vulnerabilities</span>
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="si-items">
+                      {(comp.pva || []).map((v, i) => (
+                        <div key={i} className="si-item">
+                          <div className="si-item-header">
+                            <span className="si-severity" style={{ color: severityColor(v.severity) }}>{v.severity?.toUpperCase()}</span>
+                            <span className="si-type">{v.type?.replace(/_/g, ' ')}</span>
+                          </div>
+                          <div className="si-claim">"{v.claim}"</div>
+                          <div className="si-evidence">{v.evidence}</div>
+                          <div className="si-vuln-label">Strategic Opening:</div>
+                          <div className="si-vulnerability">{v.vulnerability}</div>
+                        </div>
+                      ))}
+                      {(!comp.pva || comp.pva.length === 0) && (
+                        <div className="si-empty">No vulnerabilities identified for this competitor.</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* ═══ FAULT LINES TAB ═══ */}
+        {activeTab === 'faultlines' && !isRunning && competitors.length > 0 && (
+          <div className="si-competitors">
+            {competitors.map(comp => {
+              const isExpanded = expandedComp === comp.url || competitors.length <= 2;
+              return (
+                <div key={comp.url} className="si-comp-card">
+                  <button className="si-comp-header" onClick={() => setExpandedComp(expandedComp === comp.url ? null : comp.url)}>
+                    <div className="si-comp-name">{comp.name}</div>
+                    <div className="si-comp-meta">
+                      <span className="si-comp-url">{comp.url.replace(/https?:\/\/(www\.)?/, '')}</span>
+                      <span className="si-comp-count">{comp.faultLines?.length || 0} fault lines</span>
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="si-items">
+                      {(comp.faultLines || []).map((fl, i) => (
+                        <div key={i} className="si-item">
+                          <div className="si-item-header">
+                            <span className="si-severity" style={{ color: priorityColor(fl.priority) }}>{fl.priority?.toUpperCase()}</span>
+                          </div>
+                          <div className="si-their-lang">"{fl.theirLanguage}"</div>
+                          <div className="si-frequency">{fl.frequency}</div>
+                          {fl.context && <div className="si-context">{fl.context}</div>}
+                          <div className="si-diff-label">Differentiation Angle:</div>
+                          <div className="si-diff-angle">{fl.differentiationAngle}</div>
+                        </div>
+                      ))}
+                      {(!comp.faultLines || comp.faultLines.length === 0) && (
+                        <div className="si-empty">No fault lines mapped for this competitor.</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* ═══ BLIND SPOTS TAB ═══ */}
+        {activeTab === 'blind_spots' && !isRunning && blindSpots.length > 0 && (
+          <div className="si-competitors">
+            {blindSpots.map((spot, i) => {
+              const isExpanded = expandedSpot === i;
+              const sizeColor = spot.opportunitySize === 'large' ? '#14b8a6' : spot.opportunitySize === 'medium' ? '#f5b942' : '#94a3b8';
+              return (
+                <div key={i} className="si-comp-card">
+                  <button className="si-comp-header" onClick={() => setExpandedSpot(isExpanded ? null : i)}>
+                    <div className="si-gap-position">{spot.persona}</div>
+                    <div className="si-comp-meta">
+                      <span className="si-blind-role">{spot.role}</span>
+                      <span className="si-gap-score" style={{ color: sizeColor }}>
+                        {spot.opportunitySize?.toUpperCase()}
+                      </span>
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="si-items">
+                      <div className="si-item">
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Why the Market Is Blind</div>
+                          <div className="si-gap-text">{spot.whyBlind}</div>
+                        </div>
+                        {spot.evidence.competitorGap && (
+                          <div className="si-gap-section">
+                            <div className="si-gap-label">Competitor Gap</div>
+                            <div className="si-gap-text">{spot.evidence.competitorGap}</div>
+                          </div>
+                        )}
+                        {spot.evidence.topicalSignal && (
+                          <div className="si-gap-section">
+                            <div className="si-gap-label">Topical Signal</div>
+                            <div className="si-gap-text">{spot.evidence.topicalSignal}</div>
+                          </div>
+                        )}
+                        {spot.evidence.marketTrend && (
+                          <div className="si-gap-section">
+                            <div className="si-gap-label">Market Trend</div>
+                            <div className="si-gap-text">{spot.evidence.marketTrend}</div>
+                          </div>
+                        )}
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Right to Serve</div>
+                          <div className="si-gap-text">{spot.rightToServe}</div>
+                        </div>
+                        <div className="si-gap-section si-gap-board">
+                          <div className="si-gap-label">Board Implication</div>
+                          <div className="si-gap-text">{spot.boardImplication}</div>
+                        </div>
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Activation Play</div>
+                          <div className="si-gap-text">{spot.activationPlay}</div>
+                        </div>
+                        {spot.experientialPlay && (
+                          <div className="si-gap-section si-gap-experiential">
+                            <div className="si-gap-label">Experiential Play</div>
+                            <div className="si-gap-text">{spot.experientialPlay}</div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* ═══ WHITESPACE TAB ═══ */}
+        {activeTab === 'whitespace' && !isRunning && territories.length > 0 && (
+          <div className="si-competitors">
+            {territories.map((t, i) => {
+              const isExpanded = expandedTerritory === i;
+              const visColor = t.brandVisibility <= 30 ? '#ef4444' : t.brandVisibility <= 55 ? '#f5b942' : '#94a3b8';
+              const diffColor = t.reclaimDifficulty === 'low' ? '#14b8a6' : t.reclaimDifficulty === 'medium' ? '#f5b942' : '#ef4444';
+              return (
+                <div key={i} className="si-comp-card">
+                  <button className="si-comp-header" onClick={() => setExpandedTerritory(isExpanded ? null : i)}>
+                    <div className="si-gap-position">{t.narrative}</div>
+                    <div className="si-comp-meta">
+                      <span className="si-ws-controller">Controlled by: {t.controlledBy}</span>
+                      <span className="si-gap-score" style={{ color: visColor }}>
+                        Visibility: {t.brandVisibility}/100
+                      </span>
+                    </div>
+                  </button>
+                  {isExpanded && (
+                    <div className="si-items">
+                      <div className="si-item">
+                        <div className="si-ws-platforms">
+                          <div className="si-ws-platform">
+                            <span className="si-ws-plat-name">ChatGPT</span>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.chatgpt || 0}%`, background: '#14b8a6' }} /></div>
+                            <span className="si-ws-plat-score">{t.platformBreakdown?.chatgpt || 0}</span>
+                          </div>
+                          <div className="si-ws-platform">
+                            <span className="si-ws-plat-name">Perplexity</span>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.perplexity || 0}%`, background: '#8b5cf6' }} /></div>
+                            <span className="si-ws-plat-score">{t.platformBreakdown?.perplexity || 0}</span>
+                          </div>
+                          <div className="si-ws-platform">
+                            <span className="si-ws-plat-name">Gemini</span>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.gemini || 0}%`, background: '#3563ff' }} /></div>
+                            <span className="si-ws-plat-score">{t.platformBreakdown?.gemini || 0}</span>
+                          </div>
+                          <div className="si-ws-platform">
+                            <span className="si-ws-plat-name">AI Overviews</span>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.aiOverviews || 0}%`, background: '#f5b942' }} /></div>
+                            <span className="si-ws-plat-score">{t.platformBreakdown?.aiOverviews || 0}</span>
+                          </div>
+                        </div>
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Cost of Invisibility</div>
+                          <div className="si-gap-text">{t.invisibilityCost}</div>
+                        </div>
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Narrative Control</div>
+                          <div className="si-gap-text">{t.narrativeControl}</div>
+                        </div>
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">Reclaim Difficulty</div>
+                          <span className="si-gap-score" style={{ color: diffColor, fontSize: '0.85rem' }}>{t.reclaimDifficulty?.toUpperCase()}</span>
+                          {t.quickWin && <span className="si-ws-qw"> ⚡ Quick Win</span>}
+                        </div>
+                        <div className="si-gap-section si-gap-board">
+                          <div className="si-gap-label">Board Implication</div>
+                          <div className="si-gap-text">{t.boardImplication}</div>
+                        </div>
+                        <div className="si-gap-section">
+                          <div className="si-gap-label">90-Day Play</div>
+                          <div className="si-gap-text">{t.ninetyDayPlay}</div>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+
+
+        {/* ═══ POSITIONING PIVOT TAB ═══ */}
+        {activeTab === 'pivot' && !isRunning && pivot && (
+          <div className="si-pivot">
+            <div className="si-pivot-statement">{pivot.pivotStatement}</div>
+
+            <div className="si-pivot-fromto">
+              <div className="si-pivot-from">
+                <div className="si-pivot-fromto-label">FROM</div>
+                <div className="si-pivot-fromto-text">{pivot.fromTo.from}</div>
+              </div>
+              <div className="si-pivot-arrow">→</div>
+              <div className="si-pivot-to">
+                <div className="si-pivot-fromto-label">TO</div>
+                <div className="si-pivot-fromto-text">{pivot.fromTo.to}</div>
+              </div>
             </div>
-            <button className="si-btn-primary" onClick={() => runAnalysis(false)}>
-              Run Competitive Intelligence
+
+            <div className="si-pivot-section">
+              <div className="si-gap-label">Why Now</div>
+              <div className="si-gap-text">{pivot.whyNow}</div>
+            </div>
+
+            <div className="si-pivot-evidence">
+              <div className="si-gap-label">Convergence Evidence</div>
+              <div className="si-pivot-evidence-grid">
+                {pivot.convergenceEvidence.gapMap && (
+                  <div className="si-pivot-ev-card">
+                    <div className="si-pivot-ev-dim">Gap Map</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.gapMap}</div>
+                  </div>
+                )}
+                {pivot.convergenceEvidence.pva && (
+                  <div className="si-pivot-ev-card">
+                    <div className="si-pivot-ev-dim">Vulnerabilities</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.pva}</div>
+                  </div>
+                )}
+                {pivot.convergenceEvidence.faultLines && (
+                  <div className="si-pivot-ev-card">
+                    <div className="si-pivot-ev-dim">Fault Lines</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.faultLines}</div>
+                  </div>
+                )}
+                {pivot.convergenceEvidence.blindSpots && (
+                  <div className="si-pivot-ev-card">
+                    <div className="si-pivot-ev-dim">Blind Spots</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.blindSpots}</div>
+                  </div>
+                )}
+                {pivot.convergenceEvidence.whitespace && (
+                  <div className="si-pivot-ev-card">
+                    <div className="si-pivot-ev-dim">Whitespace</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.whitespace}</div>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="si-pivot-moves">
+              <div className="si-gap-label">Three Moves in 90 Days</div>
+              {(pivot.threeMovesIn90Days || []).map((m, i) => (
+                <div key={i} className="si-pivot-move">
+                  <div className="si-pivot-move-num">{i + 1}</div>
+                  <div className="si-pivot-move-body">
+                    <div className="si-pivot-move-title">{m.move}</div>
+                    <div className="si-pivot-move-rationale">{m.rationale}</div>
+                    <div className="si-pivot-move-outcome">{m.outcome}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="si-pivot-stop">
+              <div className="si-gap-label">Stop Doing</div>
+              <div className="si-gap-text">{pivot.whatToStopDoing}</div>
+            </div>
+
+            <div className="si-pivot-board">
+              <div className="si-gap-label">The Board Slide</div>
+              <div className="si-pivot-board-text">{pivot.boardSlide}</div>
+            </div>
+          </div>
+        )}
+
+        {/* ═══ EMPTY STATE ═══ */}
+        {!hasData && !isRunning && !error && (activeTab === 'gap_map' || activeTab === 'pva' || activeTab === 'faultlines' || activeTab === 'blind_spots' || activeTab === 'whitespace' || activeTab === 'pivot') && (
+          <div className="si-empty-state">
+            <div className="si-empty-title">No {tabMeta?.label?.toLowerCase()} data yet</div>
+            <div className="si-empty-body">
+              {activeTab === 'gap_map' && 'Forge will aggregate your GEO topical authority gaps, competitor positioning, and vulnerability data to identify undefended market positions no competitor currently owns.'}
+              {activeTab === 'pivot' && 'Forge synthesizes all five intelligence dimensions to find the ONE positioning move that exploits every gap, vulnerability, blind spot, and invisible conversation simultaneously. Run the other analyses first.'}
+              {activeTab === 'whitespace' && 'Forge will map every conversation happening on ChatGPT, Perplexity, Gemini, and AI Overviews where your brand is invisible — who controls the narrative, what it costs you, and how to reclaim territory.'}
+              {activeTab === 'blind_spots' && 'Forge will analyze your personas, competitor positioning, and topical gaps to identify audience segments the entire market is ignoring — buyers nobody is speaking to that your brand can own.'}
+              {(activeTab === 'pva' || activeTab === 'faultlines') && 'Forge will scrape your competitors\' public positioning pages, identify vulnerabilities in their claims, and map the exact language they use so you can differentiate against it.'}
+            </div>
+            <button className="si-btn-primary" onClick={() => runAction && runAction(false)}>
+              Run {tabMeta?.label || 'Analysis'}
             </button>
           </div>
         )}


### PR DESCRIPTION
## Why

**PR 2 of 2** — completes the Brand Intelligence restoration. PR 1 (#491, merged) recovered the backend; this wires the frontend that consumes it, recovered from the same last-known-good commit `5b1ac6e9c6`.

Dev already carried an **orphaned 2-tab stub** of `StrategyIntelPage` (competitive-intel only, unreachable — no route, no nav). This replaces it with the real 6-tab workspace and adds the public brief page.

## What

- **`StrategyIntelPage.tsx`** — the full **6-tab** workspace: Gap Map · Vulnerabilities (PVA) · Fault Lines · Blind Spots · Whitespace · Pivot, plus **Run Compliance** + **Share Brief**. Same scaffolding as the stub it replaces (`AppShell` / `useApp` / `authToken`), so it's a drop-in — it just calls the 4 deliverable endpoints + share + compliance that PR 1 restored.
- **`BrandIntelligenceBriefPage.tsx` + `.css`** — the token-gated **public board document** (`/brand-intelligence/:token` → `GET /api/strategy/brief/:token`). Confidential banner, Forge footer, no auth.
- **Wiring:**
  - `main.tsx` — imports + `/app/strategy-intel` (AppProvider-wrapped) + public `/brand-intelligence/:token` (no auth, beside `/review/:token`).
  - `Sidebar.tsx` — nav entry **"Brand Intelligence"** (compass icon) after GEO Strategist + `NAV_ROUTES` mapping.
  - `TopBar.tsx` — view + path title maps.

## Verification

- **Share contract end-to-end:** `POST /api/strategy/share/:id` → `https://<host>/brand-intelligence/<token>` → React route → brief page → `GET /api/strategy/brief/:token`; `410` + `"This brief link has been revoked"` on revoke.
- `npx tsc --noEmit` — clean.
- `npx vitest run` — **199/199 pass**, including the route-inventory guard (PR 2 adds **no** Express routes — the public brief route is React Router only).

## Test plan (on dev after merge)

1. Sidebar → **Brand Intelligence** → `/app/strategy-intel` loads the 6-tab workspace.
2. Run each analysis (Gap Map / Blind Spots / Whitespace / Pivot) → SSE progress → deliverable renders.
3. **Share Brief** → opens `/brand-intelligence/<token>` → the public board doc renders all deliverables.
4. Revoke → the link shows "Brief Revoked".

## Rollback

Revert the commit — pure frontend. (The 2-tab stub was already unreachable, so reverting restores the prior no-op state.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_