### PR TITLE
feat(compliance): verified-but-unnameable dismiss reason + redacted Factual Ground

### DIFF
--- a/server.js
+++ b/server.js
@@ -4138,6 +4138,7 @@ ${factualGround.methodology ? `METHODOLOGY / APPROACH (describe in these terms):
 ${factualGround.foundingStory ? `FOUNDING STORY (reference only these details):\n${factualGround.foundingStory}\n` : ''}
 ${factualGround.teamComposition ? `TEAM (only reference these people/roles):\n${factualGround.teamComposition}\n` : ''}
 ${factualGround.quotablePositions ? `QUOTABLE POSITIONS (use these phrases verbatim when making bold claims):\n${factualGround.quotablePositions}\n` : ''}
+${Array.isArray(factualGround.redactedFacts) && factualGround.redactedFacts.length ? `VERIFIED-BUT-REDACTED FACTS (owner-attested TRUE; the client/proper-noun is withheld by CONTRACT). Treat each as a first-party CITED fact: use the anonymized surface phrasing verbatim, drop ALL hedges on it (it is verified, not speculative), and NEVER name, guess, or hint at the underlying party — the redaction is a legal requirement, not a gap to fill:\n${factualGround.redactedFacts.map(r => `  • ${String(r.surface || '').slice(0, 300)}`).filter(s => s.trim() !== '•').join('\n')}\n` : ''}
 ${(() => {
   const assigned = enrichedBrief?.assignedAuthor;
   const authorsToUse = (assigned && assigned.name) ? [assigned] : (factualGround.authors || []);

--- a/src/agents/stage4_content_generator/system_prompt.md
+++ b/src/agents/stage4_content_generator/system_prompt.md
@@ -75,6 +75,8 @@ These patterns are what AI engines actually lift into answers. They are ranked b
 - **yellow** (50–79): Moderate confidence. SME quote needed OR factual claim needs verification. Flag it.
 - **red** (0–49): Low confidence. Explicit human decision required. Do NOT auto-publish.
 
+**Verified-but-redacted facts score GREEN.** When a claim maps to a `VERIFIED-BUT-REDACTED FACT` in the Factual Ground block, treat it exactly like a first-party cited fact: score it **green** with `confidenceReason: "Verified redacted fact (NDA)"`. The anonymized surface phrasing (e.g. "an enterprise technology client", "a Fortune 500 SaaS company") is owner-attested truth with the proper noun withheld by contract — it is NOT an unverified claim and must NOT be scored yellow "needs verification" for lacking a name. Never name, guess, or hint at the redacted party; the redaction is a legal requirement, not a gap.
+
 ## Writing Rules
 1. **Voice-matched**: Use brand vocabulary from the voice profile. Match formality_score and confidence_score.
 2. **Persona-targeted**: Write for the primary persona's pain point and trigger event.

--- a/src/pages/ComplianceGatePage.tsx
+++ b/src/pages/ComplianceGatePage.tsx
@@ -162,6 +162,11 @@ function ComplianceGateContent() {
   const [editedSections, setEditedSections] = useState<Record<number, string>>({});
   const [manualEditSections, setManualEditSections] = useState<Record<number, boolean>>({});
   const [dismissedFlags, setDismissedFlags] = useState<Record<number, boolean>>({});
+  // Dismiss reason picker: which section's menu is open, per-section outcome label,
+  // and the private referent typed for a "verified but unnameable (NDA)" dismissal.
+  const [dismissMenuIdx, setDismissMenuIdx] = useState<number | null>(null);
+  const [dismissOutcome, setDismissOutcome] = useState<Record<number, string>>({});
+  const [ndaReferent, setNdaReferent] = useState<string>('');
   const [decisions, setDecisions] = useState<Record<number, 'approved' | 'rejected'>>({});
   // FAQ edits — parallel structure to editedSections. Each FAQ entry can have its question
   // and/or answer overridden. Empty fields default to the LLM-generated original on submit.
@@ -296,8 +301,21 @@ function ComplianceGateContent() {
     }
   };
 
-  const dismissFlag = async (sectionIdx: number, flag: any) => {
+  // Dismiss with a typed reason. The reason is the brain signal (see compliance.js
+  // /dismiss-flag). For 'verified_unnameable' we also pass the flagged excerpt as the
+  // public `surface` and the optional private `trueReferent` (stored write-only, never
+  // fed back to a model) so the fact is promoted to Factual Ground and stops being
+  // re-flagged and under-scored on every future article.
+  const DISMISS_REASONS: { key: string; label: string; outcome: string }[] = [
+    { key: 'verified_nameable',   label: 'Verified — can name',        outcome: 'Verified fact — Brain updated' },
+    { key: 'verified_unnameable', label: "Verified — can't name (NDA)", outcome: 'Redacted fact — added to Factual Ground' },
+    { key: 'intentional_style',   label: 'Intentional voice/style',    outcome: 'Style, not a claim — Brain updated' },
+    { key: 'actually_wrong',      label: 'Flag was right',             outcome: 'Confirmed — no change' },
+  ];
+
+  const dismissFlag = async (sectionIdx: number, flag: any, reason: string) => {
     if (!selectedArticle || !activeBrand?.id) return;
+    const meta = DISMISS_REASONS.find(r => r.key === reason);
     try {
       const token = await getToken({ template: 'jwt-template-600' });
       await fetch('/api/compliance/dismiss-flag', {
@@ -309,9 +327,15 @@ function ComplianceGateContent() {
           flagType: flag.type,
           flagReason: flag.reason,
           sectionHeading: flag.sectionHeading || '',
+          reason,
+          surface: flag.flaggedExcerpt || flag.reason || '',
+          trueReferent: reason === 'verified_unnameable' ? (ndaReferent.trim() || null) : undefined,
         })
       });
       setDismissedFlags(p => ({ ...p, [sectionIdx]: true }));
+      setDismissOutcome(p => ({ ...p, [sectionIdx]: meta?.outcome || 'Dismissed — Brain updated' }));
+      setDismissMenuIdx(null);
+      setNdaReferent('');
     } catch(e) {
       console.error('Dismiss flag error:', e);
       reportError(e, { area: 'compliance-gate' });
@@ -746,16 +770,48 @@ function ComplianceGateContent() {
                                     ? (rewriteOutcomes[idx]?.mode === 'cited' ? 'Cited & Applied' : rewriteOutcomes[idx]?.mode === 'softened' ? 'Softened & Applied' : 'Rewrite Applied')
                                     : ((flag.type === 'factual_claim' || flag.type === 'legal_risk') ? 'Soften Without Citation' : 'Accept Suggestion')}
                               </button>
-                              {!dismissedFlags[idx] && (
+                              {!dismissedFlags[idx] && dismissMenuIdx !== idx && (
                                 <button
                                   className="comp-dismiss-flag-btn"
-                                  onClick={() => dismissFlag(idx, flag)}
+                                  onClick={() => { setDismissMenuIdx(idx); setNdaReferent(''); }}
                                 >
-                                  Dismiss Flag
+                                  Dismiss Flag ▾
                                 </button>
                               )}
+                              {!dismissedFlags[idx] && dismissMenuIdx === idx && (
+                                <div className="comp-dismiss-menu" style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6, padding: 10, border: '1px solid var(--color-border)', borderRadius: 8, background: 'var(--color-surface, rgba(148,163,184,0.06))' }}>
+                                  <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-text-secondary)' }}>Why is this a false positive?</div>
+                                  {DISMISS_REASONS.map(r => (
+                                    <button
+                                      key={r.key}
+                                      className="comp-dismiss-flag-btn"
+                                      style={{ textAlign: 'left' }}
+                                      onClick={() => dismissFlag(idx, flag, r.key)}
+                                      title={r.key === 'verified_unnameable'
+                                        ? 'True and owner-attested, but the client is contractually redacted. Promotes it to Factual Ground so it stops being flagged and under-scored.'
+                                        : r.outcome}
+                                    >
+                                      {r.label}
+                                    </button>
+                                  ))}
+                                  <input
+                                    type="text"
+                                    value={ndaReferent}
+                                    onChange={e => setNdaReferent(e.target.value)}
+                                    placeholder="(optional) private note: real client — stored, never published"
+                                    style={{ marginTop: 4, padding: '6px 8px', fontSize: 12, borderRadius: 6, border: '1px solid var(--color-border)', background: 'var(--color-bg, #fff)', color: 'var(--color-text)' }}
+                                  />
+                                  <button
+                                    className="comp-dismiss-flag-btn"
+                                    style={{ opacity: 0.7 }}
+                                    onClick={() => { setDismissMenuIdx(null); setNdaReferent(''); }}
+                                  >
+                                    Cancel
+                                  </button>
+                                </div>
+                              )}
                               {dismissedFlags[idx] && (
-                                <span className="comp-dismissed-label">Dismissed — Brain updated</span>
+                                <span className="comp-dismissed-label">{dismissOutcome[idx] || 'Dismissed — Brain updated'}</span>
                               )}
                             </div>
 

--- a/src/server/routes/compliance.js
+++ b/src/server/routes/compliance.js
@@ -6,6 +6,7 @@
 // registration lines changed (app.METHOD('/api/compliance/x', requireAuth, …)
 // -> router.METHOD('/x', …)).
 import express from 'express';
+import { randomUUID } from 'crypto';
 import { pool } from '../db.js';
 import { anthropic } from '../llm.js';
 import { safeParseLLM } from '../llm-json.js';
@@ -293,10 +294,11 @@ router.post('/critique', async (req, res) => {
     const fg = brand?.settings?.factualGround || null;
     const fgBlock = fg && Object.values(fg).some(v => v && (typeof v === 'string' ? v.trim() : (Array.isArray(v) && v.length)))
       ? `\nUSER-VERIFIED FACTS (stated by the brand owner — authoritative ground truth):
-${fg.whatWeDo ? `- What this brand does: ${String(fg.whatWeDo).slice(0, 500)}\n` : ''}${fg.whatWeDontDo ? `- What this brand does NOT do: ${String(fg.whatWeDontDo).slice(0, 500)}\n` : ''}${fg.companyFacts ? `- Company facts: ${String(fg.companyFacts).slice(0, 500)}\n` : ''}${fg.foundingStory ? `- Founding story: ${String(fg.foundingStory).slice(0, 400)}\n` : ''}${fg.methodology ? `- Methodology/frameworks: ${String(fg.methodology).slice(0, 400)}\n` : ''}${Array.isArray(fg.authors) && fg.authors.length ? `- Named team: ${fg.authors.map(a => `${a.name || ''}${a.title ? ` (${a.title})` : ''}`).filter(Boolean).join(', ')}\n` : ''}
+${fg.whatWeDo ? `- What this brand does: ${String(fg.whatWeDo).slice(0, 500)}\n` : ''}${fg.whatWeDontDo ? `- What this brand does NOT do: ${String(fg.whatWeDontDo).slice(0, 500)}\n` : ''}${fg.companyFacts ? `- Company facts: ${String(fg.companyFacts).slice(0, 500)}\n` : ''}${fg.foundingStory ? `- Founding story: ${String(fg.foundingStory).slice(0, 400)}\n` : ''}${fg.methodology ? `- Methodology/frameworks: ${String(fg.methodology).slice(0, 400)}\n` : ''}${Array.isArray(fg.authors) && fg.authors.length ? `- Named team: ${fg.authors.map(a => `${a.name || ''}${a.title ? ` (${a.title})` : ''}`).filter(Boolean).join(', ')}\n` : ''}${Array.isArray(fg.redactedFacts) && fg.redactedFacts.length ? `\nVERIFIED-BUT-REDACTED FACTS (owner-attested TRUE, but the client/proper-noun is withheld by contract — the anonymized surface phrasing is deliberate, not vague):\n${fg.redactedFacts.map(r => `- "${String(r.surface || '').slice(0, 300)}"`).filter(s => s !== '- ""').join('\n')}\n` : ''}
 How to use these facts:
 - A claim in the article that MATCHES or is directly supported by these facts is VERIFIED — do not flag it as an unverifiable factual_claim.
 - A claim that CONTRADICTS these facts (wrong founder, wrong methodology, claims the brand does something listed under "does NOT do") is a RED factual_claim flag — quote the contradicting excerpt and name the verified fact it violates.
+- A claim matching a VERIFIED-BUT-REDACTED fact is VERIFIED: never flag it as an unverifiable factual_claim, never treat the anonymized phrasing ("an enterprise technology client", "a Fortune 500 SaaS company") as hedging or vagueness to fix, and NEVER suggest naming the underlying party — the redaction is a contractual requirement, not a gap.
 - These facts are context for judging claims, NOT article content — the flaggedExcerpt rule is unchanged: every excerpt must still be a verbatim quote from the article section being flagged.`
       : '';
 
@@ -471,26 +473,112 @@ Return ONLY valid JSON in this exact structure:
   }
 });
 
-// POST dismiss-flag — user dismisses a false-positive flag, writes to brain as training signal
+// POST dismiss-flag — user dismisses a flag with a typed REASON. The reason is the
+// training signal. A flat "false positive" only teaches the Stage-5 critic to stop
+// flagging; a typed reason teaches WHY, and for a verified-but-unnameable (NDA) fact it
+// promotes the fact to Factual Ground so Stage-4 generation stops scoring it low on
+// every future article in the first place — the difference between swatting the same
+// flag forever and teaching the redaction rule once.
+//
+// reason ∈ { verified_nameable | verified_unnameable | intentional_style | actually_wrong }
+// Omitted/unknown reason => legacy flat dismiss (exact prior behavior, backward compat).
+//
+// For verified_unnameable the client MAY send { surface, trueReferent, note }:
+//   surface      — the phrasing that renders (defaults to the flagged excerpt); PUBLIC.
+//   trueReferent — the private truth behind it (e.g. the real client name). WRITE-ONLY:
+//                  stored for the owner's audit trail (and the day an NDA lifts) and
+//                  NEVER read back into any LLM prompt, so the gagged proper noun can
+//                  never leak into generated copy. Only `surface` ever reaches a model.
 router.post('/dismiss-flag', async (req, res) => {
-  const { brandProfileId, contentId, flagType, flagReason, sectionHeading } = req.body;
+  const { brandProfileId, contentId, flagType, flagReason, sectionHeading, reason, surface, trueReferent, note } = req.body;
   if (!brandProfileId || !contentId) return res.status(400).json({ error: 'brandProfileId and contentId required' });
+
+  const VALID_REASONS = ['verified_nameable', 'verified_unnameable', 'intentional_style', 'actually_wrong'];
+  const dismissReason = VALID_REASONS.includes(reason) ? reason : null; // null => legacy flat dismiss
+
   try {
-    await pool.query(
-      `INSERT INTO brain_mistakes (brand_profile_id, mistake_type, description, human_feedback, severity)
-       VALUES ($1, 'false_positive_flag', $2, $3, 'low')`,
-      [
-        brandProfileId,
-        `AI incorrectly flagged section "${sectionHeading || 'untitled'}" as ${flagType || 'unknown'} — user dismissed`,
-        `False positive: ${(flagReason || '').substring(0, 500)}. Do NOT flag similar content in future critiques for this brand.`
-      ]
-    );
+    let redactedFactAdded = false;
+
+    // Typed brain signal per reason. Each teaches something different from the flat
+    // "don't flag similar" of the legacy path. `actually_wrong` writes NO suppressive
+    // signal (the flag was correct — nothing to unlearn).
+    const where = `section "${sectionHeading || 'untitled'}" flagged as ${flagType || 'unknown'}`;
+    const brainSignal = (() => {
+      switch (dismissReason) {
+        case 'verified_unnameable':
+          return {
+            type: 'verified_unnameable',
+            description: `Claim in ${where} is VERIFIED but contractually unnameable (NDA/redacted) — promoted to Factual Ground redactedFacts.`,
+            feedback: `This claim is TRUE and owner-attested; only the client/proper-noun is redacted by contract. Score it high-confidence-redacted, do NOT flag it as an unverifiable factual_claim, and NEVER suggest naming the underlying party. Surface phrasing: "${String(surface || flagReason || '').slice(0, 300)}".`
+          };
+        case 'verified_nameable':
+          return {
+            type: 'verified_fact',
+            description: `Claim in ${where} is a VERIFIED, nameable fact — owner dismissed as false positive.`,
+            feedback: `Verified fact for this brand. Do NOT flag similar claims as unverifiable in future critiques. Excerpt: "${String(flagReason || '').slice(0, 400)}".`
+          };
+        case 'intentional_style':
+          return {
+            type: 'intentional_style',
+            description: `Flag in ${where} was a voice/style choice, not a factual claim — owner dismissed.`,
+            feedback: `This is an intentional voice/style construction, not a factual assertion. Do NOT treat or flag it as a factual_claim in future critiques for this brand.`
+          };
+        case 'actually_wrong':
+          return null; // flag was correct; record activity only, no suppressive signal
+        default: // legacy flat dismiss — preserve exact prior behavior
+          return {
+            type: 'false_positive_flag',
+            description: `AI incorrectly flagged section "${sectionHeading || 'untitled'}" as ${flagType || 'unknown'} — user dismissed`,
+            feedback: `False positive: ${(flagReason || '').substring(0, 500)}. Do NOT flag similar content in future critiques for this brand.`
+          };
+      }
+    })();
+
+    if (brainSignal) {
+      await pool.query(
+        `INSERT INTO brain_mistakes (brand_profile_id, mistake_type, description, human_feedback, severity)
+         VALUES ($1, $2, $3, $4, 'low')`,
+        [brandProfileId, brainSignal.type, brainSignal.description, brainSignal.feedback]
+      );
+    }
+
+    // Verified-but-unnameable: promote to Factual Ground so Stage-4 generation stops
+    // scoring this low on every future article. Read-modify-write the settings JSONB
+    // (single-reviewer UI, so the R-M-W race is acceptable); dedupe by surface
+    // (case-insensitive). trueReferent is persisted WRITE-ONLY and never re-read here.
+    if (dismissReason === 'verified_unnameable') {
+      const surfaceText = String(surface || flagReason || '').trim();
+      if (surfaceText) {
+        const brandRes = await pool.query('SELECT settings FROM brand_profiles WHERE id = $1', [brandProfileId]);
+        const settings = brandRes.rows[0]?.settings || {};
+        const fg = settings.factualGround || {};
+        const existing = Array.isArray(fg.redactedFacts) ? fg.redactedFacts : [];
+        const dupe = existing.some(r => (r.surface || '').trim().toLowerCase() === surfaceText.toLowerCase());
+        if (!dupe) {
+          existing.push({
+            id: randomUUID(),
+            surface: surfaceText.slice(0, 600),
+            trueReferent: String(trueReferent || '').slice(0, 600) || null, // WRITE-ONLY — never fed to any prompt
+            note: String(note || '').slice(0, 300) || null,
+            sourceFlagType: flagType || null,
+            addedAt: new Date().toISOString()
+          });
+          const nextSettings = { ...settings, factualGround: { ...fg, redactedFacts: existing } };
+          await pool.query(
+            `UPDATE brand_profiles SET settings = $1::jsonb, version = COALESCE(version, 1) + 1, updated_at = NOW() WHERE id = $2`,
+            [JSON.stringify(nextSettings), brandProfileId]
+          );
+          redactedFactAdded = true;
+        }
+      }
+    }
+
     await pool.query(
       `INSERT INTO agent_activity_log (agent_name, brand_profile_id, status, tokens_used, latency_ms)
        VALUES ('compliance_dismiss', $1, 'success', 0, 0)`,
       [brandProfileId]
     ).catch(() => {});
-    res.json({ success: true });
+    res.json({ success: true, reason: dismissReason, redactedFactAdded });
   } catch(e) {
     console.error('[COMPLIANCE] Dismiss flag error:', e.message);
     res.status(500).json({ success: false, error: e.message });


### PR DESCRIPTION
## Why

Dismissing a compliance flag was a **one-bit signal** ("false positive → stop flagging") that only reached the Stage-5 critic and never touched the Stage-4 generator that assigns section confidence. So NDA-anonymized copy (*"an enterprise technology client"*) was born low-confidence and re-flagged on **every new article**, no matter how many times it was dismissed. You swatted the same flag forever instead of teaching a rule once.

The real distinction the scorer was collapsing:
- **Unverifiable** — no source, might be invented. Real risk. Flag it.
- **Verified but unnameable** — owner-attested true, but the client/proper-noun is gagged by contract. Zero factual risk. Pure compliance redaction.

Those should not score the same. Treating "I can't say Intel" as "I might be making this up" punishes the operator for following the NDA.

## What

A typed dismiss taxonomy that closes the loop into Factual Ground:

- **`/dismiss-flag`** now takes `reason ∈ {verified_nameable, verified_unnameable, intentional_style, actually_wrong}`. Omitted reason = legacy flat dismiss (**backward compatible**). Each writes a distinct brain signal; `actually_wrong` writes none (the flag was right — nothing to unlearn).
- **`verified_unnameable`** promotes the fact to `factualGround.redactedFacts`, so it is taught **once** and inherited by every future article.
- **`trueReferent`** (the real client name) is stored **WRITE-ONLY**: persisted for the owner's audit trail (and the day an NDA lifts), never read back into any LLM prompt. Both render sites (Stage 4 gen, Stage 5 critique) emit `.surface` only, so the gagged proper noun cannot leak into generated copy.
- **Stage 4 prompt**: a claim matching a redacted fact scores **GREEN** (`"Verified redacted fact (NDA)"`) — this is the change that actually kills the low score at the source.
- **Stage 5 critique**: matching a redacted fact clears the flag and forbids suggesting a name.
- **Compliance Gate UI**: single "Dismiss Flag" button becomes a 4-reason picker with an optional private-referent field for the NDA path.

No schema migration — `factualGround` is JSONB, so `redactedFacts` rides along.

## Design note
`redactedFacts` promotion is a read-modify-write on the settings JSONB. Correct for the single-reviewer Compliance Gate (all users are single-hand; external reviews are out-of-platform, comment-only) — documented in-code rather than locked.

## Verification
- `npm run lint` clean
- `npm run typecheck` exit 0
- `npm test` — **212/212 pass**
- `trueReferent` leak-audited: written in exactly 1 place, read into a prompt in 0
- Prompt blocks render-tested surface-only (zero leak of injected `trueReferent`, empty surfaces filtered)
- Compliance router imports clean (validates new `crypto` import + wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)