### PR TITLE
fix(strategy): Brand Intelligence no longer blanks on malformed deliverable data

### DIFF
--- a/src/pages/StrategyIntelPage.tsx
+++ b/src/pages/StrategyIntelPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Component } from 'react';
+import type { ReactNode } from 'react';
 import { AppShell } from '../layouts/AppShell';
 import { useApp } from '../context/AppContext';
 import { Target, Map, Eye, MessageSquare, Compass, ArrowRight, Share2 } from 'lucide-react';
@@ -97,6 +98,35 @@ const TABS: { id: TabId; label: string; icon: any; ready: boolean }[] = [
   { id: 'pivot', label: 'Positioning Pivot', icon: ArrowRight, ready: true },
 ];
 
+// Container-type coercion. The stored deliverable JSONB can be double-encoded
+// (an array/object persisted as a JSON string); the server now normalizes, but
+// coerce here too so a stale backend or a bad payload can never put a string
+// into array/object state and crash a .map()/nested access at render time.
+const toArray = (v: any): any[] => {
+  if (Array.isArray(v)) return v;
+  if (typeof v === 'string') { try { const p = JSON.parse(v); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+const toObj = (v: any): any => {
+  if (v && typeof v === 'object' && !Array.isArray(v)) return v;
+  if (typeof v === 'string') { try { const p = JSON.parse(v); return (p && typeof p === 'object' && !Array.isArray(p)) ? p : null; } catch { return null; } }
+  return null;
+};
+
+// Error boundary so one malformed deliverable can never blank the whole page —
+// the crash is contained to the offending tab, which shows a recoverable notice.
+class TabErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  constructor(props: { children: ReactNode }) { super(props); this.state = { failed: false }; }
+  static getDerivedStateFromError() { return { failed: true }; }
+  componentDidCatch(err: any) { console.error('[StrategyIntel] tab render error:', err); }
+  render() {
+    if (this.state.failed) {
+      return <div className="si-error">This deliverable couldn't be displayed — its data may be malformed. Try Re-analyze to regenerate it.</div>;
+    }
+    return this.props.children;
+  }
+}
+
 export default function StrategyIntelPage() {
   const { setCurrentView, activeBrand, authToken } = useApp();
   const [activeTab, setActiveTab] = useState<TabId>('gap_map');
@@ -141,7 +171,7 @@ export default function StrategyIntelPage() {
       headers: { 'Authorization': `Bearer ${authToken}` }
     })
       .then(r => r.json())
-      .then(d => { if (d.success && d.competitors?.length) setCompetitors(d.competitors); })
+      .then(d => { if (d.success) { const a = toArray(d.competitors); if (a.length) setCompetitors(a); } })
       .catch(() => {});
   }, [brandProfileId, authToken]);
 
@@ -152,7 +182,7 @@ export default function StrategyIntelPage() {
       headers: { 'Authorization': `Bearer ${authToken}` }
     })
       .then(r => r.json())
-      .then(d => { if (d.success && d.gaps?.length) setGaps(d.gaps); })
+      .then(d => { if (d.success) { const a = toArray(d.gaps); if (a.length) setGaps(a); } })
       .catch(() => {});
   }, [brandProfileId, authToken]);
 
@@ -163,7 +193,7 @@ export default function StrategyIntelPage() {
       headers: { 'Authorization': `Bearer ${authToken}` }
     })
       .then(r => r.json())
-      .then(d => { if (d.success && d.blindSpots?.length) setBlindSpots(d.blindSpots); })
+      .then(d => { if (d.success) { const a = toArray(d.blindSpots); if (a.length) setBlindSpots(a); } })
       .catch(() => {});
   }, [brandProfileId, authToken]);
 
@@ -174,7 +204,7 @@ export default function StrategyIntelPage() {
       headers: { 'Authorization': `Bearer ${authToken}` }
     })
       .then(r => r.json())
-      .then(d => { if (d.success && d.territories?.length) setTerritories(d.territories); })
+      .then(d => { if (d.success) { const a = toArray(d.territories); if (a.length) setTerritories(a); } })
       .catch(() => {});
   }, [brandProfileId, authToken]);
 
