### PR TITLE
fix(strategy): PVA/fault-lines brittle JSON.parse zeroed out real findings

### DIFF
--- a/server.js
+++ b/server.js
@@ -3736,14 +3736,24 @@ Respond with ONLY valid JSON — no markdown, no code fences:
       messages: [{ role: 'user', content: pvaPrompt }]
     });
 
+    // Hardened parse — the quote-dense PVA output ("quote the competitor's exact
+    // language") routinely contains trailing commas / smart quotes / control chars
+    // that the old raw JSON.parse rejected, silently zeroing out real findings.
+    // safeParseLLM is the same cascade the rest of server.js uses.
     let pvaData = { competitors: [] };
     try {
-      const raw = pvaRes.content[0].text;
-      const jsonMatch = raw.match(/\{[\s\S]*\}/);
-      if (jsonMatch) pvaData = JSON.parse(jsonMatch[0]);
-    } catch(e) { console.log('[STRATEGY] PVA parse warn:', e.message); }
+      const parsed = safeParseLLM(pvaRes.content[0].text, 'object', 'strategy-pva');
+      if (parsed && Array.isArray(parsed.competitors)) pvaData = parsed;
+    } catch(e) { console.warn('[STRATEGY] PVA parse failed:', e.message, '| head:', (pvaRes.content[0]?.text || '').slice(0, 300)); }
 
     const pvaCount = pvaData.competitors?.reduce((sum, c) => sum + (c.vulnerabilities?.length || 0), 0) || 0;
+    // Never fail silently: if we scraped content but got zero vulnerabilities, log
+    // the raw head + parsed competitor count so a recurrence is diagnosable (parse
+    // loss shows findings in rawHead with parsedCompetitors=0; a genuine empty model
+    // response shows empty vulnerabilities[] arrays).
+    if (pvaCount === 0 && competitorData.some(c => c.scrapedLength > 500)) {
+      console.warn(`[STRATEGY] PVA 0 vulnerabilities despite scraped content — parsedCompetitors=${pvaData.competitors?.length || 0} rawHead=${(pvaRes.content[0]?.text || '').slice(0, 400)}`);
+    }
     send('detail', { stage: 'pva', detail: `${pvaCount} vulnerabilities identified across ${pvaData.competitors?.length || 0} competitors` });
 
     // ── Tool 2: Messaging Fault Lines ──
@@ -3800,12 +3810,14 @@ Respond with ONLY valid JSON — no markdown, no code fences:
 
     let faultLinesData = { competitors: [] };
     try {
-      const raw = flRes.content[0].text;
-      const jsonMatch = raw.match(/\{[\s\S]*\}/);
-      if (jsonMatch) faultLinesData = JSON.parse(jsonMatch[0]);
-    } catch(e) { console.log('[STRATEGY] Fault Lines parse warn:', e.message); }
+      const parsed = safeParseLLM(flRes.content[0].text, 'object', 'strategy-faultlines');
+      if (parsed && Array.isArray(parsed.competitors)) faultLinesData = parsed;
+    } catch(e) { console.warn('[STRATEGY] Fault Lines parse failed:', e.message, '| head:', (flRes.content[0]?.text || '').slice(0, 300)); }
 
     const flCount = faultLinesData.competitors?.reduce((sum, c) => sum + (c.faultLines?.length || 0), 0) || 0;
+    if (flCount === 0 && competitorData.some(c => c.scrapedLength > 500)) {
+      console.warn(`[STRATEGY] Fault Lines 0 despite scraped content — parsedCompetitors=${faultLinesData.competitors?.length || 0} rawHead=${(flRes.content[0]?.text || '').slice(0, 400)}`);
+    }
     send('detail', { stage: 'faultlines', detail: `${flCount} fault lines mapped across ${faultLinesData.competitors?.length || 0} competitors` });
 
     // ── Persist per competitor ──


### PR DESCRIPTION
## Why

Brand Intelligence **Vulnerabilities (PVA)** came back **0 for all three competitors** — while **Fault Lines** on the *same run, same model, same scraped content* returned 3-4 each.

Diagnosis from the dev DB: scraping worked (~19 KB per competitor stored), and fault-lines populated, so the input and infra were fine — PVA specifically lost its findings. Root cause: the competitive-intel PVA + fault-lines handlers are the **last two stragglers** in `server.js` still parsing model output with the brittle raw `raw.match(/\{[\s\S]*\}/)` + `JSON.parse`, instead of the house `safeParseLLM` the other 8 AI paths use. That naive parse throws on **any** JSON imperfection (trailing comma, smart quote, control char) and the `catch` **silently swallows it → stores 0**.

PVA is the single most quote-dense output — it's explicitly instructed to *"Quote the competitor's exact language"* / *"the exact quote … from their content"* — so it's the most likely to contain a character that breaks naive JSON parsing. Fault-lines quotes too, but happened to come out clean that run. The model almost certainly returned vulnerabilities; the parse ate them.

## What

- **PVA + fault-lines now use `safeParseLLM`** (`server.js`) — the same cascade as the rest of the app: strips fences/zero-width chars, balanced-extracts with truncation recovery, then control-char / trailing-comma / brute-force passes. Guarded to only accept a well-shaped `{ competitors: [] }` object.
- **Instrumentation so a silent 0 can never recur:** when a scan scrapes content but yields 0, it now logs the raw response head + parsed competitor count. That distinguishes the two failure modes on the next occurrence — **parse loss** shows findings in `rawHead` with `parsedCompetitors=0`; a **genuinely empty model response** shows empty `vulnerabilities[]` arrays.

## Test plan

- `node --check server.js` — clean.
- `npx vitest run` — 199/199 (this is an AI path, not unit-covered; route-inventory unaffected — no route changes).
- **On dev after merge:** re-run the Vulnerabilities scan on the Pitch Box brand (`b55bdde3`) — PVA should populate 2-4 per competitor like Fault Lines does. If it's still 0, the new log line will show whether the model returned empty (a prompt problem) vs a parse issue (shouldn't happen now).

## Rollback

Revert the commit — isolated to two parse blocks, no schema/route/behavior changes beyond the parse hardening + a log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_