### PR TITLE
Persist narrative identity in articles and enhance compliance lint

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import { randomUUID, randomBytes, createHmac, createHash, timingSafeEqual } from
 import { jwtVerify } from 'jose';
 import { pool } from './src/server/db.js';
 import { extractJSON, safeParseLLM } from './src/server/llm-json.js';
+import { normalizeNarrativeIdentity, narrativeIdentityPromptBlock } from './src/server/narrative-identity.js';
 // Forbid em-dashes in Brand Intelligence PVA / Fault Lines output (matches the
 // strategy module + the rest of Forge's content style). Appended to those prompts.
 const STRATEGY_NO_EM_DASH = '\n\nSTYLE (mandatory): Write in plain prose. Do NOT use em-dashes (the — character) anywhere in your output; use commas, colons, parentheses, or separate sentences instead.';
@@ -4167,7 +4168,16 @@ The entire piece is about exactly this, and the title you return must match this
 `
       : '';
 
-        const userPrompt = `${articleDirectiveBlock}Generate a long-form article using the following Brand Intelligence context.
+    // Build normalized narrative identity for the writer and include a concise
+    // non-negotiable identity block for the writer to follow. This prevents
+    // accidental shifts between company/author perspectives.
+    const identityAuthor = enrichedBrief?.authorSchema?.name
+      ? (factualGround?.authors || []).find(a => a.name === enrichedBrief.authorSchema.name) || null
+      : (factualGround?.authors || [])[0] || null;
+    const identityNormalized = normalizeNarrativeIdentity(enrichedBrief?.narrativeIdentity || {}, { brandName, author: identityAuthor });
+    const identityBlock = narrativeIdentityPromptBlock(identityNormalized, { brandName, author: identityAuthor });
+
+    const userPrompt = `${articleDirectiveBlock}${identityBlock}Generate a long-form article using the following Brand Intelligence context.
 ${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${territoriesBlock}${cgMeasuredBlock}${cgCompetitorBlock}${cgMoatsBlock}
 BRAND PROFILE:
 ${trimTo(profileData, 6000)}
@@ -4315,10 +4325,11 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
       return res.end();
     }
 
-    // Final content-safety net — strip LLM scaffolding artifacts (SME Hook, CTA,
-    // TODO, NEEDS CITATION, etc.) AND enforce the no-em-dash house style. Shared
-    // with the campaign / import / compliance-approve write paths (finalizeArticleForStorage
-    // in text.js) so the two nets can never drift apart across call sites again.
+    // Final content-safety net — persist narrative identity to the article JSON
+    // so downstream systems (publishing, compliance, UI) see the exact editorial
+    // contract used, then strip LLM scaffolding artifacts (SME Hook, CTA,
+    // TODO, NEEDS CITATION, etc.) AND enforce the no-em-dash house style.
+    try { parsed.narrativeIdentity = identityNormalized; } catch (e) { /* non-fatal */ }
     parsed = finalizeArticleForStorage(parsed);
 
     // Guarantee the TL;DR (keyTakeaway) is never missing. It's the article's
@@ -10723,5 +10734,3 @@ app.post('/api/forge/prompt-pack/lovable', requireAuth, async (req, res) => {
 app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'));
 });
-
-

--- a/src/server/narrative-identity.js
+++ b/src/server/narrative-identity.js
@@ -1,0 +1,117 @@
+const VALID_PERSONS = new Set(['first_singular', 'first_plural', 'third_plural', 'third_singular']);
+const VALID_SPEAKERS = new Set(['company', 'person']);
+const VALID_SUBJECTS = new Set(['company', 'person']);
+
+function asText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function escapeRegex(value) {
+  return asText(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function boolValue(value, fallback = false) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return value.toLowerCase() === 'true';
+  return fallback;
+}
+
+function defaultReferences(person) {
+  switch (person) {
+    case 'first_singular': return ['I', 'my', 'me', 'mine'];
+    case 'first_plural': return ['we', 'our', 'us', 'ours'];
+    case 'third_singular': return [];
+    default: return [];
+  }
+}
+
+/**
+ * Normalize the optional brief-level identity into a stable, prompt-safe contract.
+ * Missing identity intentionally preserves the historical institutional voice.
+ */
+export function normalizeNarrativeIdentity(identity, { brandName = '', author = null } = {}) {
+  const source = identity && typeof identity === 'object' ? identity : {};
+  const explicit = Object.keys(source).length > 0;
+  const authorName = asText(source.speakerName) || asText(author?.name) || null;
+  const hasExplicitPerson = VALID_SPEAKERS.has(source.speakerType) && source.speakerType === 'person';
+  const grammaticalPerson = VALID_PERSONS.has(source.grammaticalPerson)
+    ? source.grammaticalPerson
+    : 'third_plural';
+  const speakerType = VALID_SPEAKERS.has(source.speakerType)
+    ? source.speakerType
+    : (explicit && hasExplicitPerson ? 'person' : 'company');
+  const subjectType = VALID_SUBJECTS.has(source.subjectType) ? source.subjectType : 'company';
+  const personalExperienceAllowed = explicit
+    ? boolValue(source.personalExperienceAllowed, grammaticalPerson === 'first_singular' && speakerType === 'person')
+    : false;
+
+  return {
+    subjectType,
+    speakerType,
+    grammaticalPerson,
+    speakerName: asText(source.speakerName) || (speakerType === 'company' ? asText(brandName) || null : authorName),
+    bylineAuthorId: asText(source.bylineAuthorId) || null,
+    allowedSelfReferences: Array.isArray(source.allowedSelfReferences) && source.allowedSelfReferences.length
+      ? source.allowedSelfReferences.map(asText).filter(Boolean)
+      : defaultReferences(grammaticalPerson),
+    personalExperienceAllowed,
+    notes: asText(source.notes) || '',
+    explicit
+  };
+}
+
+export function narrativeIdentityPromptBlock(identity, options = {}) {
+  const normalized = normalizeNarrativeIdentity(identity, options);
+  const speaker = normalized.speakerName || (normalized.speakerType === 'person' ? 'the named author' : 'the company');
+  const perspective = {
+    first_singular: 'first-person singular',
+    first_plural: 'first-person plural',
+    third_plural: 'third-person company voice',
+    third_singular: 'third-person individual voice'
+  }[normalized.grammaticalPerson];
+
+  return `\nNARRATIVE IDENTITY — NON-NEGOTIABLE\n\n` +
+    `Subject: ${normalized.subjectType}. Speaker: ${normalized.speakerType}, ${speaker}. Perspective: ${perspective}.\n` +
+    `Allowed self-references: ${normalized.allowedSelfReferences.length ? normalized.allowedSelfReferences.join(', ') : 'refer to the subject by name or role'}.\n` +
+    `Personal experience claims: ${normalized.personalExperienceAllowed ? 'allowed only when supported by the named author profile or Factual Ground' : 'forbidden; do not turn company facts into personal anecdotes'}.\n` +
+    `${normalized.notes ? `Editorial note: ${normalized.notes}\n` : ''}` +
+    `Do not silently change who is speaking. Brand voice controls tone; this block controls narrator, pronouns, attribution, and experience claims.\n`;
+}
+
+export function lintNarrativePerspective(text, identity, options = {}) {
+  const body = asText(text);
+  const normalized = normalizeNarrativeIdentity(identity, options);
+  const issues = [];
+  if (!body) return { ok: true, issues, identity: normalized };
+
+  const add = (type, severity, phrase, message) => issues.push({ type, severity, phrase, message });
+  const firstSingular = /\b(?:I|me|my|mine)\b/i;
+  const personalAnecdote = /\b(?:I learned|I have learned|in my experience|from my experience|when I|I built|I saw|I found|I've seen|my experience)\b/i;
+
+  if (normalized.grammaticalPerson !== 'first_singular' && firstSingular.test(body)) {
+    add('unexpected_first_person', 'yellow', body.match(firstSingular)?.[0] || 'I', 'The article uses first-person singular language even though the selected narrator is not an individual first-person speaker.');
+  }
+  if (!normalized.personalExperienceAllowed && personalAnecdote.test(body)) {
+    add('unsupported_personal_experience', 'red', body.match(personalAnecdote)?.[0] || 'personal experience', 'The article makes a personal experience claim without permission from the narrative identity.');
+  }
+
+  if (normalized.grammaticalPerson === 'first_singular' && normalized.speakerName) {
+    const name = escapeRegex(normalized.speakerName);
+    const thirdPersonSelf = new RegExp(`\\b${name}\\b\\s+(?:is|was|believes|says|has|had|learned|built|found)\\b`, 'i');
+    const match = body.match(thirdPersonSelf) || body.match(/\bthe founder\b\s+(?:is|was|believes|says|has|had|learned|built|found)\b/i);
+    if (match) add('third_person_self_reference', 'yellow', match[0], 'A first-person author is referred to in the third person.');
+  }
+
+  return { ok: issues.length === 0, issues, identity: normalized };
+}
+
+export const narrativeIdentityContract = {
+  subjectType: 'company|person',
+  speakerType: 'company|person',
+  grammaticalPerson: 'first_singular|first_plural|third_plural|third_singular',
+  speakerName: 'string|null',
+  bylineAuthorId: 'string|null',
+  allowedSelfReferences: 'string[]',
+  personalExperienceAllowed: 'boolean',
+  notes: 'string'
+};

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -18,6 +18,7 @@ import { requireAuth, verifyBrandAccess } from '../auth.js';
 import { finalizeArticleForStorage } from '../text.js';
 import { buildImagePrompt, generateHeroImage } from '../images.js';
 import { ensureGeneratedContentTable } from '../content-table.js';
+import { normalizeNarrativeIdentity } from '../narrative-identity.js';
 
 const router = express.Router();
 
@@ -134,10 +135,20 @@ Output STRICT JSON matching this schema (no markdown, no commentary):
   "enrichedFAQ": [{ "q": "FAQ question this article should answer", "a": "Concise 1-2 sentence answer" }],
   "powerPhrases": ["Short, declarative phrases the writer should use verbatim — ~5 words each, specific to brand voice"],
   "contentHooks": ["Opening-paragraph hooks that would grab ${personaName}"],
-  "authorSchema": { "name": "author name from factual ground authors, or null", "jobTitle": "author job title, or null" }
+  "authorSchema": { "name": "author name from factual ground authors, or null", "jobTitle": "author job title, or null" },
+  "narrativeIdentity": {
+    "subjectType": "company|person",
+    "speakerType": "company|person",
+    "grammaticalPerson": "first_singular|first_plural|third_plural|third_singular",
+    "speakerName": "string or null",
+    "bylineAuthorId": "string or null",
+    "allowedSelfReferences": ["allowed pronouns or self-reference phrases"],
+    "personalExperienceAllowed": "boolean",
+    "notes": "short perspective guidance for the article writer"
+  }
 }
 
-Requirements: 4-6 enrichedSections, 3-5 enrichedFAQ, 4-6 powerPhrases, 2-3 contentHooks.`;
+Requirements: 4-6 enrichedSections, 3-5 enrichedFAQ, 4-6 powerPhrases, 2-3 contentHooks. The narrativeIdentity is an editorial contract, not a tone description. Do not infer first-person authorship merely because a byline exists; use company third-person defaults unless the angle explicitly calls for a person speaking.`;
 
   const userPrompt = `Produce the enriched brief for this specific campaign angle:
 
