### PR TITLE
feat(writers): constrain rhetorical architecture, not just vocabulary

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,11 @@ import { pool } from './src/server/db.js';
 import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
 // Forbid em-dashes in Brand Intelligence PVA / Fault Lines output (matches the
 // strategy module + the rest of Forge's content style). Appended to those prompts.
-const STRATEGY_NO_EM_DASH = '\n\nSTYLE (mandatory): Write in plain prose. Do NOT use em-dashes (the — character) anywhere in your output; use commas, colons, parentheses, or separate sentences instead.';
+// NOTE: this deliberately does NOT say "use commas instead". Telling a model to
+// swap in a comma makes it comma-substitute without restructuring, producing
+// ungrammatical appositives (subject and verb split by an unmarked list) that
+// read worse than the dash did. Make it rewrite the sentence instead.
+const STRATEGY_NO_EM_DASH = '\n\nSTYLE (mandatory): Write in plain prose. Never emit the em-dash character (—). When a sentence wants one, REWRITE the sentence so it does not need one: split it into two sentences, or use a colon or parentheses. Do NOT simply drop a comma into the slot where the dash was, which leaves an ungrammatical sentence.';
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
 import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripScaffoldingArtifacts, stripEmDashes } from './src/server/text.js';
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
@@ -33,6 +37,7 @@ import { normalizeGeoData } from './src/server/geo.js';
 import { buildGhostJWT } from './src/server/ghost.js';
 import { PROMO_CODES } from './src/server/promo.js';
 import { substackGet } from './src/server/substack.js';
+import { ANTI_AI_STYLE } from './src/server/writing-style.js';
 import complianceRouter from './src/server/routes/compliance.js';
 import emailCampaignRouter from './src/server/routes/email-campaign.js';
 import socialGeneratorRouter from './src/server/routes/social-generator.js';
