### PR TITLE
fix(marketing): remove "Most intelligence" ribbon from pricing card

### DIFF
--- a/src/Product.tsx
+++ b/src/Product.tsx
@@ -358,6 +358,7 @@ export default function Product() {
         <div style={{ maxWidth: '380px', margin: '0 auto' }}>
           <PricingCard
             featured
+            ribbon=""
             tier="SMB"
             price="$99"
             cadence="one-time · lifetime access"


### PR DESCRIPTION
Design review tweak on dev (per Brian).

The featured `PricingCard` defaults to a `"Most intelligence"` ribbon (`ribbon = "Most intelligence"` in the component), which reads oddly on a single-plan section. Pass `ribbon=""` to suppress it — the featured gradient border, glow, and primary CTA all stay.

One-line change to `Product.tsx`. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)