### PR TITLE
fix(marketing): center pipeline stage number + label under each dot

### DIFF
--- a/src/marketing/marketing-pages.css
+++ b/src/marketing/marketing-pages.css
@@ -16,6 +16,10 @@
 [data-forge-ds] .fi-sectionhead .fi-eyebrow { display: none; }
 [data-forge-ds] .fi-sectionhead { margin-bottom: var(--space-12); }
 
+/* Pipeline: center the number + label under each rail dot (the dot is
+   centered on the rail; the labels default to left-aligned). */
+[data-forge-ds] .fi-pipe__stage { align-items: center; text-align: center; }
+
 /* Hero accent phrase — blue→teal gradient text on the <em> inside a title. */
 [data-forge-ds] .fi-hero__title em {
   font-style: normal;


### PR DESCRIPTION
Design review tweak on dev (per Brian).

The `01 / Context Hub` number + label under each pipeline rail dot were left-justified. The dot is centered on the rail, so the labels now center under it too.

One rule: `.fi-pipe__stage { align-items: center; text-align: center; }`. CSS-only, scoped to `[data-forge-ds]`. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)