### PR TITLE
fix(strategy): rebuild Brand Intelligence UI on brand tokens + compliance feedback + kill em-dashes

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,9 @@ import { randomUUID, randomBytes, createHmac, createHash, timingSafeEqual } from
 import { jwtVerify } from 'jose';
 import { pool } from './src/server/db.js';
 import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
+// Forbid em-dashes in Brand Intelligence PVA / Fault Lines output (matches the
+// strategy module + the rest of Forge's content style). Appended to those prompts.
+const STRATEGY_NO_EM_DASH = '\n\nSTYLE (mandatory): Write in plain prose. Do NOT use em-dashes (the — character) anywhere in your output; use commas, colons, parentheses, or separate sentences instead.';
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
 import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripScaffoldingArtifacts, stripEmDashes } from './src/server/text.js';
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
@@ -3733,7 +3736,7 @@ Respond with ONLY valid JSON — no markdown, no code fences:
       model: 'claude-sonnet-4-6',
       max_tokens: 6000,
       system: 'You are a JSON API. Respond with valid JSON only — no markdown, no explanation, no code fences.',
-      messages: [{ role: 'user', content: pvaPrompt }]
+      messages: [{ role: 'user', content: pvaPrompt + STRATEGY_NO_EM_DASH }]
     });
 
     // Hardened parse — the quote-dense PVA output ("quote the competitor's exact
@@ -3805,7 +3808,7 @@ Respond with ONLY valid JSON — no markdown, no code fences:
       model: 'claude-sonnet-4-6',
       max_tokens: 6000,
       system: 'You are a JSON API. Respond with valid JSON only — no markdown, no explanation, no code fences.',
-      messages: [{ role: 'user', content: faultLinesPrompt }]
+      messages: [{ role: 'user', content: faultLinesPrompt + STRATEGY_NO_EM_DASH }]
     });
 
     let faultLinesData = { competitors: [] };

--- a/src/pages/BrandIntelligenceBriefPage.css
+++ b/src/pages/BrandIntelligenceBriefPage.css
@@ -22,7 +22,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: #3563ff;
+  color: var(--color-accent);
   margin-bottom: 16px;
 }
 .bi-brief-brand {
@@ -53,7 +53,7 @@
 .bi-section-num {
   font-size: 0.65rem;
   font-weight: 700;
-  color: #3563ff;
+  color: var(--color-accent);
   letter-spacing: 0.08em;
   margin-bottom: 8px;
 }
@@ -139,7 +139,7 @@
   font-style: italic;
   padding: 10px 14px;
   background: rgba(255,255,255,0.03);
-  border-left: 2px solid #3563ff;
+  border-left: 2px solid var(--color-accent);
   border-radius: 0 6px 6px 0;
   margin-bottom: 12px;
 }
@@ -204,8 +204,8 @@
   letter-spacing: 0.1em;
   margin-bottom: 6px;
 }