@@ -196,7 +226,7 @@ export default function StrategyIntelPage() {
       headers: { 'Authorization': `Bearer ${authToken}` }
     })
       .then(r => r.json())
-      .then(d => { if (d.success && d.pivot) setPivot(d.pivot); })
+      .then(d => { if (d.success) { const o = toObj(d.pivot); if (o) setPivot(o); } })
       .catch(() => {});
   }, [brandProfileId, authToken]);
 
@@ -225,7 +255,7 @@ export default function StrategyIntelPage() {
             try {
               const evt = JSON.parse(part.slice(6));
               if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
-              else if (evt.type === 'result') setCompetitors(evt.competitors || []);
+              else if (evt.type === 'result') setCompetitors(toArray(evt.competitors));
               else if (evt.type === 'error') throw new Error(evt.error);
             } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
           }
@@ -260,7 +290,7 @@ export default function StrategyIntelPage() {
             try {
               const evt = JSON.parse(part.slice(6));
               if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
-              else if (evt.type === 'result') setGaps(evt.gaps || []);
+              else if (evt.type === 'result') setGaps(toArray(evt.gaps));
               else if (evt.type === 'error') throw new Error(evt.error);
             } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
           }
@@ -295,7 +325,7 @@ export default function StrategyIntelPage() {
             try {
               const evt = JSON.parse(part.slice(6));
               if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
-              else if (evt.type === 'result') setBlindSpots(evt.blindSpots || []);
+              else if (evt.type === 'result') setBlindSpots(toArray(evt.blindSpots));
               else if (evt.type === 'error') throw new Error(evt.error);
             } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
           }
@@ -330,7 +360,7 @@ export default function StrategyIntelPage() {
             try {
               const evt = JSON.parse(part.slice(6));
               if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
-              else if (evt.type === 'result') setTerritories(evt.territories || []);
+              else if (evt.type === 'result') setTerritories(toArray(evt.territories));
               else if (evt.type === 'error') throw new Error(evt.error);
             } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
           }
@@ -365,7 +395,7 @@ export default function StrategyIntelPage() {
             try {
               const evt = JSON.parse(part.slice(6));
               if (evt.type === 'progress' || evt.type === 'detail') setProgress(prev => [...prev, evt.detail]);
-              else if (evt.type === 'result') setPivot(evt.pivot || null);
+              else if (evt.type === 'result') setPivot(toObj(evt.pivot));
               else if (evt.type === 'error') throw new Error(evt.error);
             } catch (pe: any) { if (pe.message && !pe.message.includes('JSON')) throw pe; }
           }
