### PR TITLE
fix(content-gen): anchor article to selected brief title (topic hijack)

### DIFF
--- a/server.js
+++ b/server.js
@@ -4065,7 +4065,7 @@ app.get('/api/content-generator/generate', requireAuth, async (req, res) => {
     } catch(e) { /* silent — non-fatal */ }
 
     const territoriesBlock = topicalTerritories.length
-      ? `\nSTRATEGIC TERRITORIES THIS BRAND OPERATES IN (write as an authority in these territories — never drift outside them):\n${topicalTerritories.map(t => `  • [${t.priority}]${t.cluster ? ` (${t.cluster})` : ''} ${t.topic}${t.coverage ? ' — ' + t.coverage : ''}${t.angle ? `\n    Information-gain angle (the unique claim THIS brand makes here — the article must deliver it): ${t.angle}` : ''}`).join('\n')}\n`
+      ? `\nSTRATEGIC TERRITORIES THIS BRAND OPERATES IN (POSITIONING CONTEXT — use these to frame the angle and authority of the article defined above; they are NOT a menu of topics and do NOT override the article title. Only draw on the territory that actually serves this article's topic; ignore the rest):\n${topicalTerritories.map(t => `  • [${t.priority}]${t.cluster ? ` (${t.cluster})` : ''} ${t.topic}${t.coverage ? ' — ' + t.coverage : ''}${t.angle ? `\n    Information-gain angle (the unique claim THIS brand makes here — deliver it only if it fits the article's topic): ${t.angle}` : ''}`).join('\n')}\n`
       : '';
 
     const cgMeasuredBlock = cgCitationProbe
@@ -4140,7 +4140,23 @@ ${(() => {
       ? `\nSELF-AS-CASE-STUDY DETECTED: Brain evidence or Factual Ground references "${brandName}" directly. Apply the Self-as-Case-Study Rule from the system prompt — drop epistemic hedges on first-party validated outcomes, let the architectural claim stand. Keep hedges for unverified third-party claims.\n`
       : '';
 
-        const userPrompt = `Generate a long-form article using the following Brand Intelligence context.
+    // Anchor the article to the SELECTED brief's own title. Without this, the
+    // brief title sits buried in the ENRICHED BRIEF JSON at the bottom of the
+    // prompt while the STRATEGIC TERRITORIES block shouts near the top — so for a
+    // brand whose territories ARE the subject matter (e.g. a GEO consultancy whose
+    // gap clusters are literally "topical authority"), the model wrote a meta-
+    // article about the brand's own strategy instead of the chosen topic. The
+    // explicit title anchor + subordinated territories block keep it on-brief.
+    const articleTitleAnchor = (topicPrompt || enrichedBrief?.enrichedTitle || enrichedBrief?.enrichedH1 || enrichedBrief?.topic || '').trim();
+    const articleDirectiveBlock = articleTitleAnchor
+      ? `THE ARTICLE YOU ARE WRITING — THE topic, non-negotiable:
+"${articleTitleAnchor}"
+The entire piece is about exactly this, and the title you return must match this brief. Everything below (strategic territories, measured AI visibility, competitor coverage, brand profile) is CONTEXT for HOW to write THIS article — it is NOT a list of alternative topics. Do NOT write a meta-article about the brand's own strategy, methodology, or GEO framework unless the brief above literally calls for it. Serve the topic above.
+
+`
+      : '';
+
+        const userPrompt = `${articleDirectiveBlock}Generate a long-form article using the following Brand Intelligence context.
 ${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${territoriesBlock}${cgMeasuredBlock}${cgCompetitorBlock}${cgMoatsBlock}
 BRAND PROFILE:
 ${trimTo(profileData, 6000)}


### PR DESCRIPTION
## Why
Running the content generator on a specific GEO brief ("Boutique vs. Agency for Enterprise Launches: How to Choose the Right Creative Model") produced a totally different article about the GEO methodology itself: "Topical Authority Is Claimed, Not Accumulated: The Gap Clustering Framework AI Engines Reward." The pipeline ignored the selected topic.

## Root cause
Prompt ordering, not brief loading. The frontend correctly passes `enrichedBriefId`, so the right enriched brief loads server-side. But in the Stage 4 user prompt (`server.js` ~4143):
- The brief's own title (`enrichedTitle`/`enrichedH1`) is buried inside the `ENRICHED BRIEF` JSON at the **bottom** of the prompt.
- The **STRATEGIC TERRITORIES** block sits near the **top** with the hardest language in the whole prompt: *"never drift outside them"* and *"the article must deliver [the information-gain angle]."*

For the Forge brand, the strategic territories **are** the GEO methodology (topical authority, gap clustering). So Sonnet obeyed the loudest/earliest instruction and wrote a meta-article about the brand's own territory instead of the chosen topic. Self-referential brand + prompt ordering = topic hijack. Any brand whose topical map overlaps its subject matter is exposed to this.

## What
- Hoist an explicit **"THE ARTICLE YOU ARE WRITING"** directive to the very top of the user prompt, anchored to `topicPrompt || enrichedTitle || enrichedH1 || topic`. Declares the title non-negotiable and reframes everything below as context for *how* to write it, not a menu of alternative topics.
- Demote the STRATEGIC TERRITORIES block to positioning context: *"use these to frame the angle ... only draw on the territory that serves this article's topic; ignore the rest."*

No schema or route changes.

## Test plan
- `node --check server.js` clean.
- Manual: re-run the content generator on the "Boutique vs. Agency" brief on dev and confirm the returned title/topic matches the brief. (Needs a dev deploy — happy to verify on `dev.forgeintelligence.ai` once this lands, or Brian can spot-check.)

## Rollback
Single-file prompt change; revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)