### PR TITLE
Implement Sonnet 5 article writer with fallback to Sonnet 4.6

### DIFF
--- a/server.js
+++ b/server.js
@@ -4215,7 +4215,7 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
     // overload (the 529 seen 2026-07-28). Falls back only before any article text
     // has streamed, so the client never sees two models' output spliced.
     let fullText = '';
-    const { model: writerModel } = await streamTextWithFallback({
+    const { model: writerModel, usage: writerUsage } = await streamTextWithFallback({
       models: ARTICLE_WRITER_MODELS,
       max_tokens: 12000,
       system: systemPrompt,
@@ -4347,7 +4347,7 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
       `INSERT INTO agent_activity_log (agent_name, brand_profile_id, status, tokens_used, latency_ms)
        VALUES ($1, $2, $3, $4, $5)`,
       ['stage4_content_generator', brandProfileId, 'success',
-       (stream.usage?.input_tokens || 0) + (stream.usage?.output_tokens || 0),
+       (writerUsage?.input_tokens || 0) + (writerUsage?.output_tokens || 0),
        0]
     ).catch(() => {});
 

--- a/server.js
+++ b/server.js
@@ -45,7 +45,7 @@ import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncat
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
 import { callZernio, zernioPublish, getOrCreateZernioProfile, zernioGuard } from './src/server/zernio.js';
 import { forgeScrape, getBrandPageContent, discoverSubpages, _forgeScrapeRateLimited, FORGE_SCRAPE_RATE_PER_MIN } from './src/server/scrape.js';
-import { anthropic, dateContext } from './src/server/llm.js';
+import { anthropic, dateContext, streamTextWithFallback, ARTICLE_WRITER_MODELS } from './src/server/llm.js';
 import { CITATION_ENGINES, isCited, findCitedSection, urlHasDomain, coldScan, extractDomain } from './src/server/geoProbe.js';
 import { installLogCapture, logBuffer, logSSEClients, errorAggregates } from './src/server/logging.js';
 import { recordAudit } from './src/server/audit.js';
@@ -4210,24 +4210,20 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
 
     send('chunk', 'Brain loaded. Building article...');
 
-    // ── Stream from Claude ────────────────────────────────────────────────────
-    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-
+    // ── Stream from Claude (Sonnet 5 → Sonnet 4.6 fallback) ───────────────────
+    // Ordered model roster with bounded retry/backoff on transient Anthropic
+    // overload (the 529 seen 2026-07-28). Falls back only before any article text
+    // has streamed, so the client never sees two models' output spliced.
     let fullText = '';
-    const stream = await client.messages.stream({
-      model: 'claude-sonnet-4-6',
+    const { model: writerModel } = await streamTextWithFallback({
+      models: ARTICLE_WRITER_MODELS,
       max_tokens: 12000,
       system: systemPrompt,
-      messages: [{ role: 'user', content: userPrompt }]
+      messages: [{ role: 'user', content: userPrompt }],
+      onText: (text) => { fullText += text; send('chunk', text.replace(/\n/g, '⏎')); },
+      log: (m) => console.log(m),
     });
-
-    for await (const chunk of stream) {
-      if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
-        const text = chunk.delta.text;
-        fullText += text;
-        send('chunk', text.replace(/\n/g, '⏎'));
-      }
-    }
+    console.log(`[CONTENT-GEN] article written by ${writerModel}`);
 
     // ── Parse + persist ───────────────────────────────────────────────────────
     let parsed;

--- a/src/server/llm.js
+++ b/src/server/llm.js
@@ -19,3 +19,76 @@ export function dateContext() {
     `do not assume an earlier year. If you write phrases like 'in ${year - 1}' or 'this year', ` +
     `they must be accurate against ${year}, not your training cutoff.`;
 }
+
+// ── Model roster + resilient streaming ───────────────────────────────────────
+// Article writer runs Sonnet 5 primary, prior-gen Sonnet 4.6 as the fallback —
+// mirrors the OpenClaw primary→fallback pattern. Ordered: try index 0 first.
+export const ARTICLE_WRITER_MODELS = ['claude-sonnet-5', 'claude-sonnet-4-6'];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Transient = capacity/infra, safe to retry or fall back. A 529 overloaded_error
+// (the failure seen 2026-07-28) lands here; a 4xx request error does NOT — that's
+// our bug, not Anthropic's load, so we fail fast instead of masking it.
+function isTransientLLMError(err) {
+  const type = err?.error?.type || err?.type;
+  if (type === 'overloaded_error') return true;
+  const status = err?.status ?? err?.statusCode;
+  if (typeof status === 'number') return status === 429 || status === 529 || (status >= 500 && status < 600);
+  return /Connection|Timeout|ECONNRESET|socket hang up/i.test(err?.name || err?.message || '');
+}
+
+/**
+ * Stream a Claude completion across an ordered model list with bounded retry.
+ *
+ * @param {string[]} models   Tried in order (e.g. ARTICLE_WRITER_MODELS).
+ * @param {function} onText   Called with each streamed text delta.
+ * @returns {Promise<{text:string, model:string}>} full text + the model that produced it.
+ *
+ * Fallback safety: we only retry or advance to the next model while ZERO text has
+ * been emitted for the current attempt. Once real content has streamed to the
+ * caller we re-throw on failure rather than splice a second model's output into
+ * the same response. Overload errors strike at stream-open (0 emitted), so the
+ * common case falls back cleanly and invisibly.
+ */
+export async function streamTextWithFallback({
+  models, max_tokens, system, messages,
+  onText = () => {}, log = () => {}, client = anthropic, attemptsPerModel = 2,
+}) {
+  let lastErr;
+  for (let m = 0; m < models.length; m++) {
+    const model = models[m];
+    for (let attempt = 1; attempt <= attemptsPerModel; attempt++) {
+      let emitted = 0;
+      try {
+        const stream = await client.messages.stream({ model, max_tokens, system, messages });
+        let fullText = '';
+        for await (const chunk of stream) {
+          if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
+            fullText += chunk.delta.text;
+            emitted += chunk.delta.text.length;
+            onText(chunk.delta.text);
+          }
+        }
+        if (m > 0 || attempt > 1) log(`[LLM] recovered on ${model} (model #${m + 1}, attempt ${attempt})`);
+        return { text: fullText, model };
+      } catch (err) {
+        lastErr = err;
+        if (emitted > 0) throw err;                 // content already streamed — no safe swap
+        if (!isTransientLLMError(err)) throw err;    // real error — surface it
+        const moreOnThisModel = attempt < attemptsPerModel;
+        const moreModels = m < models.length - 1;
+        if (!moreOnThisModel && !moreModels) throw err;
+        const label = err?.error?.type || err?.status || err?.name || 'transient';
+        if (moreOnThisModel) {
+          const backoffMs = 400 * 2 ** (attempt - 1); // 400ms, 800ms, …
+          log(`[LLM] ${model} ${label}; retry ${attempt + 1}/${attemptsPerModel} in ${backoffMs}ms`);
+          await sleep(backoffMs);
+        } else {
+          log(`[LLM] ${model} ${label} after ${attemptsPerModel} attempts; falling back to ${models[m + 1]}`);
+        }
+      }
+    }
+  }
+  throw lastErr;
+}

--- a/src/server/llm.js
+++ b/src/server/llm.js
@@ -63,15 +63,21 @@ export async function streamTextWithFallback({
       try {
         const stream = await client.messages.stream({ model, max_tokens, system, messages });
         let fullText = '';
+        const usage = { input_tokens: 0, output_tokens: 0 };
         for await (const chunk of stream) {
-          if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
+          if (chunk.type === 'message_start') {
+            usage.input_tokens = chunk.message?.usage?.input_tokens ?? usage.input_tokens;
+            usage.output_tokens = chunk.message?.usage?.output_tokens ?? usage.output_tokens;
+          } else if (chunk.type === 'message_delta' && chunk.usage?.output_tokens != null) {
+            usage.output_tokens = chunk.usage.output_tokens; // cumulative
+          } else if (chunk.type === 'content_block_delta' && chunk.delta?.type === 'text_delta') {
             fullText += chunk.delta.text;
             emitted += chunk.delta.text.length;
             onText(chunk.delta.text);
           }
         }
         if (m > 0 || attempt > 1) log(`[LLM] recovered on ${model} (model #${m + 1}, attempt ${attempt})`);
-        return { text: fullText, model };
+        return { text: fullText, model, usage };
       } catch (err) {
         lastErr = err;
         if (emitted > 0) throw err;                 // content already streamed — no safe swap


### PR DESCRIPTION
This pull request enhances the article generation pipeline by adding robust fallback and retry logic for streaming completions from Anthropic's Claude models. The main improvement is the introduction of a resilient streaming utility that tries multiple models in order, handling transient errors gracefully to maximize reliability.

**Resilient LLM Streaming and Model Fallback:**

* Added a new function `streamTextWithFallback` in `src/server/llm.js` that streams completions from an ordered list of Claude models, retrying on transient errors and falling back to a secondary model if the primary is overloaded or unavailable. This ensures that article generation is more robust against Anthropic API outages or capacity issues.
* Defined `ARTICLE_WRITER_MODELS` in `src/server/llm.js` as `['claude-sonnet-5', 'claude-sonnet-4-6']`, specifying the primary and fallback models for article writing.

**Integration into Article Generation Flow:**

* Updated `server.js` to use `streamTextWithFallback` and `ARTICLE_WRITER_MODELS` for article generation, replacing the previous direct streaming call to a single model. This change ensures that if the primary model fails before streaming any content, the system will automatically retry or fall back to the next model. [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL48-R48) [[2]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL4213-R4226)
* Adjusted logging and token usage accounting in `server.js` to use the new streaming utility's return values, ensuring accurate reporting and observability.

These changes significantly improve reliability and user experience during periods of LLM capacity constraints or transient network failures.