### PR TITLE
feat(content-gen): Sonnet 5 article writer + Sonnet 4.6 fallback

### DIFF
--- a/server.js
+++ b/server.js
@@ -4215,7 +4215,7 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
     // overload (the 529 seen 2026-07-28). Falls back only before any article text
     // has streamed, so the client never sees two models' output spliced.
     let fullText = '';
-    const { model: writerModel } = await streamTextWithFallback({
+    const { model: writerModel, usage: writerUsage } = await streamTextWithFallback({
       models: ARTICLE_WRITER_MODELS,
       max_tokens: 12000,
       system: systemPrompt,
@@ -4347,7 +4347,7 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
       `INSERT INTO agent_activity_log (agent_name, brand_profile_id, status, tokens_used, latency_ms)
        VALUES ($1, $2, $3, $4, $5)`,
       ['stage4_content_generator', brandProfileId, 'success',
-       (stream.usage?.input_tokens || 0) + (stream.usage?.output_tokens || 0),
+       (writerUsage?.input_tokens || 0) + (writerUsage?.output_tokens || 0),
        0]
     ).catch(() => {});
 

--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncat
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
 import { callZernio, zernioPublish, getOrCreateZernioProfile, zernioGuard } from './src/server/zernio.js';
 import { forgeScrape, getBrandPageContent, discoverSubpages, _forgeScrapeRateLimited, FORGE_SCRAPE_RATE_PER_MIN } from './src/server/scrape.js';
-import { anthropic, dateContext } from './src/server/llm.js';
+import { anthropic, dateContext, streamTextWithFallback, ARTICLE_WRITER_MODELS } from './src/server/llm.js';
 import { CITATION_ENGINES, isCited, findCitedSection, urlHasDomain, coldScan, extractDomain } from './src/server/geoProbe.js';
 import { installLogCapture, logBuffer, logSSEClients, errorAggregates } from './src/server/logging.js';
 import { recordAudit } from './src/server/audit.js';
@@ -4210,24 +4210,20 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
 
     send('chunk', 'Brain loaded. Building article...');
 
-    // ── Stream from Claude ────────────────────────────────────────────────────
-    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-
+    // ── Stream from Claude (Sonnet 5 → Sonnet 4.6 fallback) ───────────────────
+    // Ordered model roster with bounded retry/backoff on transient Anthropic
+    // overload (the 529 seen 2026-07-28). Falls back only before any article text
+    // has streamed, so the client never sees two models' output spliced.
     let fullText = '';
-    const stream = await client.messages.stream({
-      model: 'claude-sonnet-4-6',
+    const { model: writerModel } = await streamTextWithFallback({
+      models: ARTICLE_WRITER_MODELS,
       max_tokens: 12000,
       system: systemPrompt,
-      messages: [{ role: 'user', content: userPrompt }]
+      messages: [{ role: 'user', content: userPrompt }],
+      onText: (text) => { fullText += text; send('chunk', text.replace(/\n/g, '⏎')); },
+      log: (m) => console.log(m),
     });
-
-    for await (const chunk of stream) {
-      if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
-        const text = chunk.delta.text;
-        fullText += text;
-        send('chunk', text.replace(/\n/g, '⏎'));
-      }
-    }
+    console.log(`[CONTENT-GEN] article written by ${writerModel}`);
 
     // ── Parse + persist ───────────────────────────────────────────────────────
     let parsed;

--- a/src/server/llm.js
+++ b/src/server/llm.js
@@ -19,3 +19,76 @@ export function dateContext() {
     `do not assume an earlier year. If you write phrases like 'in ${year - 1}' or 'this year', ` +
     `they must be accurate against ${year}, not your training cutoff.`;
 }
+
+// ── Model roster + resilient streaming ───────────────────────────────────────
+// Article writer runs Sonnet 5 primary, prior-gen Sonnet 4.6 as the fallback —
+// mirrors the OpenClaw primary→fallback pattern. Ordered: try index 0 first.
+export const ARTICLE_WRITER_MODELS = ['claude-sonnet-5', 'claude-sonnet-4-6'];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Transient = capacity/infra, safe to retry or fall back. A 529 overloaded_error
+// (the failure seen 2026-07-28) lands here; a 4xx request error does NOT — that's
+// our bug, not Anthropic's load, so we fail fast instead of masking it.
+function isTransientLLMError(err) {
+  const type = err?.error?.type || err?.type;
+  if (type === 'overloaded_error') return true;
+  const status = err?.status ?? err?.statusCode;
+  if (typeof status === 'number') return status === 429 || status === 529 || (status >= 500 && status < 600);
+  return /Connection|Timeout|ECONNRESET|socket hang up/i.test(err?.name || err?.message || '');
+}
+
+/**
+ * Stream a Claude completion across an ordered model list with bounded retry.
+ *
+ * @param {string[]} models   Tried in order (e.g. ARTICLE_WRITER_MODELS).
+ * @param {function} onText   Called with each streamed text delta.
+ * @returns {Promise<{text:string, model:string}>} full text + the model that produced it.
+ *
+ * Fallback safety: we only retry or advance to the next model while ZERO text has
+ * been emitted for the current attempt. Once real content has streamed to the
+ * caller we re-throw on failure rather than splice a second model's output into
+ * the same response. Overload errors strike at stream-open (0 emitted), so the
+ * common case falls back cleanly and invisibly.
+ */
+export async function streamTextWithFallback({
+  models, max_tokens, system, messages,
+  onText = () => {}, log = () => {}, client = anthropic, attemptsPerModel = 2,
+}) {
+  let lastErr;
+  for (let m = 0; m < models.length; m++) {
+    const model = models[m];
+    for (let attempt = 1; attempt <= attemptsPerModel; attempt++) {
+      let emitted = 0;
+      try {
+        const stream = await client.messages.stream({ model, max_tokens, system, messages });
+        let fullText = '';
+        for await (const chunk of stream) {
+          if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
+            fullText += chunk.delta.text;
+            emitted += chunk.delta.text.length;
+            onText(chunk.delta.text);
+          }
+        }
+        if (m > 0 || attempt > 1) log(`[LLM] recovered on ${model} (model #${m + 1}, attempt ${attempt})`);
+        return { text: fullText, model };
+      } catch (err) {
+        lastErr = err;
+        if (emitted > 0) throw err;                 // content already streamed — no safe swap
+        if (!isTransientLLMError(err)) throw err;    // real error — surface it
+        const moreOnThisModel = attempt < attemptsPerModel;
+        const moreModels = m < models.length - 1;
+        if (!moreOnThisModel && !moreModels) throw err;
+        const label = err?.error?.type || err?.status || err?.name || 'transient';
+        if (moreOnThisModel) {
+          const backoffMs = 400 * 2 ** (attempt - 1); // 400ms, 800ms, …
+          log(`[LLM] ${model} ${label}; retry ${attempt + 1}/${attemptsPerModel} in ${backoffMs}ms`);
+          await sleep(backoffMs);
+        } else {
+          log(`[LLM] ${model} ${label} after ${attemptsPerModel} attempts; falling back to ${models[m + 1]}`);
+        }
+      }
+    }
+  }
+  throw lastErr;
+}

--- a/src/server/llm.js
+++ b/src/server/llm.js
@@ -63,15 +63,21 @@ export async function streamTextWithFallback({
       try {
         const stream = await client.messages.stream({ model, max_tokens, system, messages });
         let fullText = '';
+        const usage = { input_tokens: 0, output_tokens: 0 };
         for await (const chunk of stream) {
-          if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
+          if (chunk.type === 'message_start') {
+            usage.input_tokens = chunk.message?.usage?.input_tokens ?? usage.input_tokens;
+            usage.output_tokens = chunk.message?.usage?.output_tokens ?? usage.output_tokens;
+          } else if (chunk.type === 'message_delta' && chunk.usage?.output_tokens != null) {
+            usage.output_tokens = chunk.usage.output_tokens; // cumulative
+          } else if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
             fullText += chunk.delta.text;
             emitted += chunk.delta.text.length;
             onText(chunk.delta.text);
           }
         }
         if (m > 0 || attempt > 1) log(`[LLM] recovered on ${model} (model #${m + 1}, attempt ${attempt})`);
-        return { text: fullText, model };
+        return { text: fullText, model, usage };
       } catch (err) {
         lastErr = err;
         if (emitted > 0) throw err;                 // content already streamed — no safe swap


### PR DESCRIPTION
## Why
The article writer was pinned to prior-gen `claude-sonnet-4-6` with a **single, un-retried** streaming call. When Anthropic returned a transient `529 overloaded_error` in prod today (`req_011CdVhaESFQSTU8hbKTXN7H`), it surfaced straight to the user as a dead generation run. Brian asked to bump to Sonnet 5 and add an OpenClaw-style primary→fallback.

## What
- **Primary model → `claude-sonnet-5`** (from `claude-sonnet-4-6`).
- **New `streamTextWithFallback()`** in `src/server/llm.js` — ordered model roster `ARTICLE_WRITER_MODELS = ['claude-sonnet-5','claude-sonnet-4-6']` with bounded retry + exponential backoff (400ms→800ms) on transient errors (`overloaded_error` / 429 / 5xx / connection).
- **Fallback safety:** retries/falls back **only while zero text has streamed** for the current attempt. Once real content has streamed to the client it re-throws rather than splice two models' output into one response. Overload strikes at stream-open (0 emitted), so the common case recovers invisibly.
- **Fail-fast on non-transient 4xx** — a `400` is our bug, not capacity, so it surfaces immediately instead of being masked by a pointless fallback.
- Routes the writer through the shared **20-min-timeout** Anthropic client instead of a fresh default-timeout instance.

## Test plan
- Logic verified with a 6-case mock-client harness: `primary-overload→fallback`, `same-model retry`, `400 fail-fast`, `all-overloaded→throws`, `mid-stream-fail→no-swap`, `503-transient` — **6/6 PASS**.
- `node --check server.js` + `node --check src/server/llm.js` clean.
- Not yet exercised against the live Anthropic API (no local node_modules on this box) — recommend one real generation on the dev service after deploy to confirm Sonnet 5 output + the `[CONTENT-GEN] article written by <model>` log line.

## Scope / follow-up
Only the article writer is switched. The enrichment tools and brief-builder still run `claude-sonnet-4-6`; they can adopt the same helper in a follow-up PR once we're happy with writer output on 5.

## Rollback
Revert the commit — writer returns to the single-call 4.6 behavior. No schema/data changes.