### PR TITLE
Enforce no-em-dash rule across all article write paths

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ strategic substance, and never justify dropping or inventing a fact, example, or
   underscores, highlights the importance of.
 - Refer to a thing by the same noun each time rather than cycling synonyms for variety.`;
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
-import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripEmDashes, finalizeArticleForStorage } from './src/server/text.js';
+import { truncateStr, truncateAtSentence, stripEmDashes, finalizeArticleForStorage } from './src/server/text.js';
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
 import { callZernio, zernioPublish, getOrCreateZernioProfile, zernioGuard } from './src/server/zernio.js';
 import { forgeScrape, getBrandPageContent, discoverSubpages, _forgeScrapeRateLimited, FORGE_SCRAPE_RATE_PER_MIN } from './src/server/scrape.js';

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ strategic substance, and never justify dropping or inventing a fact, example, or
   underscores, highlights the importance of.
 - Refer to a thing by the same noun each time rather than cycling synonyms for variety.`;
 import { resolveUtmParams, buildUtmString } from './src/server/utm.js';
-import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripScaffoldingArtifacts, stripEmDashes } from './src/server/text.js';
+import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripEmDashes, finalizeArticleForStorage } from './src/server/text.js';
 import { clerkJWKS, SUPER_ADMIN_IDS, verifyBrandAccess, requireAuth, requireApiKeyScope, softAuth, mcpAuth, hashApiKey, lookupApiKey } from './src/server/auth.js';
 import { callZernio, zernioPublish, getOrCreateZernioProfile, zernioGuard } from './src/server/zernio.js';
 import { forgeScrape, getBrandPageContent, discoverSubpages, _forgeScrapeRateLimited, FORGE_SCRAPE_RATE_PER_MIN } from './src/server/scrape.js';
@@ -4310,31 +4310,11 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
       return res.end();
     }
 
-    // Strip LLM scaffolding artifacts (SME Hook, CTA, TODO, NEEDS CITATION, etc.)
-    parsed = stripScaffoldingArtifacts(parsed);
-
-    // Deterministic em-dash backstop — the prompt forbids them outright, but the
-    // model keeps emitting them, so guarantee zero ship by stripping every field.
-    if (parsed && typeof parsed === 'object') {
-      for (const k of ['title', 'metaDescription', 'keyTakeaway']) {
-        if (typeof parsed[k] === 'string') parsed[k] = stripEmDashes(parsed[k]);
-      }
-      if (Array.isArray(parsed.sections)) {
-        parsed.sections = parsed.sections.map(s => ({
-          ...s,
-          ...(typeof s.heading === 'string' ? { heading: stripEmDashes(s.heading) } : {}),
-          ...(typeof s.body === 'string' ? { body: stripEmDashes(s.body) } : {}),
-          ...(typeof s.content === 'string' ? { content: stripEmDashes(s.content) } : {}),
-        }));
-      }
-      if (Array.isArray(parsed.faqs)) {
-        parsed.faqs = parsed.faqs.map(f => ({
-          ...f,
-          ...(typeof f.question === 'string' ? { question: stripEmDashes(f.question) } : {}),
-          ...(typeof f.answer === 'string' ? { answer: stripEmDashes(f.answer) } : {}),
-        }));
-      }
-    }
+    // Final content-safety net — strip LLM scaffolding artifacts (SME Hook, CTA,
+    // TODO, NEEDS CITATION, etc.) AND enforce the no-em-dash house style. Shared
+    // with the campaign / import / compliance-approve write paths (finalizeArticleForStorage
+    // in text.js) so the two nets can never drift apart across call sites again.
+    parsed = finalizeArticleForStorage(parsed);
 
     // Guarantee the TL;DR (keyTakeaway) is never missing. It's the article's
     // required TL;DR block — rendered at the top of every publish path — and the

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -15,7 +15,7 @@ import { anthropic } from '../llm.js';
 const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 import { extractJSON, safeParseLLM } from '../llm-json.js';
 import { requireAuth, verifyBrandAccess } from '../auth.js';
-import { stripScaffoldingArtifacts } from '../text.js';
+import { finalizeArticleForStorage } from '../text.js';
 import { buildImagePrompt, generateHeroImage } from '../images.js';
 import { ensureGeneratedContentTable } from '../content-table.js';
 
