### PR TITLE
fix(content): raise article-writer output cap 16k→32k to stop tail truncation

### DIFF
--- a/server.js
+++ b/server.js
@@ -4213,16 +4213,21 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
     // ── Stream + parse one writer pass ────────────────────────────────────────
     // Sonnet 5 → Sonnet 4.6 fallback with bounded retry/backoff on transient
     // Anthropic overload (the 529 seen 2026-07-28); falls back only before any
-    // article text has streamed. max_tokens is generous: Sonnet 5's full article
-    // JSON (5 scalars + sections + 4-6 faqs + authorBlock) runs long, and a hard
-    // output cut drops the schema tail (faqs onward) — the truncation seen
-    // 2026-07-29. Returns { parsed, stopReason, model, usage }; parsed is null
-    // only when the JSON is unrecoverable.
+    // article text has streamed. max_tokens headroom matters: the full article
+    // JSON (5 scalars + sections + 4-6 faqs + authorBlock) is genuinely large,
+    // and a hard output cut drops the schema tail (faqs onward) first. Prod logs
+    // 2026-07-29/30 show clean (stop=end_turn) drafts landing at 12.5k–15k output
+    // tokens — so the old 16k cap sat right in the working range and any slightly
+    // longer draw slammed max_tokens and truncated (two articles in a row). 32k
+    // gives ~2x headroom over the largest observed real article and is well within
+    // both Sonnet 5's and Sonnet 4.6's native 64k output ceiling (no beta header).
+    // Returns { parsed, stopReason, model, usage }; parsed is null only when the
+    // JSON is unrecoverable.
     const runWriterPass = async () => {
       let fullText = '';
       const { model, usage, stopReason } = await streamTextWithFallback({
         models: ARTICLE_WRITER_MODELS,
-        max_tokens: 16000,
+        max_tokens: 32000,
         system: systemPrompt,
         messages: [{ role: 'user', content: userPrompt }],
         onText: (text) => { fullText += text; send('chunk', text.replace(/\n/g, '⏎')); },


### PR DESCRIPTION
## Why
Brian hit "The article came back incomplete twice" on two articles in a row (#forge-intelligence-agent, 2026-07-29). Not the brief — the **output cap**.

## Evidence (prod logs, srv-d73bct6a2pns73a8c65g)
Clean `stop=end_turn` drafts land at **out=12,509 / 12,806 / 13,997 / 14,888 / 15,052** tokens. The cap was `max_tokens: 16000` — right in the working range. Any slightly-longer draw hits the ceiling:
```
23:05 pass 1 incomplete (stop=max_tokens, sections=8, faqs=3, truncated=true)
23:07 stop=max_tokens, out=16000 → both passes incomplete — refusing to store
01:26 pass 1 incomplete (stop=max_tokens, sections=4, faqs=0, truncated=true)
02:21 pass 1 incomplete (stop=max_tokens, sections=2, faqs=0, truncated=true)
```
FAQs sit at the schema tail, so they're the first casualty (`faqs=0`).

## What
`max_tokens: 16000 → 32000` in the article `runWriterPass`. ~2x headroom over the largest observed real article; well within Sonnet 5 and Sonnet 4.6 native 64k output ceilings (no beta header). Normal drafts still self-terminate at ~13–15k, so common-case cost/latency unchanged — the cap only bites when it would previously have truncated.

## Test plan
- `node --check server.js` passes.
- After deploy to dev: generate 2–3 articles, confirm `stop=end_turn` and complete FAQs in the `[CONTENT-GEN]` log line.

## Follow-up (not in this PR)
A "1200–1800 word" article emitting 13–15k output tokens is ~8 tokens/word — worth a look at whether the section count (logs show 8) and per-section schema metadata are inflating output beyond the prompt's stated target.