@@ -167,34 +178,21 @@ Return ONLY the JSON object.`;
   const parsed = safeParseLLM(match ? match[0] : raw, 'object', 'campaign-angle-enrichment');
 
   // Attach a safe narrativeIdentity fallback when the LLM didn't emit one.
+  // A byline alone does not change the narrator: existing brands should retain
+  // their institutional voice until a brief explicitly selects a person.
   if (!parsed.narrativeIdentity) {
-    const fgAuthor = factualGround?.authors?.length ? factualGround.authors[0] : null;
-    const assigned = parsed.authorSchema?.name
-      ? { name: parsed.authorSchema.name, id: fgAuthor?.id || null }
-      : (fgAuthor?.name ? { name: fgAuthor.name, id: fgAuthor.id || null } : null);
-    if (assigned) {
-      parsed.narrativeIdentity = {
-        subjectType: 'company',
-        speakerType: 'person',
-        grammaticalPerson: 'first_singular',
-        speakerName: assigned.name || null,
-        bylineAuthorId: assigned.id,
-        allowedSelfReferences: ['I', 'my', 'me'],
-        personalExperienceAllowed: true,
-        notes: 'Author-attributed piece: prefer first-person for personal experience; company-level claims use we/our.'
-      };
-    } else {
-      parsed.narrativeIdentity = {
-        subjectType: 'company',
-        speakerType: 'company',
-        grammaticalPerson: 'third_plural',
-        speakerName: brandName || null,
-        bylineAuthorId: null,
-        allowedSelfReferences: ['we', 'our', 'us'],
-        personalExperienceAllowed: false,
-        notes: 'Default company voice: use third-person references to the company or first-person plural for company actions.'
-      };
-    }
+    parsed.narrativeIdentity = {
+      subjectType: 'company',
+      speakerType: 'company',
+      grammaticalPerson: 'third_plural',
+      speakerName: brandName || null,
+      bylineAuthorId: parsed.authorSchema?.name && factualGround?.authors?.length
+        ? (factualGround.authors[0].id || null)
+        : null,
+      allowedSelfReferences: [],
+      personalExperienceAllowed: false,
+      notes: 'Default institutional voice. A named byline does not authorize first-person anecdotes.'
+    };
   }
 
   // Attach author schema from factualGround if the LLM didn't emit one
@@ -205,6 +203,10 @@ Return ONLY the JSON object.`;
       jobTitle: fallbackAuthor.title || null
     };
   }
