### PR TITLE
fix(marketing): drop section eyebrows + add spacing below section headlines

### DIFF
--- a/src/marketing/marketing-pages.css
+++ b/src/marketing/marketing-pages.css
@@ -10,6 +10,12 @@
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: var(--space-3) var(--space-5);
 }
+/* Section headers: drop the kicker/eyebrow above each headline and add
+   breathing room below the headline before the section content. Scoped to
+   .fi-sectionhead so the hero and CTA-band eyebrows are untouched. */
+[data-forge-ds] .fi-sectionhead .fi-eyebrow { display: none; }
+[data-forge-ds] .fi-sectionhead { margin-bottom: var(--space-12); }
+
 /* Hero accent phrase — blue→teal gradient text on the <em> inside a title. */
 [data-forge-ds] .fi-hero__title em {
   font-style: normal;


### PR DESCRIPTION
Design review tweak on dev (per Brian).

**Change:** The repeated eyebrow/kicker above each section headline (e.g. `— THE GAP` above "The Gap Nobody's Filling") reads as clutter, and the headline sat too tight to the section content.

- Hide the eyebrow inside `.fi-sectionhead` — scoped, so the **hero** and **CTA-band** eyebrows are untouched.
- Add **48px** (`--space-12`) below every section header before its content.

CSS-only, scoped to `[data-forge-ds]`. `npm run build` passes. Merge → deploys to dev for the next look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)