### PR TITLE
fix(content-gen): brand-name anchor skip + brief provenance (optional hardening on #517)

### DIFF
--- a/server.js
+++ b/server.js
@@ -4017,12 +4017,16 @@ app.get('/api/content-generator/generate', requireAuth, async (req, res) => {
 
     // Load Enriched Brief
     let enrichedBrief = null;
+    let loadedEnrichedBriefId = null;  // the brief ACTUALLY used, for provenance
     try {
       const ebQuery = enrichedBriefId
         ? pool.query('SELECT * FROM enriched_briefs WHERE id = $1', [enrichedBriefId])
         : pool.query('SELECT * FROM enriched_briefs WHERE brand_profile_id = $1 ORDER BY version DESC LIMIT 1', [brandProfileId]);
       const ebRes = await ebQuery;
-      if (ebRes.rows.length) enrichedBrief = { ...ebRes.rows[0].enriched_data, brandName: ebRes.rows[0].brand_name };
+      if (ebRes.rows.length) {
+        enrichedBrief = { ...ebRes.rows[0].enriched_data, brandName: ebRes.rows[0].brand_name };
+        loadedEnrichedBriefId = ebRes.rows[0].id;
+      }
     } catch(e) { console.log('[CONTENT-GEN] No enriched brief:', e.message); }
 
     // ── Build prompt ─────────────────────────────────────────────────────────
@@ -4147,7 +4151,14 @@ ${(() => {
     // gap clusters are literally "topical authority"), the model wrote a meta-
     // article about the brand's own strategy instead of the chosen topic. The
     // explicit title anchor + subordinated territories block keep it on-brief.
-    const articleTitleAnchor = (topicPrompt || enrichedBrief?.enrichedTitle || enrichedBrief?.enrichedH1 || enrichedBrief?.topic || '').trim();
+    const rawTopicAnchor = (topicPrompt || enrichedBrief?.enrichedTitle || enrichedBrief?.enrichedH1 || enrichedBrief?.topic || '').trim();
+    // Guard the documented degenerate case: when a topic brief's title never
+    // propagates, Stage 3 falls enrichedTitle all the way back to the brand name
+    // (see ~server.js:3387 — "surfaced the brief as 'SYSOI' instead of the idea").
+    // An anchor equal to the brand name is NOT a topic; it re-opens the exact
+    // house-article hijack this fix exists to close. Treat it as no anchor.
+    const anchorIsBrandName = !!(rawTopicAnchor && brandName && rawTopicAnchor.toLowerCase() === String(brandName).toLowerCase());
+    const articleTitleAnchor = anchorIsBrandName ? '' : rawTopicAnchor;
     const articleDirectiveBlock = articleTitleAnchor
       ? `THE ARTICLE YOU ARE WRITING — THE topic, non-negotiable:
 "${articleTitleAnchor}"
@@ -4325,7 +4336,7 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
     const contentInsert = await pool.query(
       `INSERT INTO ${tableName} (brand_profile_id, enriched_brief_id, title, article_json, overall_confidence, brain_match_score, status)
        VALUES ($1, $2, $3, $4, $5, $6, 'draft') RETURNING id`,
-      [brandProfileId, enrichedBriefId || null, parsed.title, JSON.stringify(parsed),
+      [brandProfileId, enrichedBriefId || loadedEnrichedBriefId || null, parsed.title, JSON.stringify(parsed),
        parsed.overallConfidence || null, parsed.brainMatchScore || (() => {
          // Fallback: Claude dropped the field — compute from section confidences
          const sections = parsed.sections || [];


### PR DESCRIPTION
Optional hardening on top of #517 (already merged + live). Supersedes #518, which GitHub auto-marked "merged" when its base branch was deleted, though its code never actually reached `development`.

## Live-DB forensics that frame this
Confirmed against the real incident (brand "Brian B. Morgan", Boutique brief `00846d26`, DB `ep-odd-waterfall-akyrdo6x`): the brief enriched correctly with the right title, and the pre-#517 generator still drifted into a GEO meta-article. **#517's title anchor is the actual fix and is live.** This PR is orthogonal defense-in-depth only.

## What this adds
1. **Brand-name anchor skip** — if `enrichedTitle` degenerates to the brand name (documented fallback ~server.js:3387), treat it as no anchor so #517 doesn't pin the article to a non-topic. Did not occur in this incident; real historical failure mode. No refuse-to-generate behavior.
2. **Brief provenance** — store the id of the brief actually loaded as `enriched_brief_id`, so the omitted-param (latest-brief) path stops orphaning articles from their brief.

## Test plan
- `node --check server.js` clean. Additive; no new failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)