### PR TITLE
fix(strategy): Share Brief 500'd on crypto.randomUUID() (missing global on dev Node)

### DIFF
--- a/src/pages/StrategyIntelPage.tsx
+++ b/src/pages/StrategyIntelPage.tsx
@@ -517,7 +517,12 @@ export default function StrategyIntelPage() {
                     </button>
                   </>
                 )}
-                <button className="si-btn-share" onClick={createShareLink} disabled={sharing || !complianceReport}>
+                <button
+                  className="si-btn-share"
+                  onClick={createShareLink}
+                  disabled={sharing || !complianceReport}
+                  title={!complianceReport ? 'Run the Compliance Check first to enable a shareable brief' : 'Create a shareable board-ready brief link'}
+                >
                   <Share2 size={13} /> {sharing ? 'Creating...' : 'Share Brief'}
                 </button>
               </>

--- a/src/server/routes/strategy.js
+++ b/src/server/routes/strategy.js
@@ -811,7 +811,7 @@ router.post('/share/:brandProfileId', requireAuth, async (req, res) => {
     const profile = await pool.query('SELECT brand_name, brand_url FROM brand_profiles WHERE id = $1', [brandProfileId]);
     if (!profile.rows.length) return res.status(404).json({ success: false, error: 'Brand not found' });
     const { brand_name, brand_url } = profile.rows[0];
-    const token = (crypto.randomUUID() + crypto.randomUUID()).replace(/-/g, '');
+    const token = (randomUUID() + randomUUID()).replace(/-/g, '');
     await pool.query(
       'INSERT INTO brand_intelligence_shares (brand_profile_id, token, created_by, brand_name, brand_url) VALUES ($1, $2, $3, $4, $5)',
       [brandProfileId, token, req.userId || null, brand_name, brand_url]
@@ -819,6 +819,7 @@ router.post('/share/:brandProfileId', requireAuth, async (req, res) => {
     const shareUrl = `https://${req.headers.host}/brand-intelligence/${token}`;
     res.json({ success: true, token, url: shareUrl });
   } catch (e) {
+    console.error('[STRATEGY] share link creation failed:', e.message);
     res.status(500).json({ success: false, error: e.message });
   }
 });


### PR DESCRIPTION
## Why

Share Brief did nothing on click. Evidence from the dev DB: **no `brand_intelligence_shares` rows have been created on the recovered feature** (the most recent is 2026-05-12, from the old deploy) — so the POST is **500ing before the INSERT**.

The brand exists (not a 404) and the table exists, so the only pre-INSERT throw point is token generation: it called `crypto.randomUUID()`, which relies on the **global Web Crypto** (`globalThis.crypto`) that only exists on **Node ≥ 19**. The module imports `{ randomUUID } from 'crypto'` (named) and never binds the `crypto` namespace, so on the dev service's Node the global is absent → `crypto.randomUUID()` throws `ReferenceError` → caught → 500. And the share `catch` had **no logging**, so the 500 left no trace — which is why it was invisible.

This is a latent dependency carried verbatim from the recovered monolith (which had the identical single `crypto.*` usage and happened to run on a newer Node). Every other crypto call in the codebase uses the named `randomUUID()` — `server.js` has **zero** `crypto.` usages — this handler was the lone outlier.

## What

- **`strategy.js`:** `crypto.randomUUID()` → `randomUUID()` (the already-imported, Node-version-independent export; matches repo convention).
- **`strategy.js`:** the share `catch` now `console.error`s the failure — it was silent, the reason this was hard to diagnose.
- **`StrategyIntelPage.tsx`:** the Share button is *intentionally* disabled until the Compliance Check runs (the brief-gating design), but a bare disabled button reads as "dead" — added a `title` tooltip so it explains itself (`"Run the Compliance Check first to enable a shareable brief"`).

## Test plan

- `node --check` + `npx tsc --noEmit` — clean.
- `npx vitest run` — 199/199 (route-inventory unaffected — no route changes).
- **On dev after merge:** run an analysis + the Compliance Check, then click **Share Brief** → a `brand_intelligence_shares` row is created and the public `/brand-intelligence/<token>` brief opens. (Before: silent 500, no row.)

## Rollback

Revert — three lines, no schema/route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_