### PR TITLE
feat(narrative): persist narrative_identity + wire byline through publishing & UI

### DIFF
--- a/FACTUAL-GROUND-PITCHBOX.md
+++ b/FACTUAL-GROUND-PITCHBOX.md
@@ -1,0 +1,130 @@
+# Forge Intelligence — Optimized Factual Ground for Pitch Box (handoff)
+
+**For:** the Forge Intelligence repo agent (#forge-intelligence-agent) · **Author:** Gibson · **Date:** 2026-07-29
+**Assumption:** this is for the **Pitch Box** brand profile (the GTM push we've been building — email, DMs, site,
+LinkedIn page). If it's a different brand profile, repoint and I'll re-draft. Brian confirms the facts; I do NOT
+invent numbers (the whole pipeline is grounded-never-invented).
+
+---
+
+## Why this matters (the diagnosis)
+
+Factual Ground is `brand_profiles.settings.factualGround` — "founder-provided facts and credentials, used as
+**verbatim** source material" (`marketing.js`). It feeds the content generator, social generator, compliance gate,
+and geo-strategist. Every downstream stage is starved without it: the generator can only produce **statistical
+anchors, factual anchors, and self-as-case-study proof** if the facts exist here. A thin Factual Ground →
+qualitative, hedged, uncitable content and `[NEEDS CITATION]` flags everywhere. Optimizing it = the single highest
+-leverage GEO move, same failure mode as the DM writer being starved of `connectedOn`.
+
+**The biggest lever is dated, numeric, first-party outcomes** — a won pitch, time saved, a win-rate change. Those
+become the statistical anchors + self-as-case-study proof GEO rewards most (Princeton KDD: sources +30–115%, stats
++40%, quotes +30–40%). That's the gap only Brian can fill — marked `[BRIAN: ADD REAL NUMBER]` below.
+
+---
+
+## The Factual Ground (copy) — fits the schema in `context-hub.js` exactly
+
+Required: `brandName, whatWeDo, whatWeDoNot, competitors`. Optional but high-value: `foundingStory, methodology,
+teamComposition, quotablePositions, namedAuthors`. (Char caps: whatWeDo/whatWeDoNot 2000, competitors/foundingStory/
+methodology/quotablePositions 1500, teamComposition 1000, namedAuthors 800.)
+
+### brandName
+`Pitch Box`
+
+### whatWeDo
+Pitch Box is an AI-native RFP and pitch engine built specifically for experiential and creative agencies. It ingests
+an incoming RFP, extracts every requirement and evaluation criterion, identifies the buying committee, and drafts
+every section of the response from the agency's OWN case studies and knowledge base — grounded in the agency's real
+evidence, never invented. It parses a full RFP (~26 sections) in about 60 seconds `[BRIAN VERIFY: current metric]`,
+keeps 100% of claims traceable to a source, and produces 0 hallucinated facts. It ships with a self-building
+knowledge base that scrapes the agency's own site and past work so the library compounds with every pursuit, a Bid
+Qualifier that gives a go/no-go call before the team sinks senior hours into a long shot, and unlimited seats so the
+whole pursuit team works in one place. The human sharpens and owns the final pitch; Pitch Box removes the blank-page
+grind and the scramble to find the right proof point.
+
+Pitch Box's coverage doesn't stop at the win. Its Consistency Engine picks up the moment an RFP is marked won: it
+locks a versioned "North-Star" (the goals, KPIs, audience, voice, themes, and scope the agency actually committed to
+in the winning bid), then as the team's real delivery work lands (decks, docs, planning artifacts), a forensic scan
+diffs that work against the North-Star across seven dimensions and surfaces drift, including scope creep and gap,
+the SOW-drift problem most RFP tools never touch because they stop at proposal submission. Every flagged drift is
+human-reviewed, and every dismissal teaches the system what to ignore next time.
+
+### whatWeDoNot  (→ becomes strategicMoats, NOT competitiveGaps)
+Pitch Box is NOT a generic AI writer and NOT a content spinner. It does not invent facts, statistics, or client
+outcomes — every claim it drafts is traceable to the agency's own evidence, which is the whole point: an AI that
+fabricates your proof points loses you the pitch. It is not a full proposal-management suite or a CRM, and it does
+not replace the pursuit team, the creative, or the strategy — it makes a strong team faster and turns their past
+wins into compounding, retrievable evidence. It is not built for generic enterprise IT/security questionnaires; it
+is built for the creative and experiential agency pitch motion specifically.
+
+### competitors / who buyers also evaluate
+The default alternative is the status quo: senior people hand-assembling responses in Google Docs or Word under
+deadline, hunting proof points across old decks and people's heads. Buyers also evaluate: (a) generic AI writers used
+raw (ChatGPT, Jasper, Copy.ai) — fast but ungrounded, they hallucinate claims an agency cannot stand behind; (b)
+enterprise RFP-response platforms (Loopio, Responsive/RFPIO, Qvidian) — built for repeatable IT/SaaS security
+questionnaires, not creative competitive pitches; (c) proposal/document tools (PandaDoc, Qwilr) — polish and
+e-sign, not grounded drafting. `[BRIAN VERIFY: which of these you actually position against — do not list a
+competitor you don't mean to name.]` The wedge vs. all of them: grounded in the agency's own evidence, and built for
+the creative pitch rather than a generic writer.
+
+### foundingStory
+Pitch Box comes out of Sandbox Group LLC, founded by Brian Morgan — a designer, coder, and operator with 15 years in
+brand experience and experiential marketing who has lived the RFP grind from the inside, subcontracting for
+experiential agencies (Czarnowski, Sommers House) and delivering for clients like Intel and HubSpot.
+`[BRIAN: ADD the specific moment that made you build it — a brutal pursuit weekend, a pitch you should have won, the
+realization that win rate is an evidence problem before it's a writing problem. First-person + dated = high-value.]`
+
+### methodology
+Grounded generation. Pitch Box (1) ingests the RFP and extracts requirements, evaluation criteria, and the buying
+committee; (2) retrieves matching proof from the agency's own case-study library and self-building knowledge base;
+(3) drafts each section with 100% of claims traceable to that evidence and 0 invented facts; (4) runs a Bid
+Qualifier go/no-go so senior time only goes to winnable pursuits; (5) hands a sharp draft to the human, who owns the
+final. The principle: AI as a disciplined evidence engine, never a magic word generator.
+
+### teamComposition
+`[BRIAN: solo-founder-led out of Sandbox Group LLC (+ any collaborators). Add any real credential that lifts E-E-A-T —
+e.g., "built by an operator who has personally run/won N agency pursuits" if true. Keep it factual.]`
+
+### quotablePositions / hot takes  (this is the ONLY source the generator may quote from — real positions you'd defend)
+- "The RFP grind is a capacity problem, not a talent problem. Your best people aren't slow; the evidence is scattered."
+- "An AI that invents your proof points will lose you the pitch. Grounding isn't a feature, it's the whole game."
+- "Win rate is an evidence problem before it's a writing problem."
+- "Your best case studies are trapped in old decks and in people's heads. That's the real bottleneck."
+- "You don't need a faster blank page. You need your own wins, retrievable at pursuit speed."
+- "Winning the RFP isn't where agency risk ends. It's where it starts: scope creep and SOW drift happen after the
+  signature, and almost nobody instruments it."
+`[BRIAN: cut/rewrite to your actual voice; add the ones you'd say on a stage.]`
+
+### namedAuthors  (the only humans the generator may attribute quotes to)
+Brian Morgan — Founder, Sandbox Group LLC / Pitch Box. 15 years in brand experience and experiential marketing; fine
+arts (Penn State); building on the web since 2001; has delivered for Intel and HubSpot and subcontracted for major
+experiential agencies. `[BRIAN: confirm the exact title/byline you want, + add any other real, quotable teammate.]`
+
+---
+
+## `[BRIAN: ADD REAL NUMBERS]` — the highest-value gap (dated, first-party, verifiable)
+
+These are what turn hedged prose into cited authority. Only add ones that are TRUE:
+- A real pursuit outcome: "cut a [Czarnowski] RFP response from **X days to Y**," or "drafted a 26-section RFP in
+  **~60 seconds** vs. a typical **N-hour** first pass."
+- A win: "used Pitch Box on **[named/anonymized pursuit]**, **won**, **$X** engagement" (dated).
+- Adoption: seats, agencies onboarded, RFPs processed to date — any real count with a date.
+- Anything you'd put your name behind on-chain. Leave blank rather than estimate; the generator flags gaps itself.
+
+---
+
+## Instructions for the Forge agent
+
+1. **Target:** the **Pitch Box** brand profile in Forge Intelligence's `brand_profiles`. Confirm the row before writing.
+2. **Load:** set `settings.factualGround` to the object above (keys verbatim: `brandName, whatWeDo, whatWeDoNot,
+   competitors, foundingStory, methodology, teamComposition, quotablePositions, namedAuthors`) via the Context Hub
+   path (`context-hub.js` `handleQuickStartSynthesis` / the Factual Ground input). Stamp `_updatedAt`.
+3. **Strip the `[BRIAN ...]` / `[BRIAN VERIFY]` placeholders** before saving — do NOT persist bracketed instructions
+   as facts. Any field Brian hasn't filled: omit it rather than ship a placeholder as source material.
+4. **Do not fabricate.** Only Brian-verified facts go in. Where a number is missing, leave it out; the generator
+   correctly emits `[NEEDS CITATION]` and yellow/red confidence, which is the intended behavior.
+5. **After load:** regenerate one article + one social post and check that `overallConfidence`/`brainMatchScore`
+   climb and that sections now carry statistical + factual anchors instead of qualitative filler. That's the proof
+   the Factual Ground optimization landed.
+
+**Scope guard:** Pitch Box brand profile only. Do not touch other brands' Factual Ground.

--- a/server.js
+++ b/server.js
@@ -1023,6 +1023,18 @@ app.get('/api/articles/:brandSlug/:articleSlug', async (req, res) => {
     if (!matchedArticle) return res.status(404).json({ error: 'Article not found' });
 
     const articleJson = matchedArticle.article_json || {};
+    // narrative_identity is mirrored to its own column at write time; fall back to the
+    // article_json copy for rows written before that column existed.
+    const narrativeIdentity = matchedArticle.narrative_identity || articleJson.narrativeIdentity || null;
+    let bylineAuthor = null;
+    if (narrativeIdentity?.speakerType === 'person' && narrativeIdentity?.bylineAuthorId) {
+      try {
+        const authorsRaw = matchedBrand?.profile_data?.factualGround?.authors
+          || matchedBrand?.profile_data?.authors || [];
+        bylineAuthor = (Array.isArray(authorsRaw) ? authorsRaw : [])
+          .find(a => a?.id === narrativeIdentity.bylineAuthorId) || null;
+      } catch { /* non-fatal */ }
+    }
     res.json({
       title: matchedArticle.title,
       sections: articleJson.sections || [],
@@ -1034,6 +1046,14 @@ app.get('/api/articles/:brandSlug/:articleSlug', async (req, res) => {
       faqs: Array.isArray(articleJson.faqs) ? articleJson.faqs : [],
       brandName: matchedBrand?.brand_name || matchedBrand?.profile_data?.voice_profile?.brand_name || brandSlug,
       createdAt: matchedArticle.created_at,
+      narrativeIdentity: narrativeIdentity ? {
+        speakerType: narrativeIdentity.speakerType || 'company',
+        speakerName: narrativeIdentity.speakerName || null,
+      } : null,
+      byline: bylineAuthor ? {
+        name: bylineAuthor.name || narrativeIdentity.speakerName || null,
+        title: bylineAuthor.title || bylineAuthor.role || null,
+      } : null,
     });
   } catch (err) {
     console.error('[PUBLIC-ARTICLE]', err.message);
@@ -3977,7 +3997,11 @@ app.get('/api/assets/:filename', async function (req, res) {
 // ensureGeneratedContentTable moved to src/server/content-table.js (imported at top).
 
 app.get('/api/content-generator/generate', requireAuth, async (req, res) => {
-  const { brandProfileId, enrichedBriefId, force, topicPrompt, mandatories, constraints, audience, ctaTarget, desiredAction, wordCountTarget } = req.query;
+  const { brandProfileId, enrichedBriefId, force, topicPrompt, mandatories, constraints, audience, ctaTarget, desiredAction, wordCountTarget, writingAs } = req.query;
+  // writingAs: 'company' forces the institutional/company-voice contract; an author id
+  // (matched against factualGround.authors[].id) forces first-person-singular as that
+  // person. Omitted → falls back to the enriched brief's own narrativeIdentity/defaults.
+  const writingAsOverride = typeof writingAs === 'string' && writingAs.trim() ? writingAs.trim() : null;
   if (!brandProfileId) return res.status(400).json({ success: false, error: 'brandProfileId required' });
 
   // SSE headers
@@ -4174,8 +4198,28 @@ The entire piece is about exactly this, and the title you return must match this
     const identityAuthor = enrichedBrief?.authorSchema?.name
       ? (factualGround?.authors || []).find(a => a.name === enrichedBrief.authorSchema.name) || null
       : (factualGround?.authors || [])[0] || null;
-    const identityNormalized = normalizeNarrativeIdentity(enrichedBrief?.narrativeIdentity || {}, { brandName, author: identityAuthor });
-    const identityBlock = narrativeIdentityPromptBlock(identityNormalized, { brandName, author: identityAuthor });
+    // A UI-supplied writingAs override takes priority over the enriched brief's own
+    // narrativeIdentity: 'company' forces third-person-plural institutional voice;
+    // an author id forces first-person-singular as that specific person.
+    let identityInput = enrichedBrief?.narrativeIdentity || {};
+    let identityOverrideAuthor = identityAuthor;
+    if (writingAsOverride === 'company') {
+      identityInput = { speakerType: 'company', grammaticalPerson: 'third_plural', speakerName: brandName || null };
+    } else if (writingAsOverride) {
+      const matchedAuthor = (factualGround?.authors || []).find(a => a?.id === writingAsOverride);
+      if (matchedAuthor) {
+        identityOverrideAuthor = matchedAuthor;
+        identityInput = {
+          speakerType: 'person',
+          grammaticalPerson: 'first_singular',
+          speakerName: matchedAuthor.name || null,
+          bylineAuthorId: matchedAuthor.id,
+          personalExperienceAllowed: true,
+        };
+      }
+    }
+    const identityNormalized = normalizeNarrativeIdentity(identityInput, { brandName, author: identityOverrideAuthor });
+    const identityBlock = narrativeIdentityPromptBlock(identityNormalized, { brandName, author: identityOverrideAuthor });
 
     const userPrompt = `${articleDirectiveBlock}${identityBlock}Generate a long-form article using the following Brand Intelligence context.
 ${topicPrompt ? `\nUSER TOPIC DIRECTION (write the article around this specific topic/angle — this overrides the enriched brief's default topic selection):\n"${topicPrompt}"\n` : ''}${(mandatories || constraints || audience || ctaTarget || desiredAction || wordCountTarget) ? `\nUSER MANDATORIES & CONSTRAINTS (the user-supplied non-negotiables for this article — every section must respect these. Treat as harder than brand patterns):\n${mandatories ? `- MANDATORIES (must include): ${mandatories}\n` : ''}${constraints ? `- CONSTRAINTS (must NOT do): ${constraints}\n` : ''}${audience ? `- TARGET AUDIENCE: ${audience}\n` : ''}${ctaTarget ? `- CTA TARGET URL/PATH: ${ctaTarget} — every CTA in the article should reference this destination.\n` : ''}${desiredAction ? `- DESIRED READER ACTION: ${desiredAction} — shape the article and conclusion to drive toward this specific next step.\n` : ''}${wordCountTarget ? `- TARGET LENGTH: approximately ${wordCountTarget} words. Do not pad — depth over filler.\n` : ''}` : ''}${selfAsCaseStudyBlock}${factualGroundBlock}${territoriesBlock}${cgMeasuredBlock}${cgCompetitorBlock}${cgMoatsBlock}
@@ -4351,8 +4395,8 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
 
     const tableName = await ensureGeneratedContentTable(brandProfileId);
     const contentInsert = await pool.query(
-      `INSERT INTO ${tableName} (brand_profile_id, enriched_brief_id, title, article_json, overall_confidence, brain_match_score, status)
-       VALUES ($1, $2, $3, $4, $5, $6, 'draft') RETURNING id`,
+      `INSERT INTO ${tableName} (brand_profile_id, enriched_brief_id, title, article_json, overall_confidence, brain_match_score, status, narrative_identity)
+       VALUES ($1, $2, $3, $4, $5, $6, 'draft', $7) RETURNING id`,
       [brandProfileId, enrichedBriefId || loadedEnrichedBriefId || null, parsed.title, JSON.stringify(parsed),
        parsed.overallConfidence || null, parsed.brainMatchScore || (() => {
          // Fallback: Claude dropped the field — compute from section confidences
@@ -4360,7 +4404,7 @@ Return ONLY valid JSON matching the specified output format. No markdown, no cod
          if (!sections.length) return null;
          const avg = sections.reduce((a, s) => a + (s.confidence || 0), 0) / sections.length;
          return Math.round(avg);
-       })()]
+       })(), JSON.stringify(parsed.narrativeIdentity || identityNormalized || null)]
     );
     const contentId = contentInsert.rows[0]?.id;
 

--- a/src/pages/ContentGeneratorPage.tsx
+++ b/src/pages/ContentGeneratorPage.tsx
@@ -130,6 +130,8 @@ function ContentGeneratorContent() {
   const [ctaTarget, setCtaTarget] = useState('');
   const [desiredAction, setDesiredAction] = useState('');
   const [wordCountTarget, setWordCountTarget] = useState('');
+  const [writingAs, setWritingAs] = useState(''); // '' = brief default, 'company', or an author id
+  const [availableAuthors, setAvailableAuthors] = useState<Array<{ id: string; name: string; title?: string }>>([]);
   const [ideaDrawerOpen, setIdeaDrawerOpen] = useState(false);
   const [ideas, setIdeas] = useState<{id:string;topic:string;note:string|null;status:string;created_at:string}[]>([]);
   const [newIdea, setNewIdea] = useState('');
@@ -183,6 +185,16 @@ function ContentGeneratorContent() {
           }
         }
       })
+      .catch(() => { /* non-fatal */ });
+  }, [selectedBrainId, authToken]);
+
+  // Load the brand's Factual Ground authors so "Writing as" can offer real people,
+  // not just the company default.
+  useEffect(() => {
+    if (!selectedBrainId || !authToken) { setAvailableAuthors([]); return; }
+    fetch(`/api/factual-ground/authors/${selectedBrainId}`, { headers: { 'Authorization': `Bearer ${authToken}` } })
+      .then(r => r.json())
+      .then(d => { if (d.success) setAvailableAuthors(d.authors || []); })
       .catch(() => { /* non-fatal */ });
   }, [selectedBrainId, authToken]);
 
@@ -305,6 +317,7 @@ function ContentGeneratorContent() {
       if (desiredAction.trim()) qs.set('desiredAction', desiredAction.trim());
       if (wordCountTarget.trim()) qs.set('wordCountTarget', wordCountTarget.trim());
     }
+    if (writingAs) qs.set('writingAs', writingAs);
     if (authToken) qs.set('token', authToken);
     const es = new EventSource(`/api/content-generator/generate?${qs.toString()}`);
     streamRef.current = es;
@@ -479,6 +492,24 @@ function ContentGeneratorContent() {
               </div>
             );
           })()}