-.bi-pivot-from .bi-fromto-label { color: #ef4444; }
-.bi-pivot-to .bi-fromto-label { color: #14b8a6; }
+.bi-pivot-from .bi-fromto-label { color: var(--color-error); }
+.bi-pivot-to .bi-fromto-label { color: var(--color-success); }
 .bi-fromto-text {
   font-size: 0.85rem;
   color: #e2e8f0;
@@ -235,7 +235,7 @@
   padding: 16px;
   margin: 14px 0;
 }
-.bi-stop .bi-label { color: #ef4444; }
+.bi-stop .bi-label { color: var(--color-error); }
 .bi-board-slide {
   padding: 24px;
   background: linear-gradient(135deg, rgba(53, 99, 255, 0.12), rgba(20, 184, 166, 0.08));
@@ -243,7 +243,7 @@
   border-radius: 12px;
   margin-top: 20px;
 }
-.bi-board-slide .bi-label { color: #3563ff; }
+.bi-board-slide .bi-label { color: var(--color-accent); }
 .bi-board-slide p {
   font-size: 1rem;
   font-weight: 500;
@@ -267,7 +267,7 @@
   align-items: center;
   justify-content: center;
   background: rgba(53, 99, 255, 0.12);
-  color: #3563ff;
+  color: var(--color-accent);
   font-weight: 700;
   font-size: 0.78rem;
   border-radius: 50%;
@@ -289,7 +289,7 @@
 }
 .bi-move-outcome {
   font-size: 0.8rem;
-  color: #14b8a6;
+  color: var(--color-success);
   line-height: 1.45;
 }
 
@@ -325,7 +325,7 @@
 }
 .bi-ws-bar-fill {
   height: 100%;
-  background: #3563ff;
+  background: var(--color-accent);
   border-radius: 3px;
 }
 .bi-ws-bar-val {
@@ -352,7 +352,7 @@
   color: #64748b;
 }
 .bi-brief-footer-mark a {
-  color: #3563ff;
+  color: var(--color-accent);
   text-decoration: none;
   font-weight: 600;
 }
@@ -404,7 +404,7 @@
   text-transform: uppercase;
   letter-spacing: 0.1em;
   text-align: center;
-  color: #ef4444;
+  color: var(--color-error);
   background: rgba(239, 68, 68, 0.06);
   border-bottom: 1px solid rgba(239, 68, 68, 0.12);
   padding: 10px 24px;

--- a/src/pages/BrandIntelligenceBriefPage.tsx
+++ b/src/pages/BrandIntelligenceBriefPage.tsx
@@ -48,7 +48,7 @@ export default function BrandIntelligenceBriefPage() {
   return (
     <div className="bi-brief">
       {/* Confidential banner */}
-      <div className="bi-brief-confidential">CONFIDENTIAL — Prepared exclusively for {brief.brandName}. Do not distribute without authorization.</div>
+      <div className="bi-brief-confidential">CONFIDENTIAL. Prepared exclusively for {brief.brandName}. Do not distribute without authorization.</div>
 
       {/* Hero */}
       <header className="bi-brief-hero">

--- a/src/pages/StrategyIntelPage.css
+++ b/src/pages/StrategyIntelPage.css
@@ -1,35 +1,42 @@
+/* Brand Intelligence workspace — fully token-driven, light-theme, on-brand.
+   Rebuilt off src/index.css design tokens (was carrying dark-theme fallbacks,
+   white-alpha borders, and off-brand teal/purple/amber hardcodes). Tier colors
+   map to the brand set: success=green, warning=amber, error=red, accent=blue. */
+
 .si-page { max-width: 960px; margin: 0 auto; padding: 32px 24px; }
 .si-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 28px; gap: 16px; }
-.si-title { font-size: 1.5rem; font-weight: 700; color: var(--color-text-primary); margin: 0; }
+.si-title { font-size: 1.5rem; font-weight: 700; color: var(--color-text-emphasis); margin: 0; }
 .si-sub { font-size: 0.85rem; color: var(--color-text-muted); margin: 4px 0 0; }
-.si-header-actions { display: flex; gap: 8px; flex-shrink: 0; }
+.si-header-actions { display: flex; gap: 8px; flex-shrink: 0; flex-wrap: wrap; align-items: center; }
 
 .si-btn-primary, .si-btn-secondary {
   display: inline-flex; align-items: center; gap: 6px; height: 36px; padding: 0 20px;
-  font-size: 0.8rem; font-weight: 600; border-radius: 8px; cursor: pointer; border: none; white-space: nowrap;
+  font-size: 0.8rem; font-weight: 600; border-radius: var(--radius-md); cursor: pointer; border: none; white-space: nowrap;
 }
 .si-btn-primary { background: var(--color-accent); color: #fff; }
-.si-btn-primary:hover { opacity: 0.9; }
-.si-btn-secondary { background: transparent; color: var(--color-text-muted); border: 1px solid var(--color-border); }
-.si-btn-secondary:hover { color: var(--color-text-primary); border-color: var(--color-border); }
+.si-btn-primary:hover { background: var(--color-accent-hover); }
+.si-btn-secondary { background: var(--color-bg-card); color: var(--color-text-secondary); border: 1px solid var(--color-border); }
+.si-btn-secondary:hover { color: var(--color-text-primary); border-color: var(--color-border-input); }
 
-.si-progress { background: var(--color-accent-muted); border: 1px solid var(--color-border-subtle); border-radius: 10px; padding: 16px 20px; margin-bottom: 20px; }
-.si-progress-title { font-size: 0.85rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; }
-.si-progress-line { font-size: 0.75rem; color: var(--color-text-muted); padding: 2px 0; }
-.si-progress-spinner { width: 16px; height: 16px; border: 2px solid var(--color-accent-muted); border-top-color: var(--color-accent); border-radius: 50%; animation: si-spin 0.8s linear infinite; margin-top: 8px; }
+.si-progress { background: var(--color-accent-muted); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); padding: 16px 20px; margin-bottom: 20px; }
+.si-progress-title { font-size: 0.85rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; display: flex; align-items: center; gap: 10px; }
+.si-progress-line { font-size: 0.75rem; color: var(--color-text-secondary); padding: 2px 0; }
+.si-progress-spinner { width: 15px; height: 15px; border: 2px solid var(--color-accent-muted); border-top-color: var(--color-accent); border-radius: 50%; animation: si-spin 0.8s linear infinite; flex-shrink: 0; }
 @keyframes si-spin { to { transform: rotate(360deg); } }
 
-.si-error { background: var(--color-error-muted); border: 1px solid rgba(220,38,38,0.2); border-radius: 8px; padding: 12px 16px; color: var(--color-error); font-size: 0.8rem; margin-bottom: 16px; }
+.si-error { background: var(--color-error-muted); border: 1px solid rgba(220,38,38,0.2); border-radius: var(--radius-md); padding: 12px 16px; color: var(--color-error); font-size: 0.8rem; margin-bottom: 16px; }
 
-.si-tabs { display: flex; gap: 4px; margin-bottom: 20px; background: var(--color-bg-elevated); border-radius: 10px; padding: 4px; }
-.si-tab { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px; height: 36px; font-size: 0.8rem; font-weight: 500; color: var(--color-text-muted); background: transparent; border: none; border-radius: 8px; cursor: pointer; }
-.si-tab.active { background: var(--color-bg-card); color: var(--color-text-primary); font-weight: 600; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
-.si-tab-count { font-size: 0.7rem; background: var(--color-bg-hover); padding: 1px 7px; border-radius: 99px; }
+.si-tabs { display: flex; gap: 4px; margin-bottom: 20px; background: var(--color-bg-elevated); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); padding: 4px; }
+.si-tab { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 5px; height: 36px; font-size: 0.8rem; font-weight: 500; color: var(--color-text-muted); background: transparent; border: none; border-radius: var(--radius-sm); cursor: pointer; }
+.si-tab:hover:not(.active):not(.si-tab-disabled) { color: var(--color-text-secondary); }
+.si-tab.active { background: var(--color-bg-card); color: var(--color-text-primary); font-weight: 600; box-shadow: 0 1px 3px rgba(30,41,59,0.08); }
+.si-tab-count { font-size: 0.7rem; background: var(--color-bg-hover); color: var(--color-text-muted); padding: 1px 7px; border-radius: 99px; }
 .si-tab.active .si-tab-count { background: var(--color-accent-muted); color: var(--color-accent); }
+.si-tab-disabled { opacity: 0.45; cursor: default !important; }
 
 .si-competitors { display: flex; flex-direction: column; gap: 12px; }
-.si-comp-card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 10px; overflow: hidden; }
-.si-comp-header { display: flex; justify-content: space-between; align-items: center; width: 100%; padding: 14px 18px; background: transparent; border: none; color: var(--color-text-primary); cursor: pointer; text-align: left; }
+.si-comp-card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); overflow: hidden; }
+.si-comp-header { display: flex; justify-content: space-between; align-items: center; width: 100%; padding: 14px 18px; background: transparent; border: none; color: var(--color-text-primary); cursor: pointer; text-align: left; gap: 12px; }
 .si-comp-header:hover { background: var(--color-bg-hover); }
 .si-comp-name { font-size: 0.95rem; font-weight: 600; }
 .si-comp-meta { display: flex; gap: 12px; align-items: center; }
@@ -37,7 +44,7 @@
 .si-comp-count { font-size: 0.7rem; color: var(--color-accent); font-weight: 500; }
 
 .si-items { padding: 0 18px 16px; display: flex; flex-direction: column; gap: 12px; }
-.si-item { background: var(--color-bg-elevated); border: 1px solid var(--color-border-subtle); border-radius: 8px; padding: 14px 16px; }
+.si-item { background: var(--color-bg-elevated); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm); padding: 14px 16px; }
 .si-item-header { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
 .si-severity { font-size: 0.65rem; font-weight: 700; letter-spacing: 0.05em; }
 .si-type { font-size: 0.65rem; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
@@ -49,490 +56,104 @@
 .si-vulnerability, .si-diff-angle { font-size: 0.8rem; color: var(--color-text-primary); line-height: 1.5; }
 
 .si-empty { font-size: 0.8rem; color: var(--color-text-muted); padding: 8px 0; }
-
 .si-empty-state { text-align: center; padding: 60px 20px; }
 .si-empty-title { font-size: 1.1rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: 8px; }
 .si-empty-body { font-size: 0.85rem; color: var(--color-text-muted); max-width: 480px; margin: 0 auto 20px; line-height: 1.5; }
 
 /* Gap Map */
-.si-gap-position {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--color-text-primary, #e2e8f0);
-  line-height: 1.4;
-}
-.si-gap-score {
-  font-size: 0.8rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-}
-.si-gap-section {
-  padding: 10px 0;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
-}
+.si-gap-position { font-size: 0.95rem; font-weight: 600; color: var(--color-text-primary); line-height: 1.4; }
+.si-gap-score { font-size: 0.8rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.si-gap-section { padding: 10px 0; border-bottom: 1px solid var(--color-border-subtle); }
 .si-gap-section:last-child { border-bottom: none; }
-.si-gap-label {
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-text-muted, #94a3b8);
-  margin-bottom: 4px;
-}
-.si-gap-text {
-  font-size: 0.85rem;
-  color: var(--color-text-primary, #e2e8f0);
-  line-height: 1.55;
-}
-.si-gap-board {
-  background: rgba(53, 99, 255, 0.06);
-  border: 1px solid rgba(53, 99, 255, 0.12);
-  border-radius: 8px;
-  padding: 12px;
-  margin: 8px 0;
-}
-.si-gap-board .si-gap-label {
-  color: #3563ff;
-}
-
-/* Tab disabled + soon badge */
-.si-tab-disabled {
-  opacity: 0.45;
-  cursor: default !important;
-}
-.si-tab-soon {
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  background: rgba(255,255,255,0.06);
-  padding: 1px 5px;
-  border-radius: 3px;
-  margin-left: 4px;
-}
-
-/* Tab icon alignment */
-.si-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-}
+.si-gap-label { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-muted); margin-bottom: 4px; }
+.si-gap-text { font-size: 0.85rem; color: var(--color-text-primary); line-height: 1.55; }
+.si-gap-board { background: var(--color-accent-muted); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm); padding: 12px; margin: 8px 0; }
+.si-gap-board .si-gap-label { color: var(--color-accent); }
+.si-gap-experiential { background: var(--color-accent-muted); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm); padding: 12px; margin: 8px 0; }
+.si-gap-experiential .si-gap-label { color: var(--color-accent); }
 
 /* Blind Spots */
