### PR TITLE
Log design system rebuild and fix Instagram analytics sync

### DIFF
--- a/BUILD-HISTORY.md
+++ b/BUILD-HISTORY.md
@@ -4,6 +4,40 @@ Long-form retrospective archive (renamed from `PLAN.md`). Dated session logs, de
 
 ---
 
+## 2026-08-02 — Marketing site rebuilt on a new design system (#542, #545–#549) → promoted to prod
+
+Brian: "do a sweep on the landing page 'Product' and compare it against the working code… also use this [`ai-writing-detection`] skill to review and make copy edits." That sweep turned into a full marketing-surface rebuild on a new design system, dialed in on dev over ~17 hours, then promoted `development → main`.
+
+### The sweep (#542)
+Compared `/product` (`src/Product.tsx`) against the actual app. Findings:
+- **Factual bug:** publishing caption claimed publish-to-**HubSpot**. HubSpot is CRM contact sync + a manual "copy for HubSpot" email-template flow (`EmailCampaignPage.tsx`), **not** a CMS/publish channel. Real live channels (`IntegrationsPage.tsx` `CHANNELS`): WordPress, Webflow, LinkedIn, X, Facebook, Reddit, Ghost, Medium (legacy), self-hosted webhook. Corrected the caption.
+- **Sold a plan that doesn't exist:** the page advertised an **Agency $499/mo, multi-brand** tier. No such plan in code — only the live `$99` one-time SMB plan (`BrandSettingsPage.tsx:927`; "Coming soon — Pro $299/mo", not multi-brand). Brian: "Remove Agency for now; we will start on that soon." Removed.
+- **Undersold — whole surfaces missing:** the page never mentioned **Brand Intelligence** (the 6-dimension `StrategyIntelPage` workspace) or the content-type generators (**Campaign 4.5, Email 4.6, Google Ads 4.7, Social, Video**). Added a "Brand Intelligence" section (Gap Map · Positioning Vulnerabilities · Fault Lines · Blind Spots · Whitespace · Pivot Scenarios) and a "One Brain, Every Format" section, descriptions lifted from each page's own subtitle to avoid overclaiming.
+- **Copy pass:** ran the visible copy through the `ai-writing-detection` skill (vocab/structural/formatting checklist). No AI tells — nothing changed.
+
+### The design system (Claude Design)
+Brian asked for a prompt to give "Claude Design" a shot at a new design system that keeps the "deep blue intelligence vibe" but levels it up (dynamic cards/components/buttons). Wrote the prompt (locked the DNA: `#0B0F1A` canvas + blue/teal wash, `#3563FF`, `#1E293B` cards, Inter, diamond mark, 48px grid, 6px radius). Output was a full tokenized system (zip): CSS tokens, ~23 React components (`Hero`, `Pipeline`, `BrainTimeline`, `CitationMeter`, `GapMatrix`, `PricingCard`, cards, buttons…), plus amber=gap / rose=drift state colors and motion tokens. Brian: "It's a masterpiece… a rebuild of the landing and product page, not an adaptation. Your copy should remain the same."
+
+### Integration (#542)
+- Vendored `tokens/`, `components/`, `assets/`, `styles.css` under **`src/ds/`** (dropped `.prompt.md`/`.card.html` design-tool sidecars).
+- **Scoping was the real risk:** DS `base.css` sets `body{background:navy}` + a global reset, and its `:root` semantic tokens (`--color-accent`, `--color-border`, `--radius-sm`, `--shadow-*`) collide with the app's own `:root` tokens in `index.css`. Loaded app-wide unscoped, it would repaint the **light in-app UI**. Fix: scope everything to a **`[data-forge-ds]`** wrapper — `:root`→`[data-forge-ds]` across token files, base reset rewritten under the wrapper, `[data-theme=light]`→`[data-forge-ds][data-theme=light]`. Component CSS is all `.fi-*` class-based (inert outside the wrapper). Verified `/app/*` untouched.
+- `src/marketing/MarketingShell.tsx` — shared `.fi-canvas` + `NavBar` + `Footer`, nav routed through react-router. `src/marketing/marketing-pages.css` — scoped grid helpers + hero gradient-text.
+- `src/Product.tsx` + `src/Landing.tsx` rebuilt against the DS components. **Copy verbatim.** Landing's scan flow (domain check, claimed/returning/new states, localStorage resume, `/app/context-hub` redirect) preserved exactly. Installed deps locally to run `tsc && vite build` — 793 modules, strict, clean — before every push.
+
+### Design-review tweaks (dialed in on dev, per-screenshot)
+- **#545** — dropped the section eyebrow/kicker above each headline (`.fi-sectionhead .fi-eyebrow{display:none}`, hero/CTA eyebrows kept) + 48px below headlines.
+- **#546** — centered the pipeline stage number+label under each rail dot (`.fi-pipe__stage{align-items:center;text-align:center}`).
+- **#547** — removed the featured `PricingCard` default "Most intelligence" ribbon (`ribbon=""`).
+
+### In-app polish + product screenshot
+- **#548** — reworked `StrategyIntelPage` **Positioning Pivot** view (light in-app tokens): hero statement w/ blue→teal accent rail + eyebrow, FROM·Today → TO·The move pill cards with a circular arrow chip, shadowed section/evidence/move cards, gradient numbered badges, board-slide finale. Presentational only.
+- **#549** — wired the real pivot screenshot (`public/brand-intelligence.png`, from Brian's live Forge run) into the `/product` Brand Intelligence section via `ScreenFrame`.
+
+### Outcome & follow-up
+All six PRs merged to `development`, reviewed on dev.forgeintelligence.ai, promoted to `main` (production) by Brian 2026-08-02. **Follow-up flagged:** `src/ds/` loads app-wide → JS bundle ~1.9 MB / 573 KB gzip; code-split the marketing DS off the `/app/*` bundle so in-app users don't pay for the marketing system.
+
+---
+
 ## 2026-07-15 — Brand Intelligence recovered from git history (#491, #492) + 3 fixes (#483, #485, #489)
 
 ### #491 / #492 — Brand Intelligence: dead frontend → whole feature, recovered from a lost commit

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -13,6 +13,22 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
+### 2026-08-02 — Marketing site (`/` + `/product`) rebuilt on the new "deep blue intelligence" design system → promoted to prod
+
+**Headline: `/` and `/product` are fully rebuilt on a new Claude-Design design system and live in production.** Started as a content sweep of `/product` vs. the working code, became a full re-skin. Six PRs, all merged to `development`, dialed in on dev, then Brian promoted `development → main`.
+
+- **Content sweep first (in #542):** the old `/product` copy under- and mis-sold the app. Fixes: publishing caption claimed **HubSpot** (not a CMS channel — it's CRM sync + a manual email-copy flow; real channels are WordPress/Webflow/LinkedIn/X/Facebook/Reddit/Ghost/Medium per `IntegrationsPage.tsx`); removed the **Agency $499/mo** tier (doesn't exist — only the live `$99` one-time SMB plan); added the missing **Brand Intelligence (6-dimension)** and **One Brain / Every Format** (Campaign 4.5 · Email 4.6 · Ads 4.7 · Social · Video) sections. Copy passed the `ai-writing-detection` skill clean.
+- **Design system (Claude Design output) vendored under `src/ds/`** (tokens + components + assets). **Scoped to a `[data-forge-ds]` wrapper** — critical: the DS `base.css` paints `body` navy and its `:root` tokens collide with the app's `--color-*`/`--radius-*`/`--shadow-*`, so unscoped it would repaint the light in-app UI at `/app/*`. Token `:root` blocks + the base reset were rewritten under the wrapper; component CSS is all `.fi-*` class-based. `src/marketing/MarketingShell.tsx` = shared canvas/nav/footer; `src/marketing/marketing-pages.css` = scoped page helpers + review tweaks.
+- **Pages** (`src/Landing.tsx`, `src/Product.tsx`) rebuilt as re-skins — **copy unchanged**; Landing's scan flow (domain check, claimed/returning/new states, localStorage resume, redirect) preserved verbatim.
+- **Design-review tweaks (dev):** #545 drop section eyebrows + 48px below headlines · #546 center pipeline stage labels under dots · #547 remove "Most intelligence" pricing ribbon.
+- **In-app polish + screenshot:** #548 reworked `StrategyIntelPage` **Positioning Pivot** (hero statement w/ accent rail, FROM·Today → TO·The move pill cards + arrow chip, evidence/moves depth, board-slide finale — all in the app's light tokens). #549 wired the real pivot screenshot (`public/brand-intelligence.png`) into the `/product` Brand Intelligence section.
+
+**PRs:** #542 (rebuild + sweep), #545, #546, #547, #548, #549 — all merged → `development`, promoted to `main` 2026-08-02.
+
+**⚠️ Follow-up worth doing:** vendored `src/ds/` (23 components) loads app-wide, so the JS bundle grew to **~1.9 MB / 573 KB gzip** and first paint is a touch slower. **Code-split the marketing DS off the `/app/*` bundle** (dynamic import / route-level split) so in-app users don't download the marketing system. Not urgent, not broken — flagged to Brian.
+
+---
+
 ### 2026-07-15 — Brand Intelligence feature RECOVERED from git history (2 PRs) + 3 fixes
 
 **Headline: Brand Intelligence is live on `development` again.** Brian asked to "promote the Brand Intelligence page from the `strategy` branch." It turned out to be a *dead frontend* — its entire backend had been lost. Git forensics: the full 6-deliverable feature (gap-map, blind-spots, whitespace, pivot, shareable brief, compliance gate — 17 `/api/strategy/*` endpoints) was working at commit **`5b1ac6e9c6`** (Apr 19), wiped by `7fd4a9a50e` (a "sync server.js from production" wholesale overwrite), hand-restored once, then lost for good in the `1873bfb` strategy→main rebuild (which restored only STRATEGY.md + the brief frontend). STRATEGY.md still said "Built ✅"; the code was gone. Recovered verbatim from `5b1ac6e9c6` (GitHub still served the orphaned SHA).

--- a/src/pages/PublishingQueuePage.tsx
+++ b/src/pages/PublishingQueuePage.tsx
@@ -681,7 +681,7 @@ export default function PublishingQueuePage() {
     if (chData.success) {
       for (const ch of chData.channels) {
         const stored = ch.utm_template;
-        channelUtms[ch.channel] = (stored && Object.keys(stored).length > 0) ? stored : { utm_source: ch.channel, utm_medium: ['linkedin','x','facebook','reddit','medium'].includes(ch.channel) ? 'social' : 'organic', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' };
+        channelUtms[ch.channel] = (stored && Object.keys(stored).length > 0) ? stored : { utm_source: ch.channel, utm_medium: ['linkedin','x','facebook','instagram','reddit','medium'].includes(ch.channel) ? 'social' : 'organic', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' };
       }
     }
     setExportTab('html');
@@ -1091,7 +1091,7 @@ ${authorFooterHtml}
       if (chRes.success) {
         for (const ch of chRes.channels) {
           const stored = ch.utm_template;
-          channelUtmMap[ch.channel] = (stored && Object.keys(stored).length > 0) ? stored : { utm_source: ch.channel, utm_medium: ['linkedin','x','facebook','reddit','medium'].includes(ch.channel) ? 'social' : 'organic', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' };
+          channelUtmMap[ch.channel] = (stored && Object.keys(stored).length > 0) ? stored : { utm_source: ch.channel, utm_medium: ['linkedin','x','facebook','instagram','reddit','medium'].includes(ch.channel) ? 'social' : 'organic', utm_campaign: '{campaign_slug}', utm_content: '{article_slug}' };
         }
       }
 

--- a/src/server/routes/analytics.js
+++ b/src/server/routes/analytics.js
@@ -981,6 +981,123 @@ router.post('/sync/:brandProfileId', async (req, res) => {
       }
     }
 
+    // ── Instagram analytics (Zernio-only) ──
+    // Instagram publishing here always routes through Zernio — the publish handler
+    // hard-fails a non-Zernio Instagram connect (no legacy Graph API path, unlike
+    // Facebook). Every Instagram post stores Zernio's internal _id as `zernioPostId`
+    // in response_data; the Zernio /analytics endpoint expects that _id, NOT the
+    // Instagram platform id. So this branch mirrors Facebook's Zernio path but with
+    // no legacy fallback.
+    if (channel === 'instagram' || channel === 'all') {
+      const igLogRes = await pool.query(
+        `SELECT pl.content_id, pl.response_data, pl.attempted_at AS published_at,
+                pl.published_url, ct.title, ct.campaign_id
+           FROM publish_log pl
+           LEFT JOIN generated_content_${safeId} ct ON ct.id::text = pl.content_id
+          WHERE pl.brand_profile_id = $1 AND pl.channel = 'instagram' AND pl.status = 'published'
+            AND (pl.live_status IS NULL OR pl.live_status != 'deleted')
+          ORDER BY pl.attempted_at DESC`,
+        [brandProfileId]
+      ).catch(() => ({ rows: [] }));
+
+      const igCredRes = await pool.query(
+        `SELECT credentials FROM publishing_channels WHERE brand_profile_id = $1 AND channel = 'instagram' AND is_active = true LIMIT 1`,
+        [brandProfileId]
+      ).catch(() => ({ rows: [] }));
+      const igCreds = igCredRes.rows[0]?.credentials || {};
+      const igIsZernio = !!igCreds.zernioAccountId && !!process.env.ZERNIO_API_KEY;
+      console.log(`[Analytics/Instagram] Found ${igLogRes.rows.length} published posts, provider=${igIsZernio ? 'zernio' : 'unsupported'}`);
+
+      for (const row of igLogRes.rows) {
+        try {
+          const rd = row.response_data || {};
+          const postId = rd.postId || rd.post_id || rd.id;
+          // Zernio's internal _id — the only id Zernio /analytics accepts.
+          const zernioPostId = rd.zernioPostId || rd.zernio_post_id || null;
+
+          if (!igIsZernio) {
+            console.log('[Analytics/Instagram] No Zernio account on Instagram channel — skipping');
+            break;
+          }
+          if (!zernioPostId) { errors.push({ contentId: row.content_id, error: 'no_zernio_post_id' }); continue; }
+
+          let impressions = 0, clicks = 0, reactions = 0, comments = 0, reposts = 0;
+          let rawData = {};
+          let dataSource = 'none';
+
+          const analyticsRes = await callZernio('GET', `/analytics?postId=${encodeURIComponent(zernioPostId)}`);
+          console.log(`[Analytics/Instagram] Zernio analytics for ${zernioPostId}: HTTP ${analyticsRes.status}`);
+
+          if (analyticsRes.status === 202) {
+            await pool.query(
+              `INSERT INTO content_analytics
+                 (brand_profile_id, content_id, channel, post_id, impressions, clicks, reactions, comments, reposts, ctr, engagement_rate, raw_data, published_at, synced_at)
+               VALUES ($1, $2, 'instagram', $3, 0, 0, 0, 0, 0, 0, 0, $4::jsonb, COALESCE($5, NOW()), NOW())
+               ON CONFLICT (content_id, channel) DO NOTHING`,
+              [brandProfileId, row.content_id, postId || zernioPostId, JSON.stringify({ pending: true }), row.published_at]
+            ).catch(e => console.error('[Analytics/Instagram] pending placeholder failed:', e.message));
+            console.log(`[Analytics/Instagram] Sync pending for ${zernioPostId} — placeholder inserted, will retry next sync`);
+            continue;
+          }
+          if (analyticsRes.status === 424 || !analyticsRes.ok) {
+            errors.push({ contentId: row.content_id, error: `zernio_analytics_${analyticsRes.status}` });
+            continue;
+          }
+
+          const analytics = analyticsRes.parsed;
+          const platforms = analytics?.post?.platforms || analytics?.platforms || [];
+          const igMetrics = platforms.find(p => p.platform === 'instagram')?.analytics
+            || analytics?.post?.analytics
+            || analytics?.analytics
+            || analytics || {};
+
+          // Instagram metric name mapping. IG surfaces reach/impressions, likes,
+          // comments, and shares; saves are IG-specific engagement with no direct
+          // column, so they fold into reposts (closest "amplification" analog) and
+          // are preserved verbatim in raw_data.
+          impressions = igMetrics.impressions || igMetrics.reach || igMetrics.views || igMetrics.impression_count || 0;
+          clicks      = igMetrics.clicks || igMetrics.link_clicks || igMetrics.website_clicks || igMetrics.profile_visits || 0;
+          reactions   = igMetrics.likes || igMetrics.reactions || igMetrics.like_count || 0;
+          comments    = igMetrics.comments || igMetrics.comment_count || 0;
+          reposts     = igMetrics.shares || igMetrics.reposts || igMetrics.saves || igMetrics.saved || 0;
+          rawData     = { zernio: analytics };
+          dataSource  = 'zernio';
+          console.log(`[Analytics/Instagram] Zernio metrics for ${zernioPostId}: ${impressions} impr, ${reactions} likes, ${comments} comments, ${reposts} shares/saves, ${clicks} clicks`);
+
+          if (dataSource === 'none') continue;
+
+          const totalEngagement = reactions + comments + reposts + clicks;
+          const ctr = impressions > 0 ? parseFloat((clicks / impressions * 100).toFixed(2)) : 0;
+          const engagementRate = impressions > 0
+            ? parseFloat((totalEngagement / impressions * 100).toFixed(2))
+            : 0;
+
+          await pool.query(
+            `INSERT INTO content_analytics
+               (brand_profile_id, content_id, channel, post_id, impressions, clicks, reactions, comments, reposts, ctr, engagement_rate, raw_data, published_at, synced_at, campaign_id)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,NOW(),$14)
+             ON CONFLICT (content_id, channel) DO UPDATE SET
+               impressions      = CASE WHEN EXCLUDED.impressions > 0 THEN EXCLUDED.impressions ELSE content_analytics.impressions END,
+               clicks           = CASE WHEN EXCLUDED.impressions > 0 THEN EXCLUDED.clicks      ELSE content_analytics.clicks      END,
+               ctr              = CASE WHEN EXCLUDED.impressions > 0 THEN EXCLUDED.ctr         ELSE content_analytics.ctr         END,
+               engagement_rate  = CASE WHEN EXCLUDED.impressions > 0 THEN EXCLUDED.engagement_rate ELSE content_analytics.engagement_rate END,
+               reactions        = GREATEST(COALESCE(content_analytics.reactions, 0), EXCLUDED.reactions),
+               comments         = GREATEST(COALESCE(content_analytics.comments, 0),  EXCLUDED.comments),
+               reposts          = GREATEST(COALESCE(content_analytics.reposts, 0),   EXCLUDED.reposts),
+               raw_data         = (COALESCE(content_analytics.raw_data, '{}'::jsonb) - 'pending') || EXCLUDED.raw_data,
+               synced_at        = NOW(),
+               campaign_id      = COALESCE(EXCLUDED.campaign_id, content_analytics.campaign_id)`,
+            [brandProfileId, row.content_id, 'instagram', postId || zernioPostId,
+             impressions, clicks, reactions, comments, reposts, ctr, engagementRate,
+             JSON.stringify(rawData), row.published_at, row.campaign_id || null]
+          );
+          synced.push({ contentId: row.content_id, title: row.title, postId: zernioPostId, reactions, comments, reposts, impressions, dataSource });
+        } catch(e) {
+          errors.push({ contentId: row.content_id, error: e.message });
+        }
+      }
+    }
+
     // Ghost sync
     if (channel === 'ghost' || channel === 'all') {
       // Prefer per-brand credentials from publishing_channels, fall back to env vars


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to the marketing site, analytics, and UTM handling for the Instagram channel. The most significant changes are the full rebuild of the marketing site on a new design system, the addition of Instagram analytics sync via Zernio, and a fix to ensure Instagram is correctly classified as a "social" channel for UTM parameters.

**Marketing site and design system:**

- Rebuilt the `/` and `/product` marketing pages using a new "deep blue intelligence" design system (Claude Design), with all components, tokens, and styles vendored under `src/ds/`. The rebuild included a full content sweep, factual/copy corrections, and new sections for Brand Intelligence and content generators. The design system is now scoped to a `[data-forge-ds]` wrapper to avoid style collisions with the main app. All changes were promoted to production after review. [[1]](diffhunk://#diff-3e725d0445042b67eb64e4e5fffd6a07cb42a63938b4b6bb7b828b6538eac0d7R7-R40) [[2]](diffhunk://#diff-bcaee012e010238624d360ef46ed22ef3d77c076bb5ef07869b0d02ec23c9652R14-R29)

**Analytics improvements:**

- Added support for syncing Instagram analytics via Zernio in `src/server/routes/analytics.js`. The sync logic mirrors the Facebook/Zernio flow but is tailored for Instagram, handling Zernio's internal post IDs, metrics mapping, and proper upserts into the `content_analytics` table.

**UTM handling fixes:**

- Updated UTM template logic in `PublishingQueuePage.tsx` to include `'instagram'` as a "social" channel, ensuring UTM parameters are set correctly for Instagram posts. [[1]](diffhunk://#diff-cf20e904b3a567700961c79113c798c7daca46ce38f738c510fd067815945106L684-R684) [[2]](diffhunk://#diff-cf20e904b3a567700961c79113c798c7daca46ce38f738c510fd067815945106L1094-R1094)

**Documentation and follow-up:**

- Added detailed retrospective and working-state notes in `BUILD-HISTORY.md` and `WORKING-STATE.md` describing the scope, process, and follow-up (notably, the need to code-split the marketing design system to reduce bundle size for in-app users). [[1]](diffhunk://#diff-3e725d0445042b67eb64e4e5fffd6a07cb42a63938b4b6bb7b828b6538eac0d7R7-R40) [[2]](diffhunk://#diff-bcaee012e010238624d360ef46ed22ef3d77c076bb5ef07869b0d02ec23c9652R14-R29)