+
+          {selectedBrainId && (
+            <div style={{ marginBottom: 10, display: 'flex', alignItems: 'center', gap: 8 }}>
+              <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-text-primary, #1a1a1a)', whiteSpace: 'nowrap' }}>Writing as</label>
+              <select
+                value={writingAs}
+                onChange={e => setWritingAs(e.target.value)}
+                title="Who is speaking in this article: the company (third-person) or a named person (first-person). Leave on Brief default to let the enriched brief's own editorial contract decide."
+                style={{ padding: '6px 10px', border: '1px solid var(--color-border, #e2e8f0)', borderRadius: 6, fontFamily: 'inherit', fontSize: 13, background: 'var(--color-bg-card, #fff)' }}
+              >
+                <option value="">Brief default</option>
+                <option value="company">Company (third-person)</option>
+                {availableAuthors.map(a => (
+                  <option key={a.id} value={a.id}>{a.name}{a.title ? ` — ${a.title}` : ''} (first-person)</option>
+                ))}
+              </select>
+            </div>
+          )}
 
           <div className="geo-input-bar">
           <div style={{ flex: 1 }}>

--- a/src/pages/PublicArticlePage.tsx
+++ b/src/pages/PublicArticlePage.tsx
@@ -206,6 +206,8 @@ interface ArticleData {
   metaDescription?: string;
   keyTakeaway?: string;
   faqs?: ArticleFAQ[];
+  narrativeIdentity?: { speakerType?: string; speakerName?: string | null } | null;
+  byline?: { name?: string | null; title?: string | null } | null;
 }
 
 export default function PublicArticlePage() {
@@ -263,9 +265,42 @@ export default function PublicArticlePage() {
     ? new Date(article.createdAt).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
     : null;
 
+  // Prefer a person byline when the article's narrative identity contract names one
+  // (founder/author voice); otherwise fall back to the brand name as the speaker.
+  const isPersonSpeaker = article.narrativeIdentity?.speakerType === 'person';
+  const displayAuthorName = (isPersonSpeaker && (article.byline?.name || article.narrativeIdentity?.speakerName))
+    || article.brandName;
+  const displayAuthorTitle = isPersonSpeaker ? (article.byline?.title || null) : null;
+
   const sections = article.sections || [];
   const firstSection = sections[0];
   const restSections = sections.slice(1);
+
+  // JSON-LD Article schema — author reflects the resolved narrative-identity byline
+  // (a named person when the article's editorial contract calls for one, otherwise
+  // the brand as an Organization). Injected imperatively since this app has no
+  // head-management library; cleaned up on unmount/navigation.
+  useEffect(() => {
+    if (!article) return;
+    const authorNode = isPersonSpeaker && displayAuthorName
+      ? { '@type': 'Person', name: displayAuthorName }
+      : { '@type': 'Organization', name: article.brandName || 'Forge Intelligence' };
+    const ld = {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      headline: article.title,
+      description: article.metaDescription || article.keyTakeaway || undefined,
+      image: article.heroImageUrl || undefined,
+      datePublished: article.createdAt || undefined,
+      author: authorNode,
+      publisher: { '@type': 'Organization', name: article.brandName || 'Forge Intelligence' },
+    };
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.text = JSON.stringify(ld);
+    document.head.appendChild(script);
+    return () => { document.head.removeChild(script); };
+  }, [article, isPersonSpeaker, displayAuthorName]);
 
   return (
     <div className="pa-page">
@@ -293,7 +328,11 @@ export default function PublicArticlePage() {
             {article.category && <div className="pa-eyebrow">{article.category}</div>}
             <h1 className="pa-title pa-title-over-hero">{article.title}</h1>
             <div className="pa-meta">
-              {article.brandName && <span className="pa-author">{article.brandName}</span>}
+              {displayAuthorName && (
+                <span className="pa-author">
+                  {displayAuthorName}{displayAuthorTitle ? `, ${displayAuthorTitle}` : ''}
+                </span>
+              )}
               <span className="pa-dot">·</span>
               <span className="pa-read-time">{readTime} min read</span>
               {publishDate && <><span className="pa-dot">·</span><span className="pa-date">{publishDate}</span></>}
@@ -305,7 +344,11 @@ export default function PublicArticlePage() {
           {article.category && <div className="pa-eyebrow">{article.category}</div>}
           <h1 className="pa-title">{article.title}</h1>
           <div className="pa-meta">
-            {article.brandName && <span className="pa-author">{article.brandName}</span>}
+            {displayAuthorName && (
+              <span className="pa-author">
+                {displayAuthorName}{displayAuthorTitle ? `, ${displayAuthorTitle}` : ''}
+              </span>
+            )}
             <span className="pa-dot">·</span>
             <span className="pa-read-time">{readTime} min read</span>
             {publishDate && <><span className="pa-dot">·</span><span className="pa-date">{publishDate}</span></>}

--- a/src/server/content-table.js
+++ b/src/server/content-table.js
@@ -33,5 +33,11 @@ export async function ensureGeneratedContentTable(brandProfileId) {
   // Campaign tracking — links articles generated via campaign generator back to their campaign
   await pool.query(`ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS campaign_id UUID`).catch(() => {});
   await pool.query(`ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS campaign_article_index INTEGER`).catch(() => {});
+  // Narrative identity — the normalized editorial contract (who is speaking, in what
+  // person, with what byline) computed at generation time. Mirrored out of
+  // article_json.narrativeIdentity into a first-class column so publishing, byline/
+  // JSON-LD rendering, and social/email generators can read it without parsing the
+  // full article blob. See src/server/narrative-identity.js.
+  await pool.query(`ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS narrative_identity JSONB`).catch(() => {});
   return tableName;
 }

--- a/src/server/routes/campaign.js
+++ b/src/server/routes/campaign.js
@@ -750,8 +750,8 @@ Return ONLY valid JSON matching the content generator output format.`;
         parsed = finalizeArticleForStorage(parsed);
         const insertedContent = await pool.query(
           `INSERT INTO ${contentTableName}
-            (brand_profile_id, title, article_json, overall_confidence, status, campaign_id, campaign_article_index, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, 'draft', $5, $6, NOW(), NOW())
+            (brand_profile_id, title, article_json, overall_confidence, status, campaign_id, campaign_article_index, narrative_identity, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, 'draft', $5, $6, $7, NOW(), NOW())
            ON CONFLICT DO NOTHING
            RETURNING id`,
           [
@@ -760,7 +760,8 @@ Return ONLY valid JSON matching the content generator output format.`;
             JSON.stringify(parsed),
             parsed.overallConfidence || angle.estimated_confidence || 75,
             campaign.id,
-            angle.index
+            angle.index,
+            JSON.stringify(parsed.narrativeIdentity || null)
           ]
         );
         const contentId = insertedContent.rows[0]?.id;

--- a/src/server/routes/content.js
+++ b/src/server/routes/content.js
@@ -372,14 +372,14 @@ Return ONLY valid JSON:
         editImpactScore: parsed.editImpactScore || null,
       };
       await pool.query(
-        `UPDATE ${tableName} SET article_json = $1, title = $2, updated_at = NOW() WHERE id = $3`,
-        [JSON.stringify(mergedJson), cleanedParsed.title || originalArticle.title, originalArticle.id]
+        `UPDATE ${tableName} SET article_json = $1, title = $2, narrative_identity = COALESCE($3, narrative_identity), updated_at = NOW() WHERE id = $4`,
+        [JSON.stringify(mergedJson), cleanedParsed.title || originalArticle.title, JSON.stringify(cleanedParsed.narrativeIdentity || null), originalArticle.id]
       );
       contentId = originalArticle.id;
     } else {
       const insertRes = await pool.query(
-        `INSERT INTO ${tableName} (brand_profile_id, title, article_json, overall_confidence, brain_match_score, status, review_mode, compliance_status)
-         VALUES ($1, $2, $3, $4, $5, 'staged', 'approve-to-ship', 'pending') RETURNING id`,
+        `INSERT INTO ${tableName} (brand_profile_id, title, article_json, overall_confidence, brain_match_score, status, review_mode, compliance_status, narrative_identity)
+         VALUES ($1, $2, $3, $4, $5, 'staged', 'approve-to-ship', 'pending', $6) RETURNING id`,
         [
           brandProfileId,
           cleanedParsed.title || sourceTitle || 'Imported Article',
@@ -389,7 +389,8 @@ Return ONLY valid JSON:
             importedAt: new Date().toISOString()
           }),
           parsed.overallConfidence || 50,
-          parsed.brainMatchScore || 50
+          parsed.brainMatchScore || 50,
+          JSON.stringify(cleanedParsed.narrativeIdentity || null)
         ]
       );
       contentId = insertRes.rows[0].id;