@@ -578,6 +608,8 @@ export default function StrategyIntelPage() {
 
         {error && <div className="si-error">{error}</div>}
 
+        {/* Keyed by activeTab so a contained render error resets when you switch tabs. */}
+        <TabErrorBoundary key={activeTab}>
         {/* ═══ GAP MAP TAB ═══ */}
         {activeTab === 'gap_map' && !isRunning && gaps.length > 0 && (
           <div className="si-competitors">
@@ -600,22 +632,22 @@ export default function StrategyIntelPage() {
                           <div className="si-gap-label">Current State</div>
                           <div className="si-gap-text">{gap.currentState}</div>
                         </div>
-                        {gap.evidence.geo && (
+                        {gap.evidence?.geo && (
                           <div className="si-gap-section">
                             <div className="si-gap-label">GEO Signal</div>
-                            <div className="si-gap-text">{gap.evidence.geo}</div>
+                            <div className="si-gap-text">{gap.evidence?.geo}</div>
                           </div>
                         )}
-                        {gap.evidence.pva && (
+                        {gap.evidence?.pva && (
                           <div className="si-gap-section">
                             <div className="si-gap-label">Vulnerability Signal</div>
-                            <div className="si-gap-text">{gap.evidence.pva}</div>
+                            <div className="si-gap-text">{gap.evidence?.pva}</div>
                           </div>
                         )}
-                        {gap.evidence.faultLines && (
+                        {gap.evidence?.faultLines && (
                           <div className="si-gap-section">
                             <div className="si-gap-label">Messaging Signal</div>
-                            <div className="si-gap-text">{gap.evidence.faultLines}</div>
+                            <div className="si-gap-text">{gap.evidence?.faultLines}</div>
                           </div>
                         )}
                         <div className="si-gap-section">
@@ -741,22 +773,22 @@ export default function StrategyIntelPage() {
                           <div className="si-gap-label">Why the Market Is Blind</div>
                           <div className="si-gap-text">{spot.whyBlind}</div>
                         </div>
-                        {spot.evidence.competitorGap && (
+                        {spot.evidence?.competitorGap && (
                           <div className="si-gap-section">
                             <div className="si-gap-label">Competitor Gap</div>
-                            <div className="si-gap-text">{spot.evidence.competitorGap}</div>
+                            <div className="si-gap-text">{spot.evidence?.competitorGap}</div>
                           </div>
                         )}
-                        {spot.evidence.topicalSignal && (
+                        {spot.evidence?.topicalSignal && (
                           <div className="si-gap-section">
                             <div className="si-gap-label">Topical Signal</div>
-                            <div className="si-gap-text">{spot.evidence.topicalSignal}</div>
+                            <div className="si-gap-text">{spot.evidence?.topicalSignal}</div>
                           </div>
                         )}
-                        {spot.evidence.marketTrend && (
+                        {spot.evidence?.marketTrend && (
                           <div className="si-gap-section">
                             <div className="si-gap-label">Market Trend</div>
-                            <div className="si-gap-text">{spot.evidence.marketTrend}</div>
+                            <div className="si-gap-text">{spot.evidence?.marketTrend}</div>
                           </div>
                         )}
                         <div className="si-gap-section">
@@ -869,12 +901,12 @@ export default function StrategyIntelPage() {
             <div className="si-pivot-fromto">
               <div className="si-pivot-from">
                 <div className="si-pivot-fromto-label">FROM</div>
-                <div className="si-pivot-fromto-text">{pivot.fromTo.from}</div>
+                <div className="si-pivot-fromto-text">{pivot.fromTo?.from}</div>
               </div>
               <div className="si-pivot-arrow">→</div>
               <div className="si-pivot-to">
                 <div className="si-pivot-fromto-label">TO</div>
-                <div className="si-pivot-fromto-text">{pivot.fromTo.to}</div>
+                <div className="si-pivot-fromto-text">{pivot.fromTo?.to}</div>
               </div>
             </div>
 
@@ -886,34 +918,34 @@ export default function StrategyIntelPage() {
             <div className="si-pivot-evidence">
               <div className="si-gap-label">Convergence Evidence</div>
               <div className="si-pivot-evidence-grid">
-                {pivot.convergenceEvidence.gapMap && (
+                {pivot.convergenceEvidence?.gapMap && (
                   <div className="si-pivot-ev-card">
                     <div className="si-pivot-ev-dim">Gap Map</div>
-                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.gapMap}</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence?.gapMap}</div>
                   </div>
                 )}
-                {pivot.convergenceEvidence.pva && (
+                {pivot.convergenceEvidence?.pva && (
                   <div className="si-pivot-ev-card">
                     <div className="si-pivot-ev-dim">Vulnerabilities</div>
-                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.pva}</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence?.pva}</div>
                   </div>
                 )}
-                {pivot.convergenceEvidence.faultLines && (
+                {pivot.convergenceEvidence?.faultLines && (
                   <div className="si-pivot-ev-card">
                     <div className="si-pivot-ev-dim">Fault Lines</div>
-                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.faultLines}</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence?.faultLines}</div>
                   </div>
                 )}
-                {pivot.convergenceEvidence.blindSpots && (
+                {pivot.convergenceEvidence?.blindSpots && (
                   <div className="si-pivot-ev-card">
                     <div className="si-pivot-ev-dim">Blind Spots</div>
-                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.blindSpots}</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence?.blindSpots}</div>
                   </div>
                 )}
-                {pivot.convergenceEvidence.whitespace && (
+                {pivot.convergenceEvidence?.whitespace && (
                   <div className="si-pivot-ev-card">
                     <div className="si-pivot-ev-dim">Whitespace</div>
-                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence.whitespace}</div>
+                    <div className="si-pivot-ev-text">{pivot.convergenceEvidence?.whitespace}</div>
                   </div>
                 )}
               </div>
@@ -921,7 +953,7 @@ export default function StrategyIntelPage() {
 
             <div className="si-pivot-moves">
               <div className="si-gap-label">Three Moves in 90 Days</div>
-              {(pivot.threeMovesIn90Days || []).map((m, i) => (
+              {(Array.isArray(pivot.threeMovesIn90Days) ? pivot.threeMovesIn90Days : []).map((m, i) => (
                 <div key={i} className="si-pivot-move">
                   <div className="si-pivot-move-num">{i + 1}</div>
                   <div className="si-pivot-move-body">
@@ -961,6 +993,7 @@ export default function StrategyIntelPage() {
             </button>
           </div>
         )}
+        </TabErrorBoundary>
       </div>
     </AppShell>
   );

--- a/src/server/routes/strategy.js
+++ b/src/server/routes/strategy.js
@@ -21,6 +21,22 @@ import { requireAuth } from '../auth.js';
 
 const router = express.Router();
 
+// Container-type normalizers for stored deliverable JSONB. Historically one
+// gap_map row was persisted double-encoded (data.gaps = a JSON *string*, not an
+// array — the pg driver parses the outer JSONB but leaves the inner string),
+// which crashed the frontend's gaps.map(). These recover a double-encoded value
+// and enforce the array/object contract so the API never emits a wrong type.
+const asArray = (v) => {
+  if (Array.isArray(v)) return v;
+  if (typeof v === 'string') { try { const p = JSON.parse(v); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+const asObject = (v) => {
+  if (v && typeof v === 'object' && !Array.isArray(v)) return v;
+  if (typeof v === 'string') { try { const p = JSON.parse(v); return (p && typeof p === 'object' && !Array.isArray(p)) ? p : null; } catch { return null; } }
+  return null;
+};
+
 router.get('/gap-map/:brandProfileId', requireAuth, async (req, res) => {
   try {
     const { brandProfileId } = req.params;
@@ -32,7 +48,7 @@ router.get('/gap-map/:brandProfileId', requireAuth, async (req, res) => {
     const profile = await pool.query('SELECT version FROM brand_profiles WHERE id = $1', [brandProfileId]);
     const currentVersion = profile.rows[0]?.version || 1;
     const stale = r.rows[0].brain_version < currentVersion;
-    res.json({ success: true, gaps: r.rows[0].data.gaps || [], cached: true, stale, updatedAt: r.rows[0].updated_at });
+    res.json({ success: true, gaps: asArray(r.rows[0].data?.gaps), cached: true, stale, updatedAt: r.rows[0].updated_at });
   } catch (e) {
     res.status(500).json({ success: false, error: e.message });
   }
@@ -66,7 +82,7 @@ router.post('/gap-map/:brandProfileId', requireAuth, async (req, res) => {
         [brandProfileId, 'gap_map']
       );
       if (cached.rows.length && cached.rows[0].brain_version >= brainVersion) {
-        send('result', { gaps: cached.rows[0].data.gaps || [], cached: true });
+        send('result', { gaps: asArray(cached.rows[0].data?.gaps), cached: true });
         return res.end();
       }
     }
@@ -214,7 +230,7 @@ router.get('/blind-spots/:brandProfileId', requireAuth, async (req, res) => {
     const profile = await pool.query('SELECT version FROM brand_profiles WHERE id = $1', [brandProfileId]);
     const currentVersion = profile.rows[0]?.version || 1;
     const stale = r.rows[0].brain_version < currentVersion;
-    res.json({ success: true, blindSpots: r.rows[0].data.blindSpots || [], cached: true, stale, updatedAt: r.rows[0].updated_at });
+    res.json({ success: true, blindSpots: asArray(r.rows[0].data?.blindSpots), cached: true, stale, updatedAt: r.rows[0].updated_at });
   } catch (e) {
     res.status(500).json({ success: false, error: e.message });
   }
@@ -247,7 +263,7 @@ router.post('/blind-spots/:brandProfileId', requireAuth, async (req, res) => {
         [brandProfileId, 'blind_spots']
       );
       if (cached.rows.length && cached.rows[0].brain_version >= brainVersion) {
-        send('result', { blindSpots: cached.rows[0].data.blindSpots || [], cached: true });
+        send('result', { blindSpots: asArray(cached.rows[0].data?.blindSpots), cached: true });
         return res.end();
       }
     }
@@ -401,7 +417,7 @@ router.get('/whitespace/:brandProfileId', requireAuth, async (req, res) => {
     const profile = await pool.query('SELECT version FROM brand_profiles WHERE id = $1', [brandProfileId]);
     const currentVersion = profile.rows[0]?.version || 1;
     const stale = r.rows[0].brain_version < currentVersion;
-    res.json({ success: true, territories: r.rows[0].data.territories || [], cached: true, stale, updatedAt: r.rows[0].updated_at });
+    res.json({ success: true, territories: asArray(r.rows[0].data?.territories), cached: true, stale, updatedAt: r.rows[0].updated_at });
   } catch (e) {
     res.status(500).json({ success: false, error: e.message });
   }
@@ -434,7 +450,7 @@ router.post('/whitespace/:brandProfileId', requireAuth, async (req, res) => {
         [brandProfileId, 'whitespace']
       );
       if (cached.rows.length && cached.rows[0].brain_version >= brainVersion) {
-        send('result', { territories: cached.rows[0].data.territories || [], cached: true });
+        send('result', { territories: asArray(cached.rows[0].data?.territories), cached: true });
         return res.end();
       }
     }
@@ -590,7 +606,7 @@ router.get('/pivot/:brandProfileId', requireAuth, async (req, res) => {
     const profile = await pool.query('SELECT version FROM brand_profiles WHERE id = $1', [brandProfileId]);
     const currentVersion = profile.rows[0]?.version || 1;
     const stale = r.rows[0].brain_version < currentVersion;
-    res.json({ success: true, pivot: r.rows[0].data.pivot || null, cached: true, stale, updatedAt: r.rows[0].updated_at });
+    res.json({ success: true, pivot: asObject(r.rows[0].data?.pivot), cached: true, stale, updatedAt: r.rows[0].updated_at });
   } catch (e) {
     res.status(500).json({ success: false, error: e.message });
   }
@@ -623,7 +639,7 @@ router.post('/pivot/:brandProfileId', requireAuth, async (req, res) => {
         [brandProfileId, 'pivot']
       );
       if (cached.rows.length && cached.rows[0].brain_version >= brainVersion) {
-        send('result', { pivot: cached.rows[0].data.pivot || null, cached: true });
+        send('result', { pivot: asObject(cached.rows[0].data?.pivot), cached: true });
         return res.end();
       }
     }
@@ -643,9 +659,9 @@ router.post('/pivot/:brandProfileId', requireAuth, async (req, res) => {
       [brandProfileId]
     );
 
-    const gapMap = (deliverables.gap_map || {}).gaps || [];
-    const blindSpots = (deliverables.blind_spots || {}).blindSpots || [];
-    const whitespace = (deliverables.whitespace || {}).territories || [];
+    const gapMap = asArray((deliverables.gap_map || {}).gaps);
+    const blindSpots = asArray((deliverables.blind_spots || {}).blindSpots);
+    const whitespace = asArray((deliverables.whitespace || {}).territories);
     const pva = pvaRes.rows.map(r => ({
       competitor: r.competitor_name,
       vulnerabilities: (r.pva_data || []).map(v => ({ severity: v.severity, claim: v.claim, vulnerability: v.vulnerability })),
@@ -868,10 +884,10 @@ router.get('/brief/:token', async (req, res) => {
       brandName: share.brand_name,
       brandUrl: share.brand_url,
       createdAt: share.created_at,
-      pivot: deliverables.pivot?.data?.pivot || null,
-      gapMap: deliverables.gap_map?.data?.gaps || [],
-      blindSpots: deliverables.blind_spots?.data?.blindSpots || [],
-      whitespace: deliverables.whitespace?.data?.territories || [],
+      pivot: asObject(deliverables.pivot?.data?.pivot),
+      gapMap: asArray(deliverables.gap_map?.data?.gaps),
+      blindSpots: asArray(deliverables.blind_spots?.data?.blindSpots),
+      whitespace: asArray(deliverables.whitespace?.data?.territories),
       competitors,
       updatedAt: biRes.rows.reduce((latest, r) => r.updated_at > latest ? r.updated_at : latest, share.created_at)
     });
@@ -932,10 +948,10 @@ router.post('/compliance/:brandProfileId', requireAuth, async (req, res) => {
       [brandProfileId]
     );
 
-    const pivot = deliverables.pivot?.pivot || null;
-    const gaps = deliverables.gap_map?.gaps || [];
-    const blindSpots = deliverables.blind_spots?.blindSpots || [];
-    const whitespace = deliverables.whitespace?.territories || [];
+    const pivot = asObject(deliverables.pivot?.pivot);
+    const gaps = asArray(deliverables.gap_map?.gaps);
+    const blindSpots = asArray(deliverables.blind_spots?.blindSpots);
+    const whitespace = asArray(deliverables.whitespace?.territories);
     const competitors = pvaRes.rows;
 
     if (!pivot && gaps.length === 0 && blindSpots.length === 0 && whitespace.length === 0) {


### PR DESCRIPTION
## Why

Opening **Brand Intelligence** loaded for a few seconds, then the content area went to a solid background — a React render crash unmounting the whole subtree (the page has no error boundary).

**Root cause:** one stored `gap_map` row (brand `b55bdde3`) has `data.gaps` persisted as a **double-encoded JSON string**, not an array. The gap-map GET returned it as-is; the frontend gated on truthy `d.gaps?.length` (true for a non-empty *string*), so `setGaps(string)`; `gap_map` is the default tab, so render hit `gaps.map()` → **`gaps.map is not a function`** → blank.

A diagnostic workflow (4 crash-class lenses → adversarial verify → synthesize, 37 agents) confirmed **25 crash sites**: the live string-container defect **plus** latent unguarded nested AI fields the model may omit — `gap.evidence.*`, `spot.evidence.*`, `pivot.fromTo.*`, `pivot.convergenceEvidence.*`, `threeMovesIn90Days`. Any of these white-screens the whole feature because nothing contains the throw.

## What (defense-in-depth)

**Backend (`src/server/routes/strategy.js`)**
- New `asArray()` / `asObject()` normalizers applied at **every** read boundary: gap-map / blind-spots / whitespace / pivot **GET + cache-hit SSE**, the **pivot POST** and **compliance POST** internal deliverable reads, and the **public brief** route. A double-encoded string is re-parsed to the real array/object — the API can never emit a wrong container type (this alone recovers `b55bdde3`'s real gaps).

**Frontend (`src/pages/StrategyIntelPage.tsx`)**
- `toArray()` / `toObj()` coercion at **every** `setState` (load effects + SSE result handlers) so a stale backend or bad payload can't put a string into array/object state.
- Optional-chained every omittable nested access; `Array.isArray`-guarded `threeMovesIn90Days`.
- **`TabErrorBoundary`** (keyed by `activeTab`) wraps the tab content — one malformed deliverable is now contained to a recoverable "couldn't be displayed — try Re-analyze" card instead of blanking the page. Switching tabs resets it.

**Data**
- Repaired the one double-encoded row on dev (`gaps` string → 7-item array). Non-urgent now that the server self-heals on read, but restores the clean stored shape.

## Test plan

- `npx tsc --noEmit` — clean.
- `npx vitest run` — **199/199** (route-inventory green: only handler bodies changed, **no** route registrations).
- Dev row verified `jsonb_typeof(data->'gaps') = array`, length 7.
- Backend `node --check` — clean.
- On dev after merge: Brand Intelligence loads the gap_map tab with real data (no blank); every other tab renders; a deliberately malformed deliverable shows the contained error card, not a white screen.

## Rollback

Revert the commit — pure hardening (normalizers + guards + boundary), no schema or route changes. The DB row repair stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_