### PR TITLE
Add narrativeIdentity to enriched brief schema with fallback

### DIFF
--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -168,14 +168,17 @@ Return ONLY the JSON object.`;
 
   // Attach a safe narrativeIdentity fallback when the LLM didn't emit one.
   if (!parsed.narrativeIdentity) {
-    const assigned = parsed.authorSchema && parsed.authorSchema.name ? parsed.authorSchema : null;
+    const fgAuthor = factualGround?.authors?.length ? factualGround.authors[0] : null;
+    const assigned = parsed.authorSchema?.name
+      ? { name: parsed.authorSchema.name, id: fgAuthor?.id || null }
+      : (fgAuthor?.name ? { name: fgAuthor.name, id: fgAuthor.id || null } : null);
     if (assigned) {
       parsed.narrativeIdentity = {
         subjectType: 'company',
         speakerType: 'person',
         grammaticalPerson: 'first_singular',
-        speakerName: parsed.authorSchema.name || null,
-        bylineAuthorId: factualGround?.authors?.length ? (factualGround.authors[0].id || null) : null,
+        speakerName: assigned.name || null,
+        bylineAuthorId: assigned.id,
         allowedSelfReferences: ['I', 'my', 'me'],
         personalExperienceAllowed: true,
         notes: 'Author-attributed piece: prefer first-person for personal experience; company-level claims use we/our.'

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -166,6 +166,34 @@ Return ONLY the JSON object.`;
   const match = raw.match(/\{[\s\S]*\}/);
   const parsed = safeParseLLM(match ? match[0] : raw, 'object', 'campaign-angle-enrichment');
 
+  // Attach a safe narrativeIdentity fallback when the LLM didn't emit one.
+  if (!parsed.narrativeIdentity) {
+    const assigned = parsed.authorSchema && parsed.authorSchema.name ? parsed.authorSchema : null;
+    if (assigned) {
+      parsed.narrativeIdentity = {
+        subjectType: 'company',
+        speakerType: 'person',
+        grammaticalPerson: 'first_singular',
+        speakerName: parsed.authorSchema.name || null,
+        bylineAuthorId: factualGround?.authors?.length ? (factualGround.authors[0].id || null) : null,
+        allowedSelfReferences: ['I', 'my', 'me'],
+        personalExperienceAllowed: true,
+        notes: 'Author-attributed piece: prefer first-person for personal experience; company-level claims use we/our.'
+      };
+    } else {
+      parsed.narrativeIdentity = {
+        subjectType: 'company',
+        speakerType: 'company',
+        grammaticalPerson: 'third_plural',
+        speakerName: brandName || null,
+        bylineAuthorId: null,
+        allowedSelfReferences: ['we', 'our', 'us'],
+        personalExperienceAllowed: false,
+        notes: 'Default company voice: use third-person references to the company or first-person plural for company actions.'
+      };
+    }
+  }
+
   // Attach author schema from factualGround if the LLM didn't emit one
   if ((!parsed.authorSchema || !parsed.authorSchema.name) && factualGround?.authors?.length) {
     const fallbackAuthor = factualGround.authors[0];


### PR DESCRIPTION
This pull request adds a robust fallback mechanism for the `narrativeIdentity` property in the campaign enrichment API to ensure consistent data structure, even when the LLM output is incomplete. If `narrativeIdentity` is missing, it is now synthesized using available author or brand information.

Fallback logic for `narrativeIdentity`:

* When `narrativeIdentity` is missing, the code checks for an `authorSchema` with a name and constructs a first-person narrative identity; otherwise, it defaults to a company-level third-person plural identity using the brand name. (`src/server/routes/campaign.js`)