### PR TITLE
Fix byline author resolution and first-person speaker inference

### DIFF
--- a/src/server/narrative-identity.js
+++ b/src/server/narrative-identity.js
@@ -33,13 +33,16 @@ export function normalizeNarrativeIdentity(identity, { brandName = '', author = 
   const source = identity && typeof identity === 'object' ? identity : {};
   const explicit = Object.keys(source).length > 0;
   const authorName = asText(source.speakerName) || asText(author?.name) || null;
-  const hasExplicitPerson = VALID_SPEAKERS.has(source.speakerType) && source.speakerType === 'person';
   const grammaticalPerson = VALID_PERSONS.has(source.grammaticalPerson)
     ? source.grammaticalPerson
     : 'third_plural';
+  // Infer speaker from the grammatical person when speakerType is missing/invalid:
+  // a first-person-singular contract is an individual speaking, so it must not
+  // collapse to a 'company' speaker (which would pair company voice with I/me/my
+  // and force speakerName to the brand instead of the author).
   const speakerType = VALID_SPEAKERS.has(source.speakerType)
     ? source.speakerType
-    : (explicit && hasExplicitPerson ? 'person' : 'company');
+    : (explicit && grammaticalPerson === 'first_singular' ? 'person' : 'company');
   const subjectType = VALID_SUBJECTS.has(source.subjectType) ? source.subjectType : 'company';
   const personalExperienceAllowed = explicit
     ? boolValue(source.personalExperienceAllowed, grammaticalPerson === 'first_singular' && speakerType === 'person')

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -186,8 +186,8 @@ Return ONLY the JSON object.`;
       speakerType: 'company',
       grammaticalPerson: 'third_plural',
       speakerName: brandName || null,
-      bylineAuthorId: parsed.authorSchema?.name && factualGround?.authors?.length
-        ? (factualGround.authors[0].id || null)
+      bylineAuthorId: (parsed.authorSchema?.name && Array.isArray(factualGround?.authors))
+        ? (factualGround.authors.find(a => a?.name === parsed.authorSchema.name)?.id || null)
         : null,
       allowedSelfReferences: [],
       personalExperienceAllowed: false,

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -186,8 +186,11 @@ Return ONLY the JSON object.`;
       speakerType: 'company',
       grammaticalPerson: 'third_plural',
       speakerName: brandName || null,
-      bylineAuthorId: (parsed.authorSchema?.name && Array.isArray(factualGround?.authors))
-        ? (factualGround.authors.find(a => a?.name === parsed.authorSchema.name)?.id || null)
+      bylineAuthorId: (typeof parsed.authorSchema?.name === 'string' && Array.isArray(factualGround?.authors))
+        ? (factualGround.authors.find(a =>
+          typeof a?.name === 'string' &&
+          a.name.trim().toLowerCase() === parsed.authorSchema.name.trim().toLowerCase()
+        )?.id || null)
         : null,
       allowedSelfReferences: [],
       personalExperienceAllowed: false,

--- a/test/narrative-identity.test.js
+++ b/test/narrative-identity.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeNarrativeIdentity,
+  lintNarrativePerspective
+} from '../src/server/narrative-identity.js';
+
+describe('normalizeNarrativeIdentity', () => {
+  it('missing identity preserves institutional (company/third-plural) voice', () => {
+    const n = normalizeNarrativeIdentity(undefined, { brandName: 'Acme' });
+    expect(n.explicit).toBe(false);
+    expect(n.speakerType).toBe('company');
+    expect(n.grammaticalPerson).toBe('third_plural');
+    expect(n.speakerName).toBe('Acme');
+    expect(n.personalExperienceAllowed).toBe(false);
+  });
+
+  // Bug fix: an explicit first-person-singular contract that omits speakerType
+  // must resolve to a PERSON speaker (not collapse to 'company'), and the
+  // speakerName must be the author, not the brand.
+  it('explicit first_singular without speakerType resolves to the author, not the company', () => {
+    const n = normalizeNarrativeIdentity(
+      { grammaticalPerson: 'first_singular' },
+      { brandName: 'Acme', author: { name: 'Jane Founder', id: 'auth_jane' } }
+    );
+    expect(n.speakerType).toBe('person');
+    expect(n.grammaticalPerson).toBe('first_singular');
+    expect(n.speakerName).toBe('Jane Founder');
+    expect(n.speakerName).not.toBe('Acme');
+    expect(n.personalExperienceAllowed).toBe(true);
+    expect(n.allowedSelfReferences).toContain('I');
+  });
+
+  it('an explicit speakerType is always honored, even against the grammatical person', () => {
+    const n = normalizeNarrativeIdentity(
+      { speakerType: 'person', grammaticalPerson: 'first_plural' },
+      { brandName: 'Acme', author: { name: 'Jane' } }
+    );
+    expect(n.speakerType).toBe('person');
+    expect(n.speakerName).toBe('Jane');
+  });
+
+  it('a non-first-singular explicit contract without speakerType stays company', () => {
+    const n = normalizeNarrativeIdentity(
+      { grammaticalPerson: 'third_plural' },
+      { brandName: 'Acme', author: { name: 'Jane' } }
+    );
+    expect(n.speakerType).toBe('company');
+    expect(n.speakerName).toBe('Acme');
+  });
+
+  it('passes a caller-provided bylineAuthorId through untouched (source must be correct)', () => {
+    const n = normalizeNarrativeIdentity(
+      { grammaticalPerson: 'third_plural', bylineAuthorId: 'auth_correct' },
+      { brandName: 'Acme' }
+    );
+    expect(n.bylineAuthorId).toBe('auth_correct');
+  });
+});
+
+describe('lintNarrativePerspective', () => {
+  it('flags first-person singular in a company third-plural contract', () => {
+    const identity = normalizeNarrativeIdentity({ grammaticalPerson: 'third_plural' }, { brandName: 'Acme' });
+    const res = lintNarrativePerspective('I built this platform myself.', identity);
+    expect(res.ok).toBe(false);
+    expect(res.issues.some(i => i.type === 'unexpected_first_person')).toBe(true);
+  });
+
+  it('flags unsupported personal anecdote when personal experience is not allowed', () => {
+    const identity = normalizeNarrativeIdentity({ grammaticalPerson: 'third_plural' }, { brandName: 'Acme' });
+    const res = lintNarrativePerspective('In my experience, the market always rewards speed.', identity);
+    expect(res.issues.some(i => i.type === 'unsupported_personal_experience' && i.severity === 'red')).toBe(true);
+  });
+
+  it('clean company-voice prose passes', () => {
+    const identity = normalizeNarrativeIdentity({ grammaticalPerson: 'third_plural' }, { brandName: 'Acme' });
+    const res = lintNarrativePerspective('Acme helps teams ship faster with less overhead.', identity);
+    expect(res.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
This pull request improves the handling and testing of narrative identity normalization, especially for cases where the speaker type is omitted but the grammatical person is first-person singular. It also fixes author attribution logic and adds comprehensive tests to prevent regressions.

**Narrative identity logic improvements:**

* Fixed `normalizeNarrativeIdentity` so that when an explicit contract specifies `grammaticalPerson: 'first_singular'` but omits `speakerType`, it correctly infers a `'person'` speaker and uses the author's name, rather than defaulting to `'company'` and the brand name.
* Updated the logic for `bylineAuthorId` to find the correct author by name from `factualGround.authors`, ensuring the right author is attributed when multiple authors are present.

**Testing and validation:**

* Added a new test suite in `test/narrative-identity.test.js` covering various scenarios for `normalizeNarrativeIdentity`, including the fixed bug, honoring explicit speaker types, and author ID passthrough.
* Added tests for `lintNarrativePerspective` to ensure it flags mismatches between grammatical person and speaker type, and validates personal experience usage.