### PR TITLE
feat(integrations): Instagram publishing via Zernio

### DIFF
--- a/src/pages/IntegrationsPage.tsx
+++ b/src/pages/IntegrationsPage.tsx
@@ -81,7 +81,7 @@ function SetupGuide({ guide }: { guide: SetupGuide }) {
 }
 
 // ── Channel definitions ───────────────────────────────────────────────────────
-type ChannelId = 'wordpress' | 'webflow' | 'linkedin' | 'x' | 'facebook' | 'reddit' | 'medium' | 'ghost' | 'website';
+type ChannelId = 'wordpress' | 'webflow' | 'linkedin' | 'x' | 'facebook' | 'instagram' | 'reddit' | 'medium' | 'ghost' | 'website';
 
 interface ChannelDef {
   id: ChannelId;
@@ -202,6 +202,26 @@ const CHANNELS: ChannelDef[] = [
     },
   },
   {
+    id: 'instagram',
+    label: 'Instagram',
+    description: 'Publish the article\'s hero image with an AI-written caption to your Instagram Business account via Zernio. Instagram posts require an image — Forge uses the generated hero image. Click Connect to authorize — no manual tokens needed.',
+    color: '#E4405F',
+    logo: 'IG',
+    liveStatus: 'live',
+    oauthFlow: true,
+    credentialFields: [],
+    setupGuide: {
+      title: 'Instagram via Zernio',
+      steps: [
+        { text: 'Instagram publishing requires an Instagram Business or Creator account linked to a Facebook Page. Personal accounts can\'t post via the API.' },
+        { text: 'Click Connect above. You\'ll be redirected to Instagram/Facebook to authorize via Zernio.' },
+        { text: 'Sign in and grant posting permissions for the Instagram account you want to publish from.' },
+        { text: 'You\'ll be redirected back automatically. No tokens to copy.' },
+        { text: 'Every Instagram post is the article\'s hero image plus a caption. Instagram captions don\'t support clickable links, so the article URL appears as plain text.' },
+      ],
+    },
+  },
+  {
     id: 'reddit',
     label: 'Reddit',
     description: 'Publish to subreddits where you have permission to post. Connect via Zernio, then add the subreddits you can post in. Forge will refuse to post outside your allowlist.',
@@ -291,6 +311,7 @@ const DEFAULT_UTM: Record<ChannelId, Record<string, string>> = {
   linkedin:  { utm_source: 'linkedin', utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
   x:         { utm_source: 'x',        utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
   facebook:  { utm_source: 'facebook', utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
+  instagram: { utm_source: 'instagram', utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
   reddit:    { utm_source: 'reddit',   utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
   medium:    { utm_source: 'medium',   utm_medium: 'social', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
   ghost:     { utm_source: 'ghost',    utm_medium: 'blog',   utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' },
@@ -459,11 +480,11 @@ export default function IntegrationsPage() {
   
   const selectedBrand = activeBrand?.id || '';
   const [savedChannels, setSavedChannels] = useState<Record<ChannelId, SavedChannel | null>>({
-    wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, reddit: null, medium: null, ghost: null, website: null
+    wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, instagram: null, reddit: null, medium: null, ghost: null, website: null
   });
   const [expanded, setExpanded] = useState<ChannelId | null>(null);
   const [credentials, setCredentials] = useState<Record<ChannelId, Record<string, string>>>({
-    wordpress: {}, webflow: {}, linkedin: {}, x: {}, facebook: {}, reddit: {}, medium: {}, ghost: {}, website: {}
+    wordpress: {}, webflow: {}, linkedin: {}, x: {}, facebook: {}, instagram: {}, reddit: {}, medium: {}, ghost: {}, website: {}
   });
   const [utmTemplates, setUtmTemplates] = useState<Record<ChannelId, Record<string, string>>>(DEFAULT_UTM);
   const [saving, setSaving] = useState<ChannelId | null>(null);
@@ -490,7 +511,7 @@ export default function IntegrationsPage() {
       .then(d => {
         if (d.success) {
           const map: Record<ChannelId, SavedChannel | null> = {
-            wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, reddit: null, medium: null, ghost: null, website: null
+            wordpress: null, webflow: null, linkedin: null, x: null, facebook: null, instagram: null, reddit: null, medium: null, ghost: null, website: null
           };
           for (const ch of d.channels) map[ch.channel as ChannelId] = ch;
           setSavedChannels(map);
@@ -527,7 +548,7 @@ export default function IntegrationsPage() {
     const channel = CHANNELS.find(c => c.id === channelId);
 
     // Zernio-powered OAuth — redirect flow with callback
-    const zernioPlatforms: Record<string, string> = { linkedin: 'linkedin', facebook: 'facebook', reddit: 'reddit' };
+    const zernioPlatforms: Record<string, string> = { linkedin: 'linkedin', facebook: 'facebook', instagram: 'instagram', reddit: 'reddit' };
     if (zernioPlatforms[channelId] && channel?.oauthFlow) {
       if (!selectedBrand) { setError('Select a Brain first'); return; }
       try {
@@ -669,7 +690,7 @@ export default function IntegrationsPage() {
       // (no picker). /api/zernio/disconnect calls Zernio's DELETE /accounts/{id}.
       // Best-effort: if this channel isn't actually Zernio, the endpoint 400s and we
       // still fall through to the local-row delete below.
-      const zernioPlatforms: Record<string, string> = { linkedin: 'linkedin', facebook: 'facebook', reddit: 'reddit' };
+      const zernioPlatforms: Record<string, string> = { linkedin: 'linkedin', facebook: 'facebook', instagram: 'instagram', reddit: 'reddit' };
       if (zernioPlatforms[channelId] && selectedBrand) {
         try {
           await fetch('/api/zernio/disconnect', {

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -121,6 +121,7 @@ const CHANNEL_LABELS: Record<string, { label: string; color: string }> = {
   linkedin:  { label: 'LinkedIn',  color: '#0A66C2' },
   x:         { label: 'X',         color: '#E7E9EA' },
   facebook:  { label: 'Facebook',   color: '#1877F2' },
+  instagram: { label: 'Instagram',  color: '#E4405F' },
   reddit:    { label: 'Reddit',     color: '#FF4500' },
   medium:    { label: 'Medium',     color: '#A8A8A8' },
   ghost:     { label: 'Ghost',      color: '#738A94' },
@@ -466,7 +467,7 @@ export default function PublishingQueuePage() {
         .then(r => r.json())
         .then(d => {
           if (d.success) {
-            const PUBLISH_ONLY = ['wordpress','webflow','hubspot','linkedin','x','facebook','reddit','medium','ghost','website'];
+            const PUBLISH_ONLY = ['wordpress','webflow','hubspot','linkedin','x','facebook','instagram','reddit','medium','ghost','website'];
             setConnectedChannels(prev => ({
               ...prev,
               [bid]: d.channels.map((c: ConnectedChannel) => c.channel).filter((ch: string) => PUBLISH_ONLY.includes(ch))

--- a/src/server/routes/publishing-publish.js
+++ b/src/server/routes/publishing-publish.js
@@ -848,6 +848,96 @@ Output only the post text.` }]
             results[channel] = { status: 'published', url: fbPostUrl, postId: fbData.id, utmParams };
           }
 
+        } else if (channel === 'instagram') {
+          // ── Instagram publish via Zernio — image + caption ──
+          // Instagram is NOT like the text platforms: the Graph API refuses any
+          // feed post without a media asset. Every Instagram post here is the
+          // article's hero image + a caption. The hero image is ensured at the
+          // top of this handler (generated if missing), so if it's still absent
+          // something upstream failed and we fail loudly rather than let Zernio
+          // reject a media-less post with an opaque error.
+          if (!creds.zernioAccountId) {
+            throw new Error('Instagram must be connected via Zernio. Visit /app/integrations to connect.');
+          }
+          const igImageUrl = article.hero_image_url || (article.article_json || {}).hero_image_url;
+          if (!igImageUrl) {
+            throw new Error('Instagram requires an image and none is available. Generate a hero image for this article, then republish.');
+          }
+
+          const articleUrl = forgeArticleUrl;
+          const utmUrl = `${articleUrl}${utmString ? '?' + utmString : ''}`;
+
+          // Caption. Priority: user-edited postCopy → Haiku-generated → title+URL.
+          // Instagram captions don't render clickable links, so the URL rides
+          // along as plain text (the classic "link in bio" limitation).
+          const igPostCopyOverride = (req.body.postCopy || {})[channel];
+          let igCaption;
+          if (igPostCopyOverride && igPostCopyOverride.trim()) {
+            igCaption = igPostCopyOverride.trim();
+          } else {
+            igCaption = `${article.title}\n\n${utmUrl}`;
+            try {
+              const haiku = await anthropic.messages.create({
+                model: 'claude-haiku-4-5-20251001',
+                max_tokens: 500,
+                messages: [{ role: 'user', content: `Write an Instagram caption for a B2B company promoting this article. 2-4 short lines that create curiosity without giving away the answer, then a final line pointing readers to the link. Max 5 relevant hashtags on the last line. Instagram captions do NOT support clickable links, so mention the article is linked in bio / at the URL as plain text.\n\nPlain text only — no markdown, no # headings, no **bold**.\n\nArticle title: ${article.title}\nArticle URL: ${utmUrl}\nArticle excerpt: ${(article.article_json?.sections?.[0]?.body || '').slice(0, 500)}` }]
+              });
+              igCaption = stripSocialMarkdown(haiku.content[0]?.text) || igCaption;
+            } catch (e) {
+              console.warn('[IG-ZERNIO] Haiku caption failed, using fallback:', e.message);
+            }
+          }
+
+          try {
+            // Zernio /posts with a media item — the mediaItems[].{type,url} shape
+            // is Zernio's documented image schema (same endpoint as every other
+            // platform). Zernio auto-transcodes to Instagram's requirements.
+            const zResult = await callZernio('POST', '/posts', {
+              content: igCaption,
+              publishNow: true,
+              mediaItems: [{ type: 'image', url: igImageUrl }],
+              platforms: [{ platform: 'instagram', accountId: creds.zernioAccountId }]
+            });
+
+            if (!zResult.ok) {
+              throw new Error(`Zernio instagram publish failed (${zResult.status}): ${zResult.raw?.slice(0, 300) || 'no body'}`);
+            }
+            const post = zResult.parsed?.post;
+            const platformResult = (post?.platforms || []).find(p => p.platform === 'instagram');
+            if (!platformResult || platformResult.status !== 'published') {
+              const errMsg = platformResult?.error || platformResult?.platformSpecificData?.lastError || 'Zernio did not publish';
+              throw new Error(`Instagram (Zernio): ${errMsg}`);
+            }
+
+            results[channel] = {
+              status: 'published',
+              url: platformResult.platformPostUrl,
+              postId: platformResult.platformPostId || post._id,
+              // Zernio's internal _id — needed by analytics sync for Zernio lookups.
+              zernioPostId: post._id,
+              via: 'zernio',
+              utmParams
+            };
+
+            // Write publish_log inside the dispatch (continue skips the loop-end writer).
+            await pool.query(
+              `INSERT INTO publish_log (queue_item_id, brand_profile_id, content_id, channel, status, response_data, utm_params, published_url, error_message)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+              [
+                queueItemId, item.brand_profile_id, item.content_id, channel,
+                'published',
+                JSON.stringify(results[channel]),
+                JSON.stringify(utmParams),
+                platformResult.platformPostUrl,
+                null
+              ]
+            ).catch(e => console.error('[PUBLISH] instagram zernio publish_log insert failed:', e.message));
+            continue;
+          } catch (igerr) {
+            // No fallback — Instagram publishing only works through Zernio here.
+            throw igerr;
+          }
+
         } else if (channel === 'reddit') {
           // ── Reddit publish via Zernio — brand-owned subreddits ONLY ──
           // Reddit is NOT like LinkedIn/Facebook. The destination is per-post and


### PR DESCRIPTION
## Why
Brian asked to add Instagram as an integration through Zernio. This wires it end to end alongside the existing Zernio channels (LinkedIn / Facebook / Reddit).

## What
**Verified against Zernio's live API first** (read-only, using the dev ZERNIO_API_KEY):
- `GET /connect/instagram` with a real profileId returns a genuine Instagram OAuth `authUrl` (bogus platforms return `Platform not supported`), so Instagram is a supported connect platform.
- The `/posts` media schema is `mediaItems: [{ type: 'image', url }]` on the same endpoint used for every other platform (confirmed via Zernio's own docs + live post objects, which carry a `mediaItems` field).

**The one real gotcha:** unlike the text-only Zernio channels, the Instagram Graph API refuses any feed post without a media asset. So the new publish branch:
- Requires the article's hero image (already ensured at the top of the publish handler; fails loudly if still missing rather than letting Zernio return an opaque error).
- Builds a caption via user-override → Haiku → title+URL fallback. IG captions don't render clickable links, so the article URL appears as plain text.
- Is Zernio-only (no fallback path), like Reddit.

The OAuth connect/callback/disconnect plumbing is already platform-agnostic (both zernio callbacks pass `platform` through verbatim), so **no backend auth changes were needed** — only the frontend channel definition and the publish dispatcher branch.

### Frontend
- `IntegrationsPage.tsx`: new `instagram` `ChannelDef` (Zernio OAuth flow, IG branding, setup guide noting the Business-account + image-required constraints); added to `ChannelId`, `DEFAULT_UTM`, all state initializers, and the `zernioPlatforms` maps in `handleSave`/`handleDisconnect`.
- `PublishingQueuePage.tsx`: added to `CHANNEL_LABELS` + the `PUBLISH_ONLY` allowlist so it's selectable and renders a chip.

### Backend
- `publishing-publish.js`: new `channel === 'instagram'` branch — Zernio `/posts` with the `mediaItems` image, `publish_log` write, `continue`.

## Test plan
- `node --check` on backend files + `npx tsc --noEmit` → clean.
- `vitest run` on `zernio` + `route-mounts` → 14/14 pass.
- Not yet exercised against a live connected IG Business account — that requires a real Instagram Business/Creator account linked to a Facebook Page to be connected via the Integrations UI. Recommend a real-account smoke test on dev before promoting to main.

## Notes / follow-ups
- Analytics: Instagram is intentionally **not** added to the Performance Dashboard's live-platform list — the per-channel analytics sync (facebook/reddit/linkedin) isn't wired for IG, and I didn't want to show an empty "live" tab. `zernioPostId` is stored on publish so analytics can be added later without a data backfill.