@@ -711,7 +711,7 @@ Return ONLY valid JSON matching the content generator output format.`;
       // This is what connects campaign articles to publishing_queue, UTM tracking, and analytics.
       try {
         const contentTableName = await ensureGeneratedContentTable(campaign.brand_profile_id);
-        parsed = stripScaffoldingArtifacts(parsed);
+        parsed = finalizeArticleForStorage(parsed);
         const insertedContent = await pool.query(
           `INSERT INTO ${contentTableName}
             (brand_profile_id, title, article_json, overall_confidence, status, campaign_id, campaign_article_index, created_at, updated_at)

--- a/src/server/routes/compliance.js
+++ b/src/server/routes/compliance.js
@@ -9,7 +9,7 @@ import express from 'express';
 import { pool } from '../db.js';
 import { anthropic } from '../llm.js';
 import { safeParseLLM } from '../llm-json.js';
-import { stripScaffoldingArtifacts } from '../text.js';
+import { finalizeArticleForStorage } from '../text.js';
 import { verifyBrandAccess } from '../auth.js';
 import { findCitationSources } from '../citations.js';
 
@@ -560,8 +560,12 @@ router.post('/approve', async (req, res) => {
     const finalStatus = reviewMode === 'auto-ship' ? 'approved' :
       decisions && Object.values(decisions).some(d => d === 'rejected') ? 'rejected' : 'approved';
 
-    // Final safety net — strip any LLM scaffolding that slipped past human review
-    articleJson = stripScaffoldingArtifacts(articleJson);
+    // Final safety net — strip LLM scaffolding AND em dashes that slipped past
+    // human review. The human reviewer edits in this gate, so this is the LAST
+    // write before publish: enforce the no-em-dash house style here too, not just
+    // at content-gen. (Previously this path only stripped scaffolding, so any em
+    // dash a human missed shipped straight to the live article.)
+    articleJson = finalizeArticleForStorage(articleJson);
 
     await pool.query(
       `UPDATE ${tableName} SET article_json = $1, compliance_status = $2, review_mode = $3, reviewed_at = NOW(), updated_at = NOW() WHERE id = $4`,

--- a/src/server/routes/content.js
+++ b/src/server/routes/content.js
@@ -11,7 +11,7 @@ import { pool } from '../db.js';
 import { anthropic } from '../llm.js';
 import { safeParseLLM } from '../llm-json.js';
 import { requireAuth, requireApiKeyScope } from '../auth.js';
-import { stripScaffoldingArtifacts } from '../text.js';
+import { finalizeArticleForStorage } from '../text.js';
 import { buildImagePrompt, generateHeroImage } from '../images.js';
 
 const router = express.Router();
@@ -357,7 +357,7 @@ Return ONLY valid JSON:
     // 5. Insert (net-new) or UPDATE (edit-reconciliation) into generated_content.
     //    Edit-reconciliation preserves the original article's id + queue placement
     //    so Frank's edit replaces the draft in-place rather than spawning a dup.
-    const cleanedParsed = stripScaffoldingArtifacts(parsed);
+    const cleanedParsed = finalizeArticleForStorage(parsed);
     let contentId;
     if (originalArticle) {
       // Merge cleanedParsed (which has Frank's edited sections) into the existing article_json,

--- a/src/server/text.js
+++ b/src/server/text.js
@@ -116,10 +116,51 @@ export function stripScaffoldingArtifacts(article) {
   };
 
   article.sections = article.sections.map(s => {
+    if (!s || typeof s !== 'object') return s; // tolerate a null/malformed section without throwing
     const updated = { ...s };
     if (typeof s.body === 'string') updated.body = cleanBody(s.body);
     if (typeof s.content === 'string') updated.content = cleanBody(s.content);
     return updated;
   });
   return article;
+}
+
+// Enforce the no-em-dash house style across a whole article object. Applies
+// stripEmDashes to every prose field the writer produces: title, metaDescription,
+// keyTakeaway, each section heading/body/content, and each FAQ question/answer.
+// (Mirrors the field set the content-gen backstop has always covered.) Non-article
+// input is returned untouched; returns a new object, does not mutate the input.
+export function stripEmDashesFromArticle(article) {
+  if (!article || typeof article !== 'object') return article;
+  const out = { ...article };
+  for (const k of ['title', 'metaDescription', 'keyTakeaway']) {
+    if (typeof out[k] === 'string') out[k] = stripEmDashes(out[k]);
+  }
+  if (Array.isArray(out.sections)) {
+    out.sections = out.sections.map(s => (s && typeof s === 'object') ? {
+      ...s,
+      ...(typeof s.heading === 'string' ? { heading: stripEmDashes(s.heading) } : {}),
+      ...(typeof s.body === 'string' ? { body: stripEmDashes(s.body) } : {}),
+      ...(typeof s.content === 'string' ? { content: stripEmDashes(s.content) } : {}),
+    } : s);
+  }
+  if (Array.isArray(out.faqs)) {
+    out.faqs = out.faqs.map(f => (f && typeof f === 'object') ? {
+      ...f,
+      ...(typeof f.question === 'string' ? { question: stripEmDashes(f.question) } : {}),
+      ...(typeof f.answer === 'string' ? { answer: stripEmDashes(f.answer) } : {}),
+    } : f);
+  }
+  return out;
+}
+
+// The single final content-safety net for EVERY article write path
+// (content-gen, campaign, compliance approve, content-import): strip LLM
+// scaffolding artifacts AND enforce the no-em-dash house style. Keeping both
+// in one function guarantees the two nets can never drift apart across call
+// sites again — the em-dash backstop previously lived ONLY on the content-gen
+// path, so campaign / import / compliance-approve writes shipped em dashes
+// straight through.
+export function finalizeArticleForStorage(article) {
+  return stripEmDashesFromArticle(stripScaffoldingArtifacts(article));
 }

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripScaffoldingArtifacts, stripEmDashes } from '../src/server/text.js';
+import { truncateStr, truncateAtSentence, stripSocialMarkdown, quickStartTruncate, stripScaffoldingArtifacts, stripEmDashes, stripEmDashesFromArticle, finalizeArticleForStorage } from '../src/server/text.js';
 
 describe('truncateStr', () => {
   it('returns null for null/undefined', () => {
@@ -123,5 +123,69 @@ describe('stripEmDashes — semicolon when the sentence already has 2+ commas', 
   it('decides per sentence (semicolon in one, comma in the next)', () => {
     expect(stripEmDashes('A, B, C — done. Quick — go.'))
       .toBe('A, B, C; done. Quick, go.');
+  });
+});
+
+// Helper: no em/en dash survives anywhere in the stored article JSON — the same
+// recursive check used to audit live articles in the DB.
+const hasWideDash = (obj) => /[—–]/.test(JSON.stringify(obj));
+
+describe('stripEmDashesFromArticle', () => {
+  it('strips em dashes from every prose field the writer produces', () => {
+    const article = {
+      title: 'The Collaboration Tax — Why Per-Seat Pricing Drags',
+      metaDescription: 'Per-seat pricing is a hidden drag — here is the math.',
+      keyTakeaway: 'Seats gate access — access gates speed.',
+      sections: [
+        { heading: 'The Setup — First', body: 'Each access workaround — waiting for a screenshot, reformatting a file, re-entering data — can cost 5 to 7 senior hours.', content: 'inline — dash' },
+      ],
+      faqs: [
+        { question: 'What is the tax — really?', answer: 'It is the overhead — measured in senior hours.' },
+      ],
+    };
+    const out = stripEmDashesFromArticle(article);
+    expect(hasWideDash(out)).toBe(false);
+    expect(out.title).toBe('The Collaboration Tax, Why Per-Seat Pricing Drags');
+    expect(out.sections[0].heading).toBe('The Setup, First');
+    expect(out.faqs[0].answer).toBe('It is the overhead, measured in senior hours.');
+  });
+
+  it('returns non-article input untouched and does not mutate the input', () => {
+    expect(stripEmDashesFromArticle(null)).toBeNull();
+    expect(stripEmDashesFromArticle('nope')).toBe('nope');
+    const input = { title: 'a — b', sections: [{ body: 'c — d' }] };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    stripEmDashesFromArticle(input);
+    expect(input).toEqual(snapshot); // original object unchanged (new object returned)
+  });
+
+  it('leaves numeric ranges as hyphens, not comma splices', () => {
+    const out = stripEmDashesFromArticle({ sections: [{ body: 'the 2024–2026 window' }] });
+    expect(out.sections[0].body).toBe('the 2024-2026 window');
+  });
+});
+
+describe('finalizeArticleForStorage — the shared net for every write path', () => {
+  it('strips scaffolding AND em dashes in one pass', () => {
+    const article = {
+      title: 'Launch Playbook — Enterprise',
+      sections: [
+        { body: '[SME Hook: get an expert quote here]\n\nBoutique operators move fast — that is the edge.' },
+      ],
+      faqs: [{ question: 'Why boutique?', answer: 'Speed — and focus.' }],
+    };
+    const out = finalizeArticleForStorage(article);
+    expect(hasWideDash(out)).toBe(false);                 // em dashes gone
+    expect(out.sections[0].body).not.toMatch(/SME Hook/); // scaffolding gone
+    expect(out.sections[0].body).toContain('Boutique operators move fast');
+    expect(out.faqs[0].answer).toBe('Speed, and focus.');
+  });
+
+  it('is safe on minimal / malformed articles', () => {
+    expect(finalizeArticleForStorage(null)).toBeNull();
+    expect(finalizeArticleForStorage({ title: 'clean title' }).title).toBe('clean title');
+    // sections with a null entry must not throw
+    const out = finalizeArticleForStorage({ title: 'x — y', sections: [null, { body: 'a — b' }] });
+    expect(hasWideDash(out)).toBe(false);
   });
 });


### PR DESCRIPTION
This pull request introduces a unified content-cleaning function, `finalizeArticleForStorage`, to ensure all article write paths consistently strip both LLM scaffolding artifacts and em dashes from stored content. Previously, em dash removal was only enforced on the content generation path, which allowed em dashes to slip through during campaign, compliance, or content import writes. The update adds and tests `stripEmDashesFromArticle` and `finalizeArticleForStorage`, and replaces all direct calls to `stripScaffoldingArtifacts` in server routes with the new unified function.

**Content cleaning and consistency improvements:**

* Added `stripEmDashesFromArticle` and `finalizeArticleForStorage` to `src/server/text.js`, ensuring em dashes and LLM scaffolding artifacts are stripped from all relevant article fields in a single, reusable function.
* Replaced all calls to `stripScaffoldingArtifacts` with `finalizeArticleForStorage` in the main article write paths: content generation (`server.js`), campaign creation (`src/server/routes/campaign.js`), compliance approval (`src/server/routes/compliance.js`), and content import/edit (`src/server/routes/content.js`). [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL44-R44) [[2]](diffhunk://#diff-007adbe59e0ed06a38ed6ebf74cda8bdfba852e15a93b713020e9d94e0060676L18-R18) [[3]](diffhunk://#diff-8f85458ac30321de5faa7f5c2922725713ee91901d7bc53b1e19f20746be40deL12-R12) [[4]](diffhunk://#diff-148af78afce7a0450563885e41fa0874b31d1c83a6f5873466ff91b21b501a01L14-R14) [[5]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL4313-R4317) [[6]](diffhunk://#diff-007adbe59e0ed06a38ed6ebf74cda8bdfba852e15a93b713020e9d94e0060676L714-R714) [[7]](diffhunk://#diff-8f85458ac30321de5faa7f5c2922725713ee91901d7bc53b1e19f20746be40deL563-R568) [[8]](diffhunk://#diff-148af78afce7a0450563885e41fa0874b31d1c83a6f5873466ff91b21b501a01L360-R360)

**Testing and safety:**

* Added comprehensive tests for both `stripEmDashesFromArticle` and `finalizeArticleForStorage` in `test/text.test.js`, verifying correct removal of em dashes and scaffolding, non-mutation of inputs, and robustness to malformed input.

These changes guarantee that all article content stored in the database adheres to the house style (no em dashes) and is free of LLM scaffolding artifacts, regardless of the write path.