### PR TITLE
fix(enricher): topic banner text was white on a pale tint (barely visible)

### DIFF
--- a/src/pages/GeoStrategistPage.css
+++ b/src/pages/GeoStrategistPage.css
@@ -560,11 +560,13 @@
 .enrich-topic-banner {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #ffffff;
+  /* Was color:#fff (a dark-theme leftover) on a pale tint — barely legible on the
+     light theme. Accent text on accent-muted is the app's readable banner pattern. */
+  color: var(--color-accent);
   padding: 8px 14px;
   margin-bottom: 12px;
-  background: rgba(53, 99, 255, 0.12);
-  border: 1px solid rgba(53, 99, 255, 0.15);
+  background: var(--color-accent-muted);
+  border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-sm);
   letter-spacing: 0.01em;
 }


### PR DESCRIPTION
## Why

The topic card on the Authenticity Enricher (the "currently enriching: `<topic>`" banner) was **white text on a pale lavender background** — near-invisible on the light theme. Caught on mobile (screenshot).

Root cause: `.enrich-topic-banner` (in `GeoStrategistPage.css`, shared by the enricher) had `color: #ffffff` on a `rgba(53,99,255,0.12)` tint — a **dark-theme leftover**. White-on-pale-blue fails contrast badly.

## What

Switched the banner to the app's readable accent-banner treatment: **accent-colored text on `--color-accent-muted`**, token-driven border. Clearly legible, on-brand, looks intentional.

Checked the other `color: #fff` in the same file — all sit on **solid `--color-accent`** (buttons/badges), which is correct high-contrast usage, so they were left alone.

## Test plan

- `npx tsc --noEmit` clean. CSS-only, no logic/route change.
- On dev: run an enrichment on the Authenticity Enricher (or GEO Strategist) → the topic banner reads clearly instead of ghosting into the background.

## Rollback

Revert the one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_