### PR TITLE
Silence jsdom CSS parse errors in scrape process

### DIFF
--- a/docs/daily/2026-08-03.md
+++ b/docs/daily/2026-08-03.md
@@ -1,10 +1,25 @@
-# Forge Intelligence — 2026-08-03
+# forge-intelligence — 2026-08-03 (auto nightly digest)
 
-## Repo-agent architecture migration (automated by Gibson)
-- Worktree now lives on `agent/forge-intelligence`, reconciled to canonical `development`.
-- repo-guard status line active (branch + behind-development, every turn).
-- Nightly reconcile→doc routine established; this is the first entry.
+## Commits on `development` (last 24h): 18
+- dc2d2b9 docs: nightly log 2026-08-03 (forge-intelligence)
+- 625cb94 docs: nightly log 2026-08-03 (forge-intelligence)
+- 970bf1f Merge pull request #551 from Sandbox-Group-LLC/chore/log-design-rebuild (Sandbox Group)
+- d14579b Merge pull request #554 from Sandbox-Group-LLC/fix/instagram-analytics-utm (Sandbox Group)
+- a9ce4b8 fix(instagram): wire analytics sync + UTM social gating for Zernio Instagram (Sandbox Group)
+- a280fb4 Merge pull request #552 from Sandbox-Group-LLC/feat/instagram-zernio (Sandbox Group)
+- 273ba7f feat(integrations): add Instagram as a Zernio-routed publishing channel (Sandbox Group)
+- 821f4ae docs: log the 2026-08-02 marketing design-system rebuild session (Sandbox Group)
+- 0fcbf42 Merge pull request #549 from Sandbox-Group-LLC/feat/product-brand-intel-shot (Sandbox Group)
+- af543b6 feat(product): add Brand Intelligence screenshot (Positioning Pivot) (Sandbox Group)
+- 26f2b0c Merge pull request #548 from Sandbox-Group-LLC/feat/pivot-polish (Sandbox Group)
+- a6ebfb0 feat(brand-intel): polish the Positioning Pivot view (Sandbox Group)
+- e69134e Merge pull request #547 from Sandbox-Group-LLC/fix/pricing-remove-ribbon (Sandbox Group)
+- 31800dd fix(marketing): remove "Most intelligence" ribbon from the pricing card (Sandbox Group)
+- b4a305c Merge pull request #546 from Sandbox-Group-LLC/fix/pipeline-center-labels (Sandbox Group)
+- bb7f13b fix(marketing): center pipeline stage number + label under each dot (Sandbox Group)
+- 675b953 Merge pull request #545 from Sandbox-Group-LLC/fix/marketing-section-eyebrows (Sandbox Group)
+- 532e9a9 fix(marketing): drop section eyebrows, add spacing below section headlines (Sandbox Group)
 
-## Open threads
-- Nightly runs will summarize each day's activity here going forward.
-- 23:59 nightly-cycle self-test (auto-reverted)
+## Branch status
+- worktree branch: agent/forge-intelligence
+- behind `development`: 0

--- a/docs/daily/2026-08-03.md
+++ b/docs/daily/2026-08-03.md
@@ -1,0 +1,9 @@
+# Forge Intelligence — 2026-08-03
+
+## Repo-agent architecture migration (automated by Gibson)
+- Worktree now lives on `agent/forge-intelligence`, reconciled to canonical `development`.
+- repo-guard status line active (branch + behind-development, every turn).
+- Nightly reconcile→doc routine established; this is the first entry.
+
+## Open threads
+- Nightly runs will summarize each day's activity here going forward.

--- a/docs/daily/2026-08-03.md
+++ b/docs/daily/2026-08-03.md
@@ -7,3 +7,4 @@
 
 ## Open threads
 - Nightly runs will summarize each day's activity here going forward.
+- 23:59 nightly-cycle self-test (auto-reverted)

--- a/src/server/scrape.js
+++ b/src/server/scrape.js
@@ -4,7 +4,7 @@
 // extraction, markdown conversion, and subpage discovery.
 import puppeteer from 'puppeteer-core';
 import { Readability } from '@mozilla/readability';
-import { JSDOM } from 'jsdom';
+import { JSDOM, VirtualConsole } from 'jsdom';
 import TurndownService from 'turndown';
 import { pool } from './db.js';
 
@@ -376,9 +376,21 @@ export async function forgeScrape(url, opts = {}) {
 // Every attempt is logged to scrape_log with caller='context-hub' for audit.
 const _turndown = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced', emDelimiter: '_' });
 
+// jsdom's CSS parser (rrweb-cssom) chokes on modern CSS — nested rules, @layer,
+// @container, :has(), etc. — and emits noisy "Could not parse CSS stylesheet"
+// jsdomError events on the default virtual console, which forwards straight to
+// console.error and spams scrape logs. We only build the DOM for Readability
+// text extraction; CSS is irrelevant here. Swallow the CSS-parse noise while
+// still surfacing any other jsdom error.
+const _scrapeConsole = new VirtualConsole();
+_scrapeConsole.on('jsdomError', (err) => {
+  if (err && /Could not parse CSS stylesheet/.test(err.message || '')) return;
+  console.error(err);
+});
+
 function htmlToMarkdown(html, url) {
   try {
-    const dom = new JSDOM(html, { url });
+    const dom = new JSDOM(html, { url, virtualConsole: _scrapeConsole });
     const article = new Readability(dom.window.document).parse();
     if (!article?.content) return '';
     return _turndown.turndown(article.content).trim();


### PR DESCRIPTION
This pull request improves the reliability and cleanliness of server-side scraping logs by suppressing noisy CSS parsing errors from `jsdom` that are not relevant to the scraping process. It also ensures that only meaningful errors are logged, reducing log spam and making debugging easier.

Error handling improvements:

* Suppressed irrelevant "Could not parse CSS stylesheet" errors from `jsdom` by routing them through a custom `VirtualConsole` and ignoring them, while still logging other errors. This prevents unnecessary log noise during HTML parsing.
* Updated the `JSDOM` instantiation in `htmlToMarkdown` to use the custom `VirtualConsole`, ensuring the improved error handling is applied during scraping.
* Imported `VirtualConsole` from `jsdom` to support the new error handling logic.

Documentation:

* Added a nightly digest log for 2026-08-03 in `docs/daily/2026-08-03.md`, summarizing recent commits and branch status.