@@ -4108,7 +4113,7 @@ ${(() => {
       : '';
 
         const userPrompt = `Generate a long-form article using the following Brand Intelligence context.
-${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${territoriesBlock}${cgMeasuredBlock}${cgCompetitorBlock}${cgMoatsBlock}
+${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${ANTI_AI_STYLE}${territoriesBlock}${cgMeasuredBlock}${cgCompetitorBlock}${cgMoatsBlock}
 BRAND PROFILE:
 ${trimTo(profileData, 6000)}
 

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -18,6 +18,7 @@ import { requireAuth, verifyBrandAccess } from '../auth.js';
 import { stripScaffoldingArtifacts } from '../text.js';
 import { buildImagePrompt, generateHeroImage } from '../images.js';
 import { ensureGeneratedContentTable } from '../content-table.js';
+import { ANTI_AI_STYLE } from '../writing-style.js';
 
 const router = express.Router();
 
@@ -650,7 +651,7 @@ ${(() => {
 
 CAMPAIGN ANGLE (follow this precisely):
 ${JSON.stringify(angle, null, 2)}
-${factualGroundBlock}${territoriesBlock}${cpMeasuredBlock}${cpCompetitorBlock}${cpMoatsBlock}
+${factualGroundBlock}${ANTI_AI_STYLE}${territoriesBlock}${cpMeasuredBlock}${cpCompetitorBlock}${cpMoatsBlock}
 BRAND PROFILE:
 ${trimTo(profileData, 5000)}
 

--- a/src/server/writing-style.js
+++ b/src/server/writing-style.js
@@ -1,0 +1,84 @@
+// Anti-AI-tell style constraints for the long-form writers.
+//
+// Why this exists: a third-party AI-writing detector run against a published
+// Forge article found the vocabulary layer clean (no "delve"/"tapestry"/
+// "robust", no em dashes) but the RHETORICAL ARCHITECTURE fully intact and
+// extremely dense: 20+ "not X, it is Y" constructions (one per ~140 words),
+// rule-of-three scaffolding at the section level six times, verbatim concept
+// repetition across sections, and a case study with no company/year/number.
+// Its takeaway: "whoever built this pipeline solved the vocabulary problem and
+// skipped the structural one. Banning delve is cosmetic."
+//
+// The em-dash rule is the sharpest lesson. Telling a model "no em dashes, use
+// commas instead" makes it swap a comma in WITHOUT restructuring, producing
+// ungrammatical appositives that are a louder tell than the dash was:
+//   "Resonance, engagement metrics, time on page, email opens, asset
+//    downloads, is captured by nearly every martech configuration"
+// So the rule below bans the dash AND bans the comma substitution.
+//
+// Constraints are budgets, not bans: these are legitimate rhetorical moves that
+// only read as machine-written at pathological density.
+export const ANTI_AI_STYLE = `
+═══════════════════════════════════════════════════════════════════════════
+STYLE CONSTRAINTS — RHETORICAL ARCHITECTURE (mandatory)
+═══════════════════════════════════════════════════════════════════════════
+These govern SENTENCE SHAPE, not word choice. A clean vocabulary with this
+architecture still reads as machine-written. Treat each as a hard budget.
+
+1. NEGATIVE PARALLELISM — at most 2 in the entire article.
+   The pattern is "It is not X, it is Y" and every punctuation variant of it:
+   "X, not Y" / "X. Not Y." / "not just X but Y" / "This is not a P problem.
+   It is a Q problem." Swapping the punctuation does NOT make it a different
+   move. After two, make the point directly: state what is true and move on.
+
+2. NO EM DASHES, AND DO NOT SUBSTITUTE A COMMA.
+   Never emit the "—" character. When a sentence wants one, REWRITE the
+   sentence so it does not need one: split it in two, use a colon, or use
+   parentheses. Never drop a comma into a slot where a dash was doing the work
+   of setting off an appositive; that produces an ungrammatical sentence with
+   a subject and verb separated by an unmarked list. Read every sentence you
+   write for this specific failure before finalizing.
+
+3. VARY LIST LENGTH — do not default to three.
+   Three-item lists ("documented, versioned, and used") are the single most
+   common machine tell. Use 2, 4, or 5 items when that is what is true. Never
+   scaffold consecutive sections on a count ("Three failure modes", "three
+   signals", "three decisions"); at most ONE counted-list section heading per
+   article, and only when the count is real rather than chosen for balance.
+
+4. VARY SENTENCE LENGTH DELIBERATELY (burstiness).
+   Uniform 12-18 word sentences are a statistical fingerprint. Mix genuinely
+   short sentences with long complex ones inside the same paragraph. Do not
+   manufacture this with a staccato opener and then settle into a uniform
+   body; the variance has to run through the whole piece.
+
+5. NAMED SPECIFICS OR NOTHING — no evidence-shaped filler.
+   Never write an anonymized case study: "a recent B2B program review", "a
+   marketing team at a mid-market SaaS company", "one client saw". If you
+   cannot name the company, the year, and the actual number from FACTUAL
+   GROUND or the brief, cut the example entirely and make the argument on
+   mechanism instead. A plausible-sounding figure attached to nothing (a
+   "$200,000 program") is worse than no figure. Do not invent numbers.
+
+6. REPEAT NOUNS INSTEAD OF CYCLING SYNONYMS.
+   Referring to one thing as "the platform", then "the solution", then "the
+   system", then "the tooling" is a machine tell (elegant variation). Pick the
+   correct noun and reuse it.
+
+7. NO PUFFERY VERBS.
+   Never write that something "stands as", "serves as", "is a testament to",
+   "plays a vital/crucial/pivotal role", "underscores/highlights the
+   importance of", "marks a pivotal moment", or "leaves an indelible mark".
+   State what the thing does.
+
+8. LIMIT CORRELATIVE CONSTRUCTIONS.
+   "Not only... but also", "both... and", "whether... or" are fine once. Past
+   that they read as balanced-for-the-sake-of-balance.
+
+9. DO NOT RESTATE ACROSS SECTIONS.
+   Each section must advance the argument. If a sentence's claim already
+   appeared in an earlier section, cut it rather than rephrasing it. Looping
+   back to the opening thesis in later sections is the clearest sign of local
+   coherence without global structure.
+═══════════════════════════════════════════════════════════════════════════
+`;


### PR DESCRIPTION
## Why

An AI-writing detector run against a published Forge article came back **"likely AI-generated, high confidence"** — and the diagnosis was fair. The vocabulary layer is clean (no "delve"/"tapestry"/"robust", no em dashes) but the **rhetorical architecture** is fully intact and pathologically dense:

- **20+ "not X, it is Y" constructions** — roughly one per 140 words
- **Rule-of-three scaffolding at the section level six times** ("Three failure modes", "three signals", "three decisions"...)
- **Verbatim concept repetition** across sections (local coherence, no global structure)
- **A case study with no company, year, or number** — plus a "$200,000 program" figure attached to nothing

Its takeaway: *"whoever built this pipeline solved the vocabulary problem and skipped the structural one. Banning delve is cosmetic."*

**Two things I verified in code before changing anything:**
1. The detector guessed the broken appositives were **find-and-replace damage**. They aren't — there is **no mechanical em-dash stripper** anywhere in the content path. It's the model obeying a badly-worded ban.
2. A grep of the article writer for **any** structural constraint (parallelism, rule-of-three, sentence-length variance) returns **nothing**. The gap is real.

## What

**New `src/server/writing-style.js`** exporting `ANTI_AI_STYLE`, injected into **both** long-form writers (`server.js` article + `campaign.js`) immediately after FACTUAL GROUND. Nine budgets, grounded in the detector's own pattern reference:

| # | Constraint |
|---|---|
| 1 | Negative parallelism capped at **2 per article** (all punctuation variants are the same move) |
| 2 | No em dash **and no comma-substitution** — rewrite the sentence |
| 3 | Vary list length off three; at most one counted-list heading |
| 4 | Deliberate sentence-length variance (burstiness) |
| 5 | Named specifics or cut the example; never invent numbers |
| 6 | Repeat nouns instead of cycling synonyms |
| 7 | No puffery verbs ("stands as", "plays a vital role", "underscores") |
| 8 | Limit correlatives ("not only... but also") |
| 9 | No cross-section restatement |

**Also fixes `STRATEGY_NO_EM_DASH`** — which I wrote earlier today and which said *"use commas, colons, parentheses, or separate sentences instead."* Leading with "use commas" is the **actual cause** of the ungrammatical appositives the detector caught: told to swap in a comma, the model does exactly that without restructuring, splitting subject from verb with an unmarked list. Both rules now require rewriting the sentence.

These are **budgets, not bans** — legitimate rhetorical moves that only read as machine-written at density.

## Test plan

- `node --check` clean on all three files; `npx vitest run` **199/199**; no route changes (route snapshot unaffected).
- On dev: generate one article and one campaign article, then re-run the detector. Expect negative parallelism ≤ 2, no counted-section stacking, no anonymized case study, and no comma-appositive breakage.

## Rollback

Revert the commit — prompt-text only, no schema/route/behavior change.

## Note

Existing published articles keep their current prose; this only affects new generations. Worth spot-checking one fresh article before promoting to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3K76ZuFvWD2d6VN2xKGKG)_