### PR TITLE
fix(scrape): silence "Could not parse CSS stylesheet" jsdom noise

### DIFF
--- a/src/server/scrape.js
+++ b/src/server/scrape.js
@@ -4,7 +4,7 @@
 // extraction, markdown conversion, and subpage discovery.
 import puppeteer from 'puppeteer-core';
 import { Readability } from '@mozilla/readability';
-import { JSDOM } from 'jsdom';
+import { JSDOM, VirtualConsole } from 'jsdom';
 import TurndownService from 'turndown';
 import { pool } from './db.js';
 
@@ -376,9 +376,21 @@ export async function forgeScrape(url, opts = {}) {
 // Every attempt is logged to scrape_log with caller='context-hub' for audit.
 const _turndown = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced', emDelimiter: '_' });
 
+// jsdom's CSS parser (rrweb-cssom) chokes on modern CSS — nested rules, @layer,
+// @container, :has(), etc. — and emits noisy "Could not parse CSS stylesheet"
+// jsdomError events on the default virtual console, which forwards straight to
+// console.error and spams scrape logs. We only build the DOM for Readability
+// text extraction; CSS is irrelevant here. Swallow the CSS-parse noise while
+// still surfacing any other jsdom error.
+const _scrapeConsole = new VirtualConsole();
+_scrapeConsole.on('jsdomError', (err) => {
+  if (err && /Could not parse CSS stylesheet/.test(err.message || '')) return;
+  console.error(err);
+});
+
 function htmlToMarkdown(html, url) {
   try {
-    const dom = new JSDOM(html, { url });
+    const dom = new JSDOM(html, { url, virtualConsole: _scrapeConsole });
     const article = new Readability(dom.window.document).parse();
     if (!article?.content) return '';
     return _turndown.turndown(article.content).trim();


### PR DESCRIPTION
## Why
Brian flagged a recurring `Error: Could not parse CSS stylesheet` in the logs.

## Root cause
`htmlToMarkdown()` in `src/server/scrape.js` built `new JSDOM(html, { url })` with **no** `virtualConsole`. jsdom's default virtual console forwards every `jsdomError` to `console.error`. jsdom's CSS parser (rrweb-cssom) can't parse modern CSS — nested rules, `@layer`, `@container`, `:has()` — and emits `Could not parse CSS stylesheet` for each stylesheet it chokes on. This fires on essentially every brand-page scrape (`getBrandPageContent` → context-hub), producing the noise.

It's **noise, not a break** — the DOM is only used to feed Readability text extraction, which is CSS-agnostic, and the whole thing is already wrapped in try/catch.

## What
- Import `VirtualConsole` from jsdom.
- Add a shared `_scrapeConsole` that swallows `Could not parse CSS stylesheet` `jsdomError`s and re-forwards anything else (so real jsdom errors stay visible).
- Pass it into the `JSDOM` constructor.

## Test plan
- `node --check src/server/scrape.js` ✅
- Built a JSDOM from HTML containing `@container` + `:has()` with the new console → DOM builds, `h1` extracted, zero non-CSS errors leaked. ✅

## Blast radius
`gitnexus_impact(htmlToMarkdown, upstream)` → **LOW**, 2 impacted (`getBrandPageContent` → `context-hub.js`). Signature unchanged.

## Rollback
Revert the single commit; behavior returns to (noisy but functional) prior state.