-.si-blind-role {
-  font-size: 0.75rem;
-  color: var(--color-text-muted, #94a3b8);
-  font-style: italic;
-}
+.si-blind-role { font-size: 0.75rem; color: var(--color-text-muted); font-style: italic; }
 
 /* Whitespace */
-.si-ws-controller {
-  font-size: 0.75rem;
-  color: var(--color-text-muted, #94a3b8);
-}
-.si-ws-platforms {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px 0;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
-}
-.si-ws-platform {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.si-ws-plat-name {
-  font-size: 0.72rem;
-  color: var(--color-text-muted, #94a3b8);
-  width: 80px;
-  flex-shrink: 0;
-}
-.si-ws-bar {
-  flex: 1;
-  height: 6px;
-  background: rgba(255,255,255,0.06);
-  border-radius: 3px;
-  overflow: hidden;
-}
-.si-ws-bar-fill {
-  height: 100%;
-  border-radius: 3px;
-  transition: width 0.4s ease;
-}
-.si-ws-plat-score {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: var(--color-text-primary, #e2e8f0);
-  width: 24px;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-.si-ws-qw {
-  font-size: 0.75rem;
-  margin-left: 8px;
-}
-
-.si-gap-experiential {
-  background: rgba(139, 92, 246, 0.06);
-  border: 1px solid rgba(139, 92, 246, 0.12);
-  border-radius: 8px;
-  padding: 12px;
-  margin: 8px 0;
-}
-.si-gap-experiential .si-gap-label {
-  color: #8b5cf6;
-}
+.si-ws-controller { font-size: 0.75rem; color: var(--color-text-muted); }
+.si-ws-platforms { display: flex; flex-direction: column; gap: 8px; padding: 12px 0; border-bottom: 1px solid var(--color-border-subtle); }
+.si-ws-platform { display: flex; align-items: center; gap: 10px; }
+.si-ws-plat-name { font-size: 0.72rem; color: var(--color-text-muted); width: 80px; flex-shrink: 0; }
+.si-ws-bar { flex: 1; height: 6px; background: var(--color-bg-hover); border-radius: 3px; overflow: hidden; }
+.si-ws-bar-fill { height: 100%; border-radius: 3px; background: var(--color-accent); transition: width 0.4s ease; }
+.si-ws-plat-score { font-size: 0.72rem; font-weight: 600; color: var(--color-text-primary); width: 24px; text-align: right; font-variant-numeric: tabular-nums; }
+.si-ws-qw { font-size: 0.75rem; margin-left: 8px; color: var(--color-warning); font-weight: 600; }
 
 /* Positioning Pivot */
-.si-pivot {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-.si-pivot-statement {
-  font-size: 1.3rem;
-  font-weight: 700;
-  color: #1e293b;
-  line-height: 1.4;
-  padding: 24px;
-  background: linear-gradient(135deg, #c7d7ff, #ddd6fe);
-  border: 1px solid rgba(53, 99, 255, 0.3);
-  border-radius: 12px;
-}
-.si-pivot-fromto {
-  display: flex;
-  align-items: stretch;
-  gap: 16px;
-}
-.si-pivot-from, .si-pivot-to {
-  flex: 1;
-  padding: 16px;
-  border-radius: 10px;
-}
-.si-pivot-from {
-  background: rgba(239, 68, 68, 0.06);
-  border: 1px solid rgba(239, 68, 68, 0.15);
-}
-.si-pivot-to {
-  background: rgba(20, 184, 166, 0.06);
-  border: 1px solid rgba(20, 184, 166, 0.15);
-}
-.si-pivot-fromto-label {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 6px;
-}
-.si-pivot-from .si-pivot-fromto-label { color: #ef4444; }
-.si-pivot-to .si-pivot-fromto-label { color: #14b8a6; }
-.si-pivot-fromto-text {
-  font-size: 0.88rem;
-  color: var(--color-text-primary, #e2e8f0);
-  line-height: 1.5;
-}
-.si-pivot-arrow {
-  display: flex;
-  align-items: center;
-  font-size: 1.5rem;
-  color: var(--color-text-muted, #94a3b8);
-  flex-shrink: 0;
-}
-.si-pivot-section {
-  padding: 16px;
-  background: var(--color-bg-card, #12141a);
-  border: 1px solid var(--color-border, rgba(255,255,255,0.06));
-  border-radius: 10px;
-}
-.si-pivot-evidence {
-  padding: 16px;
-  background: var(--color-bg-card, #12141a);
-  border: 1px solid var(--color-border, rgba(255,255,255,0.06));
-  border-radius: 10px;
-}
-.si-pivot-evidence-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
-  margin-top: 10px;
-}
-.si-pivot-ev-card {
-  padding: 12px;
-  background: rgba(255,255,255,0.02);
-  border: 1px solid rgba(255,255,255,0.05);
-  border-radius: 8px;
-}
-.si-pivot-ev-dim {
-  font-size: 0.68rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #3563ff;
-  margin-bottom: 6px;
-}
-.si-pivot-ev-text {
-  font-size: 0.8rem;
-  color: var(--color-text-primary, #e2e8f0);
-  line-height: 1.5;
-}
-.si-pivot-moves {
-  padding: 16px;
-  background: var(--color-bg-card, #12141a);
-  border: 1px solid var(--color-border, rgba(255,255,255,0.06));
-  border-radius: 10px;
-}
-.si-pivot-move {
-  display: flex;
-  gap: 14px;
-  padding: 14px 0;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
-}
+.si-pivot { display: flex; flex-direction: column; gap: 24px; }
+.si-pivot-statement { font-size: 1.3rem; font-weight: 700; color: var(--color-text-emphasis); line-height: 1.4; padding: 24px; background: var(--color-accent-muted); border: 1px solid var(--color-accent-70); border-radius: var(--radius-md); }
+.si-pivot-fromto { display: flex; align-items: stretch; gap: 16px; }
+.si-pivot-from, .si-pivot-to { flex: 1; padding: 16px; border-radius: var(--radius-md); }
+.si-pivot-from { background: var(--color-error-muted); border: 1px solid rgba(220,38,38,0.15); }
+.si-pivot-to { background: var(--color-success-muted); border: 1px solid rgba(14,165,114,0.18); }
+.si-pivot-fromto-label { font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 6px; }
+.si-pivot-from .si-pivot-fromto-label { color: var(--color-error); }
+.si-pivot-to .si-pivot-fromto-label { color: var(--color-success); }
+.si-pivot-fromto-text { font-size: 0.88rem; color: var(--color-text-primary); line-height: 1.5; }
+.si-pivot-arrow { display: flex; align-items: center; font-size: 1.5rem; color: var(--color-text-muted); flex-shrink: 0; }
+.si-pivot-section, .si-pivot-evidence, .si-pivot-moves { padding: 16px; background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); }
+.si-pivot-evidence-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-top: 10px; }
+.si-pivot-ev-card { padding: 12px; background: var(--color-bg-elevated); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm); }
+.si-pivot-ev-dim { font-size: 0.68rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-accent); margin-bottom: 6px; }
+.si-pivot-ev-text { font-size: 0.8rem; color: var(--color-text-primary); line-height: 1.5; }
+.si-pivot-move { display: flex; gap: 14px; padding: 14px 0; border-bottom: 1px solid var(--color-border-subtle); }
 .si-pivot-move:last-child { border-bottom: none; }
-.si-pivot-move-num {
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(53, 99, 255, 0.12);
-  color: #3563ff;
-  font-weight: 700;
-  font-size: 0.8rem;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.si-pivot-move-body {
-  flex: 1;
-  min-width: 0;
-}
-.si-pivot-move-title {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--color-text-primary, #e2e8f0);
-  margin-bottom: 4px;
-}
-.si-pivot-move-rationale {
-  font-size: 0.8rem;
-  color: var(--color-text-muted, #94a3b8);
-  margin-bottom: 4px;
-  line-height: 1.45;
-}
-.si-pivot-move-outcome {
-  font-size: 0.8rem;
-  color: #14b8a6;
-  line-height: 1.45;
-}
-.si-pivot-stop {
-  padding: 16px;
-  background: rgba(239, 68, 68, 0.04);
-  border: 1px solid rgba(239, 68, 68, 0.12);
-  border-radius: 10px;
-}
-.si-pivot-stop .si-gap-label {
-  color: #ef4444;
-}
-.si-pivot-board {
-  padding: 24px;
-  background: linear-gradient(135deg, #c7d7ff, #ccfbf1);
-  border: 1px solid rgba(53, 99, 255, 0.25);
-  border-radius: 12px;
-}
-.si-pivot-board .si-gap-label {
-  color: #1e40af;
-  font-size: 0.72rem;
-  margin-bottom: 10px;
-}
-.si-pivot-board-text {
-  font-size: 1.05rem;
-  font-weight: 500;
-  color: #1e293b;
-  line-height: 1.7;
-}
+.si-pivot-move-num { width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; background: var(--color-accent-muted); color: var(--color-accent); font-weight: 700; font-size: 0.8rem; border-radius: 50%; flex-shrink: 0; }
+.si-pivot-move-body { flex: 1; min-width: 0; }
+.si-pivot-move-title { font-size: 0.9rem; font-weight: 600; color: var(--color-text-primary); margin-bottom: 4px; }
+.si-pivot-move-rationale { font-size: 0.8rem; color: var(--color-text-secondary); margin-bottom: 4px; line-height: 1.45; }
+.si-pivot-move-outcome { font-size: 0.8rem; color: var(--color-success); line-height: 1.45; }
+.si-pivot-stop { padding: 16px; background: var(--color-error-muted); border: 1px solid rgba(220,38,38,0.12); border-radius: var(--radius-md); }
+.si-pivot-stop .si-gap-label { color: var(--color-error); }
+.si-pivot-board { padding: 24px; background: var(--color-accent-muted); border: 1px solid var(--color-accent-70); border-radius: var(--radius-md); }
+.si-pivot-board .si-gap-label { color: var(--color-accent); font-size: 0.72rem; margin-bottom: 10px; }
+.si-pivot-board-text { font-size: 1.05rem; font-weight: 500; color: var(--color-text-emphasis); line-height: 1.7; }
 
 /* Share button + banner */
-.si-btn-share {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 34px;
-  padding: 0 14px;
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: #ffffff;
-  background: #3563ff;
-  border: 1px solid #3563ff;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: opacity 0.15s;
-}
-.si-btn-share:hover { opacity: 0.85; }
-.si-btn-share:disabled { opacity: 0.5; cursor: default; }
-.si-share-banner {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
-  background: rgba(20, 184, 166, 0.08);
-  border: 1px solid rgba(20, 184, 166, 0.2);
-  border-radius: 8px;
-  font-size: 0.8rem;
-  color: #94a3b8;
-  margin-bottom: 8px;
-}
-.si-share-banner a {
-  color: #14b8a6;
-  text-decoration: none;
-  font-weight: 500;
-  word-break: break-all;
-}
+.si-btn-share { display: inline-flex; align-items: center; gap: 6px; height: 34px; padding: 0 14px; font-size: 0.78rem; font-weight: 600; color: #fff; background: var(--color-accent); border: 1px solid var(--color-accent); border-radius: var(--radius-md); cursor: pointer; transition: background 0.15s; }
+.si-btn-share:hover:not(:disabled) { background: var(--color-accent-hover); }
+.si-btn-share:disabled { opacity: 0.45; cursor: not-allowed; }
+.si-share-banner { display: flex; align-items: center; gap: 10px; padding: 10px 16px; background: var(--color-success-muted); border: 1px solid rgba(14,165,114,0.2); border-radius: var(--radius-md); font-size: 0.8rem; color: var(--color-text-secondary); margin-bottom: 8px; }
+.si-share-banner a { color: var(--color-success); text-decoration: none; font-weight: 500; word-break: break-all; }
 .si-share-banner a:hover { text-decoration: underline; }
-.si-share-dismiss {
-  margin-left: auto;
-  background: none;
-  border: none;
-  color: #64748b;
-  font-size: 1.1rem;
-  cursor: pointer;
-  padding: 0 4px;
-}
+.si-share-dismiss { margin-left: auto; background: none; border: none; color: var(--color-text-muted); font-size: 1.1rem; cursor: pointer; padding: 0 4px; }
 
 /* Compliance gate */
-.si-btn-compliance {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 34px;
-  padding: 0 14px;
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: #f5b942;
-  background: rgba(245, 185, 66, 0.08);
-  border: 1px solid rgba(245, 185, 66, 0.2);
-  border-radius: 8px;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-.si-btn-compliance:hover { background: rgba(245, 185, 66, 0.14); }
-
-.si-btn-compliance-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 34px;
-  padding: 0 14px;
-  font-size: 0.78rem;
-  font-weight: 600;
-  border-radius: 8px;
-  cursor: pointer;
-  background: none;
-  border: 1px solid rgba(255,255,255,0.1);
-  color: #e2e8f0;
-  transition: background 0.15s;
-}
-.si-btn-compliance-status:hover { background: rgba(255,255,255,0.04); }
+.si-btn-compliance { display: inline-flex; align-items: center; gap: 6px; height: 34px; padding: 0 14px; font-size: 0.78rem; font-weight: 600; color: var(--color-warning); background: var(--color-warning-muted); border: 1px solid rgba(217,119,6,0.22); border-radius: var(--radius-md); cursor: pointer; transition: background 0.15s; }
+.si-btn-compliance:hover:not(:disabled) { background: rgba(217,119,6,0.18); }
+.si-btn-compliance:disabled { opacity: 0.6; cursor: default; }
+.si-btn-compliance-status { display: inline-flex; align-items: center; gap: 6px; height: 34px; padding: 0 14px; font-size: 0.78rem; font-weight: 600; border-radius: var(--radius-md); cursor: pointer; background: var(--color-bg-card); border: 1px solid var(--color-border); color: var(--color-text-primary); transition: background 0.15s; }
+.si-btn-compliance-status:hover { background: var(--color-bg-hover); }
 
 /* Compliance panel */
-.si-compliance-panel {
-  background: var(--color-bg-card, #12141a);
-  border: 1px solid rgba(255,255,255,0.08);
-  border-radius: 12px;
-  margin-bottom: 16px;
-  overflow: hidden;
-}
-.si-compliance-header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 14px 18px;
-  border-bottom: 1px solid rgba(255,255,255,0.06);
-  flex-wrap: wrap;
-}
-.si-compliance-title {
-  font-size: 0.9rem;
-  font-weight: 700;
-  color: var(--color-text-primary, #e2e8f0);
-}
-.si-compliance-summary {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex: 1;
-}
-.si-compliance-stat {
-  font-size: 0.72rem;
-  font-weight: 600;
-  padding: 3px 8px;
-  border-radius: 4px;
-}
-.si-compliance-verified { color: #14b8a6; background: rgba(20, 184, 166, 0.1); }
-.si-compliance-inferred { color: #f5b942; background: rgba(245, 185, 66, 0.1); }
-.si-compliance-unverified { color: #ef4444; background: rgba(239, 68, 68, 0.1); }
-.si-compliance-pass {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-text-muted, #94a3b8);
-  margin-left: auto;
-}
-.si-compliance-close {
-  background: none;
-  border: none;
-  color: #64748b;
-  font-size: 1.2rem;
-  cursor: pointer;
-  padding: 0 4px;
-}
+.si-compliance-panel { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-md); margin-bottom: 16px; overflow: hidden; }
+.si-compliance-header { display: flex; align-items: center; gap: 16px; padding: 14px 18px; border-bottom: 1px solid var(--color-border-subtle); flex-wrap: wrap; }
+.si-compliance-title { font-size: 0.9rem; font-weight: 700; color: var(--color-text-primary); }
+.si-compliance-summary { display: flex; align-items: center; gap: 12px; flex: 1; }
+.si-compliance-stat { font-size: 0.72rem; font-weight: 600; padding: 3px 8px; border-radius: var(--radius-sm); }
+.si-compliance-verified { color: var(--color-success); background: var(--color-success-muted); }
+.si-compliance-inferred { color: var(--color-warning); background: var(--color-warning-muted); }
+.si-compliance-unverified { color: var(--color-error); background: var(--color-error-muted); }
+.si-compliance-pass { font-size: 0.75rem; font-weight: 600; color: var(--color-text-muted); margin-left: auto; }
+.si-compliance-close { background: none; border: none; color: var(--color-text-muted); font-size: 1.2rem; cursor: pointer; padding: 0 4px; }
 
 /* Findings */
-.si-compliance-findings {
-  max-height: 480px;
-  overflow-y: auto;
-  padding: 8px 0;
-}
-.si-compliance-finding {
-  padding: 12px 18px;
-  border-bottom: 1px solid rgba(255,255,255,0.03);
-}
+.si-compliance-findings { max-height: 480px; overflow-y: auto; padding: 8px 0; }
+.si-compliance-finding { padding: 12px 18px; border-bottom: 1px solid var(--color-border-subtle); }
 .si-compliance-finding:last-child { border-bottom: none; }
-.si-compliance-finding-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
-}
-.si-compliance-badge {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 2px 7px;
-  border-radius: 4px;
-}
-.si-badge-verified { color: #14b8a6; background: rgba(20, 184, 166, 0.1); }
-.si-badge-inferred { color: #f5b942; background: rgba(245, 185, 66, 0.1); }
-.si-badge-unverified { color: #ef4444; background: rgba(239, 68, 68, 0.1); }
-.si-compliance-deliverable {
-  font-size: 0.7rem;
-  color: #64748b;
-  text-transform: capitalize;
-}
-.si-compliance-claim {
-  font-size: 0.82rem;
-  color: var(--color-text-primary, #e2e8f0);
-  line-height: 1.5;
-  margin-bottom: 6px;
-  font-style: italic;
-}
-.si-compliance-source {
-  font-size: 0.75rem;
-  color: #14b8a6;
-  margin-bottom: 3px;
-}
-.si-compliance-issue {
-  font-size: 0.75rem;
-  color: #ef4444;
-  margin-bottom: 3px;
-}
-.si-compliance-rec {
-  font-size: 0.75rem;
-  color: #f5b942;
-}
+.si-compliance-finding-header { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.si-compliance-badge { font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; padding: 2px 7px; border-radius: var(--radius-sm); }
+.si-badge-verified { color: var(--color-success); background: var(--color-success-muted); }
+.si-badge-inferred { color: var(--color-warning); background: var(--color-warning-muted); }
+.si-badge-unverified { color: var(--color-error); background: var(--color-error-muted); }
+.si-compliance-deliverable { font-size: 0.7rem; color: var(--color-text-muted); text-transform: capitalize; }
+.si-compliance-claim { font-size: 0.82rem; color: var(--color-text-primary); line-height: 1.5; margin-bottom: 6px; font-style: italic; }
+.si-compliance-source { font-size: 0.75rem; color: var(--color-success); margin-bottom: 3px; }
+.si-compliance-issue { font-size: 0.75rem; color: var(--color-error); margin-bottom: 3px; }
+.si-compliance-rec { font-size: 0.75rem; color: var(--color-warning); }

--- a/src/pages/StrategyIntelPage.tsx
+++ b/src/pages/StrategyIntelPage.tsx
@@ -121,7 +121,7 @@ class TabErrorBoundary extends Component<{ children: ReactNode }, { failed: bool
   componentDidCatch(err: any) { console.error('[StrategyIntel] tab render error:', err); }
   render() {
     if (this.state.failed) {
-      return <div className="si-error">This deliverable couldn't be displayed — its data may be malformed. Try Re-analyze to regenerate it.</div>;
+      return <div className="si-error">This deliverable couldn't be displayed. Its data may be malformed; try Re-analyze to regenerate it.</div>;
     }
     return this.props.children;
   }
@@ -458,9 +458,11 @@ export default function StrategyIntelPage() {
     finally { setSharing(false); }
   };
 
-  const severityColor = (s: string) => s === 'high' ? '#ef4444' : s === 'medium' ? '#f5b942' : '#94a3b8';
-  const priorityColor = (p: string) => p === 'high' ? '#3563ff' : p === 'medium' ? '#8b5cf6' : '#94a3b8';
-  const scoreColor = (s: number) => s >= 75 ? '#14b8a6' : s >= 50 ? '#f5b942' : '#ef4444';
+  // Tier/score colors map to the brand token set (green/amber/red/blue), not the
+  // old off-brand teal/purple hardcodes. CSS vars resolve fine inside inline styles.
+  const severityColor = (s: string) => s === 'high' ? 'var(--color-error)' : s === 'medium' ? 'var(--color-warning)' : 'var(--color-text-muted)';
+  const priorityColor = (p: string) => p === 'high' ? 'var(--color-accent)' : p === 'medium' ? 'var(--color-warning)' : 'var(--color-text-muted)';
+  const scoreColor = (s: number) => s >= 75 ? 'var(--color-success)' : s >= 50 ? 'var(--color-warning)' : 'var(--color-error)';
 
   const runAction = activeTab === 'gap_map' ? runGapMap
     : activeTab === 'blind_spots' ? runBlindSpots
@@ -546,7 +548,7 @@ export default function StrategyIntelPage() {
                 <span className="si-compliance-stat si-compliance-verified">{complianceReport.summary?.verified || 0} Verified</span>
                 <span className="si-compliance-stat si-compliance-inferred">{complianceReport.summary?.inferred || 0} Inferred</span>
                 <span className="si-compliance-stat si-compliance-unverified">{complianceReport.summary?.unverified || 0} Unverified</span>
-                <span className="si-compliance-pass">Pass rate: {complianceReport.summary?.passRate || '—'}</span>
+                <span className="si-compliance-pass">Pass rate: {complianceReport.summary?.passRate || 'n/a'}</span>
               </div>
               <button className="si-compliance-close" onClick={() => setComplianceExpanded(false)}>×</button>
             </div>
@@ -601,13 +603,15 @@ export default function StrategyIntelPage() {
         </div>
 
         {/* Progress feed */}
-        {isRunning && (
+        {(isRunning || complianceRunning) && (
           <div className="si-progress">
-            <div className="si-progress-title">Analyzing...</div>
+            <div className="si-progress-title">
+              <span className="si-progress-spinner" />
+              {complianceRunning ? 'Running Compliance Check...' : 'Analyzing...'}
+            </div>
             {progress.map((msg, i) => (
               <div key={i} className="si-progress-line">{msg}</div>
             ))}
-            <div className="si-progress-spinner" />
           </div>
         )}
 
@@ -759,7 +763,7 @@ export default function StrategyIntelPage() {
           <div className="si-competitors">
             {blindSpots.map((spot, i) => {
               const isExpanded = expandedSpot === i;
-              const sizeColor = spot.opportunitySize === 'large' ? '#14b8a6' : spot.opportunitySize === 'medium' ? '#f5b942' : '#94a3b8';
+              const sizeColor = spot.opportunitySize === 'large' ? 'var(--color-success)' : spot.opportunitySize === 'medium' ? 'var(--color-warning)' : 'var(--color-text-muted)';
               return (
                 <div key={i} className="si-comp-card">
                   <button className="si-comp-header" onClick={() => setExpandedSpot(isExpanded ? null : i)}>
@@ -828,8 +832,8 @@ export default function StrategyIntelPage() {
           <div className="si-competitors">
             {territories.map((t, i) => {
               const isExpanded = expandedTerritory === i;
-              const visColor = t.brandVisibility <= 30 ? '#ef4444' : t.brandVisibility <= 55 ? '#f5b942' : '#94a3b8';
-              const diffColor = t.reclaimDifficulty === 'low' ? '#14b8a6' : t.reclaimDifficulty === 'medium' ? '#f5b942' : '#ef4444';
+              const visColor = t.brandVisibility <= 30 ? 'var(--color-error)' : t.brandVisibility <= 55 ? 'var(--color-warning)' : 'var(--color-text-muted)';
+              const diffColor = t.reclaimDifficulty === 'low' ? 'var(--color-success)' : t.reclaimDifficulty === 'medium' ? 'var(--color-warning)' : 'var(--color-error)';
               return (
                 <div key={i} className="si-comp-card">
                   <button className="si-comp-header" onClick={() => setExpandedTerritory(isExpanded ? null : i)}>
@@ -847,22 +851,22 @@ export default function StrategyIntelPage() {
                         <div className="si-ws-platforms">
                           <div className="si-ws-platform">
                             <span className="si-ws-plat-name">ChatGPT</span>
-                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.chatgpt || 0}%`, background: '#14b8a6' }} /></div>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.chatgpt || 0}%` }} /></div>
                             <span className="si-ws-plat-score">{t.platformBreakdown?.chatgpt || 0}</span>
                           </div>
                           <div className="si-ws-platform">
                             <span className="si-ws-plat-name">Perplexity</span>
-                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.perplexity || 0}%`, background: '#8b5cf6' }} /></div>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.perplexity || 0}%` }} /></div>
                             <span className="si-ws-plat-score">{t.platformBreakdown?.perplexity || 0}</span>
                           </div>
                           <div className="si-ws-platform">
                             <span className="si-ws-plat-name">Gemini</span>
-                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.gemini || 0}%`, background: '#3563ff' }} /></div>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.gemini || 0}%` }} /></div>
                             <span className="si-ws-plat-score">{t.platformBreakdown?.gemini || 0}</span>
                           </div>
                           <div className="si-ws-platform">
                             <span className="si-ws-plat-name">AI Overviews</span>
-                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.aiOverviews || 0}%`, background: '#f5b942' }} /></div>
+                            <div className="si-ws-bar"><div className="si-ws-bar-fill" style={{ width: `${t.platformBreakdown?.aiOverviews || 0}%` }} /></div>
                             <span className="si-ws-plat-score">{t.platformBreakdown?.aiOverviews || 0}</span>
                           </div>
                         </div>
@@ -989,8 +993,8 @@ export default function StrategyIntelPage() {
             <div className="si-empty-body">
               {activeTab === 'gap_map' && 'Forge will aggregate your GEO topical authority gaps, competitor positioning, and vulnerability data to identify undefended market positions no competitor currently owns.'}
               {activeTab === 'pivot' && 'Forge synthesizes all five intelligence dimensions to find the ONE positioning move that exploits every gap, vulnerability, blind spot, and invisible conversation simultaneously. Run the other analyses first.'}
-              {activeTab === 'whitespace' && 'Forge will map every conversation happening on ChatGPT, Perplexity, Gemini, and AI Overviews where your brand is invisible — who controls the narrative, what it costs you, and how to reclaim territory.'}
-              {activeTab === 'blind_spots' && 'Forge will analyze your personas, competitor positioning, and topical gaps to identify audience segments the entire market is ignoring — buyers nobody is speaking to that your brand can own.'}
+              {activeTab === 'whitespace' && 'Forge will map every conversation happening on ChatGPT, Perplexity, Gemini, and AI Overviews where your brand is invisible: who controls the narrative, what it costs you, and how to reclaim territory.'}
+              {activeTab === 'blind_spots' && 'Forge will analyze your personas, competitor positioning, and topical gaps to identify audience segments the entire market is ignoring: buyers nobody is speaking to that your brand can own.'}
               {(activeTab === 'pva' || activeTab === 'faultlines') && 'Forge will scrape your competitors\' public positioning pages, identify vulnerabilities in their claims, and map the exact language they use so you can differentiate against it.'}
             </div>
             <button className="si-btn-primary" onClick={() => runAction && runAction(false)}>

--- a/src/server/routes/strategy.js
+++ b/src/server/routes/strategy.js
@@ -21,6 +21,11 @@ import { requireAuth } from '../auth.js';
 
 const router = express.Router();
 
+// Appended to every deliverable prompt. The generated brief text was littered
+// with em-dashes (the prompts themselves modeled them); this forbids them so the
+// board-facing output reads clean, matching the rest of Forge's content rules.
+const NO_EM_DASH = '\n\nSTYLE (mandatory): Write in plain prose. Do NOT use em-dashes (the — character) anywhere in your output; use commas, colons, parentheses, or separate sentences instead.';
+
 // Container-type normalizers for stored deliverable JSONB. Historically one
 // gap_map row was persisted double-encoded (data.gaps = a JSON *string*, not an
 // array — the pg driver parses the outer JSONB but leaves the inner string),
@@ -181,7 +186,7 @@ Sort by opportunityScore descending. Be ruthlessly specific — no generic strat
     const synthesisRes = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 6144,
-      messages: [{ role: 'user', content: synthesisPrompt }]
+      messages: [{ role: 'user', content: synthesisPrompt + NO_EM_DASH }]
     });
 
     let gaps = [];
@@ -368,7 +373,7 @@ Sort by opportunitySize (large first). Be ruthlessly specific — name real role
     const synthesisRes = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 6144,
-      messages: [{ role: 'user', content: prompt }]
+      messages: [{ role: 'user', content: prompt + NO_EM_DASH }]
     });
 
     let blindSpots = [];
@@ -557,7 +562,7 @@ Sort by brandVisibility ascending (most invisible first). Be brutally specific �
     const synthesisRes = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 8192,
-      messages: [{ role: 'user', content: prompt }]
+      messages: [{ role: 'user', content: prompt + NO_EM_DASH }]
     });
 
     let territories = [];
@@ -767,7 +772,7 @@ Be ruthlessly specific. Name competitors. Name products. Name audiences. This is
     const synthesisRes = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 4096,
-      messages: [{ role: 'user', content: prompt }]
+      messages: [{ role: 'user', content: prompt + NO_EM_DASH }]
     });
 
     let pivot = null;
@@ -1069,7 +1074,7 @@ Sort findings: unverified first, then inferred, then verified. Within each tier,
     const auditRes = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 8192,
-      messages: [{ role: 'user', content: auditPrompt }]
+      messages: [{ role: 'user', content: auditPrompt + NO_EM_DASH }]
     });
 
     let report = null;


### PR DESCRIPTION
## Why

Not another patch — a front-to-back pass on the three things wrong with Brand Intelligence, all rooted in the page being recovered verbatim from April: it was built for a **dark theme with off-brand accents**, the **Compliance run gave no feedback**, and the **generated copy was full of em-dashes**.

## What

**1. CSS totally off-brand → full token-driven rebuild (`StrategyIntelPage.css`)**
The file carried dark-theme token *fallbacks* (`var(--color-bg-card, #12141a)`), **white-alpha borders** (`rgba(255,255,255,.04)` — invisible on the light theme), and hardcoded off-brand **teal `#14b8a6` / purple `#8b5cf6` / amber `#f5b942` / red `#ef4444`**. Rebuilt fully on `src/index.css` tokens:
- Tiers map to the brand set: success **green** / warning **amber** / error **red** / accent **blue**; purple dropped.
- Borders → `--color-border(-subtle)`, radii → `--radius`, backgrounds → `--color-bg-*`.
- The `tsx` color helpers (severity/priority/score/size/vis/diff) and the whitespace bars now return brand CSS vars instead of hardcodes (bars unified to one accent, no rainbow).

**2. Run Compliance gave no feedback ("all buttons go grey and nothing happens")**
The controls block is gated `!complianceRunning` so it vanished during a run, and the progress panel was gated on `isRunning` only (compliance sets `complianceRunning`), so nothing rendered. The progress panel now fires for `(isRunning || complianceRunning)` and shows a spinner + **"Running Compliance Check…"** + the live SSE progress lines, so it's obvious it ran (and the status button appears when it finishes).

**3. Em-dashes everywhere**
Stripped from user-facing UI copy (empty states, error boundary, confidential banner, pass-rate fallback), and — the real source — appended a **mandatory no-em-dash STYLE rule to every deliverable prompt** (gap-map / blind-spots / whitespace / pivot / compliance in `strategy.js`; PVA / fault-lines in `server.js`) so newly generated brief text comes out clean, matching the rest of Forge's content rules.

Also brand-aligned the public brief page's accent colors (`BrandIntelligenceBriefPage.css`) to the same tokens.

## Test plan

- `npx tsc --noEmit` clean; `npx vitest run` 199/199; no route changes.
- Grep audit: **0** off-brand hexes, **0** dark-theme fallbacks, **0** user-facing em-dashes.
- On dev: the workspace reads on-brand across all six tabs; **Run Compliance** shows a live running panel instead of going silent; re-running any analysis produces em-dash-free copy.

## Rollback

Revert the commit — CSS/copy/prompt changes only, no schema or route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_