+  parsed.narrativeIdentity = normalizeNarrativeIdentity(parsed.narrativeIdentity, {
+    brandName,
+    author: factualGround?.authors?.find(a => a?.name === parsed.authorSchema?.name) || factualGround?.authors?.[0] || null
+  });
 
   // Sanitize eeatInjections + smeHooks: unwrap any stringified JSON back to its suggestedContent prose.
   const unwrapLeakedJSON = (item) => {

--- a/src/server/routes/compliance.js
+++ b/src/server/routes/compliance.js
@@ -11,6 +11,7 @@ import { anthropic } from '../llm.js';
 import { safeParseLLM } from '../llm-json.js';
 import { finalizeArticleForStorage } from '../text.js';
 import { verifyBrandAccess } from '../auth.js';
+import { normalizeNarrativeIdentity, lintNarrativePerspective } from '../narrative-identity.js';
 import { findCitationSources } from '../citations.js';
 
 const router = express.Router();
@@ -430,6 +431,32 @@ Return ONLY valid JSON in this exact structure:
         report.flags = report.flags.map(f => ({ ...f, sectionIndex: Math.max(0, f.sectionIndex - 1) }));
       }
     }
+
+    // Perspective lint: ensure article sections respect the stored narrativeIdentity.
+    try {
+      const articleIdentity = articleJson?.narrativeIdentity || {};
+      const normalizedIdentity = normalizeNarrativeIdentity(articleIdentity, { brandName: brand?.brand_name || '', author: fg?.authors?.find(a => a?.name === articleJson?.authorSchema?.name) || fg?.authors?.[0] || null });
+      const sections = articleJson?.sections || [];
+      report.flags = report.flags || [];
+      sections.forEach((s, i) => {
+        const text = String(s.body || s.content || '').slice(0, 5000);
+        if (!text) return;
+        const lint = lintNarrativePerspective(text, normalizedIdentity, { brandName: brand?.brand_name || '' });
+        if (!lint.ok && lint.issues?.length) {
+          lint.issues.forEach(issue => {
+            report.flags.push({
+              sectionIndex: i,
+              sectionHeading: s.heading || s.title || 'Untitled',
+              severity: issue.severity === 'red' ? 'red' : 'yellow',
+              type: 'brand_voice',
+              flaggedExcerpt: issue.phrase || '',
+              reason: issue.message || 'Perspective mismatch with narrative identity',
+              suggestion: 'Align pronouns and experience claims with the selected narrative identity.'
+            });
+          });
+        }
+      });
+    } catch (e) { console.warn('[COMPLIANCE] perspective lint failed:', e.message); }
 
     // Persist compliance report to article record
     await pool.query(


### PR DESCRIPTION
This pull request introduces a robust system for handling and enforcing narrative identity (the perspective, narrator, and attribution style) in generated articles and campaign briefs. The main changes include the addition of a new `narrative-identity.js` module, integration of narrative identity normalization and enforcement throughout article generation, campaign enrichment, and compliance review, and improved schema and fallback handling for narrative identity. These changes ensure that the editorial voice remains consistent and intentional, and that downstream systems can reliably interpret and enforce the intended narrative perspective.

**Narrative Identity System Integration:**

* Added new `src/server/narrative-identity.js` module with functions to normalize narrative identity, generate prompt blocks, lint article perspective, and provide a contract schema. This enables consistent handling of narrator, pronouns, and experience claims across the application.

**Article Generation Improvements:**

* In `server.js`, narrative identity is now normalized and injected into the article prompt, ensuring that the LLM receives explicit, non-negotiable instructions about narrator and perspective. The normalized identity is also persisted in the article JSON for downstream use. [[1]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fR10) [[2]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL4170-R4180) [[3]](diffhunk://#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fL4318-R4332)

**Campaign Brief Enrichment:**

* The campaign enrichment prompt in `src/server/routes/campaign.js` now includes a detailed `narrativeIdentity` schema and guidance, clarifying that a byline does not automatically imply first-person narration. Fallback logic for missing narrative identity now defaults to an institutional/company voice unless explicitly overridden, and all narrative identities are normalized before use. [[1]](diffhunk://#diff-007adbe59e0ed06a38ed6ebf74cda8bdfba852e15a93b713020e9d94e0060676R21) [[2]](diffhunk://#diff-007adbe59e0ed06a38ed6ebf74cda8bdfba852e15a93b713020e9d94e0060676L137-R151) [[3]](diffhunk://#diff-007adbe59e0ed06a38ed6ebf74cda8bdfba852e15a93b713020e9d94e0060676R181-L198) [[4]](diffhunk://#diff-007adbe59e0ed06a38ed6ebf74cda8bdfba852e15a93b713020e9d94e0060676R206-R209)

**Compliance and Perspective Linting:**

* Compliance review in `src/server/routes/compliance.js` now lints article sections against the stored narrative identity, flagging perspective mismatches (e.g., unauthorized first-person anecdotes) and suggesting corrections. [[1]](diffhunk://#diff-8f85458ac30321de5faa7f5c2922725713ee91901d7bc53b1e19f20746be40deR14) [[2]](diffhunk://#diff-8f85458ac30321de5faa7f5c2922725713ee91901d7bc53b1e19f20746be40deR435-R460)

These changes provide a clear editorial contract for every article, reduce accidental shifts in narrative perspective, and make compliance and downstream processing more reliable.