### PR DESCRIPTION
## What this closes

Follow-on to #536/#537/#538 (narrative-identity generation-layer engine + bugfixes). This lands the remaining 60%: DB persistence, downstream rendering, and a real UI control — the pieces that turn "logic exists" into "a user can pick company-vs-founder voice and have it actually publish with the right byline."

## Changes

- **DB:** `narrative_identity` JSONB column on every `generated_content_<brand>` table, added idempotently in `ensureGeneratedContentTable()` (`ADD COLUMN IF NOT EXISTS`, self-migrates on next call — same pattern as `campaign_id`/`campaign_article_index`). No manual migration step.
- **Persistence — all 3 write paths mirror it now:**
  - Stage-4 writer (`server.js`) — INSERT
  - Campaign generator (`campaign.js`) — INSERT
  - Content import (`content.js`) — both net-new INSERT and edit-reconciliation UPDATE (`COALESCE` so a merge-edit without `narrativeIdentity` doesn't null out the original)
- **UI control:** new **"Writing as"** selector on Content Generator (Brief default / Company / named author), sourced from the existing `/api/factual-ground/authors/:brandProfileId` endpoint. Wired into the generate SSE call as a new `writingAs` query param that overrides the enriched brief's own `narrativeIdentity` — `company` forces institutional third-person, an author id forces that person's first-person-singular voice.
- **Downstream rendering:**
  - Public article API (`/api/articles/:brandSlug/:articleSlug`) resolves `narrative_identity` → an optional `byline` (name + title from `factualGround.authors`) and returns both.
  - `PublicArticlePage.tsx` renders the resolved person byline instead of always defaulting to the brand name, and injects an `Article` JSON-LD block whose `author` is a `Person` when `speakerType === 'person'`, `Organization` otherwise (previously: no JSON-LD existed on this page at all).

## Verified

- `node --check` on every touched server file (`server.js`, `campaign.js`, `content.js`).
- Brace-balance sanity check on both edited `.tsx` files (no `tsc` available in this box's node_modules-less checkout — CI's `Typecheck & Test` will run the real check).
- No new dependencies.

## Still open after this (not in scope here)

- E2E QA — generate + review an article in both company and founder modes end-to-end, confirm it publishes correctly.
- Docs / WORKING-STATE update.
- Social/email generators still don't read `narrativeIdentity` — only the public article page does. Worth a follow-up if founder-voice content needs to carry through to those surfaces too.

🤖 Generated with care by the forge-intelligence agent, staged as draft for review (not auto-merge).