### PR TITLE
fix(ci): stop the required merge gate from getting stuck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,18 @@ on:
   push:
     branches: [main]
 
+# NOTE: cancel-in-progress is intentionally FALSE. This workflow is the required
+# merge gate ("Typecheck & Test" is a required status check on PRs into main). A
+# cancelled run reports the required context as cancelled — which is NOT success —
+# so cancelling an in-flight run leaves the rollup PR BLOCKED until a fresh run for
+# the latest SHA settles clean. Bursts of commits on development (e.g. the nightly
+# docs-log automation pushing straight to the branch) used to guillotine the gate
+# run and park the PR as "stuck". A few redundant ~45s runs are cheaper than a
+# wedged merge gate. cancel-in-progress belongs on throwaway workflows (see
+# brain-refresh.yml), not on a required check.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   test:
@@ -27,6 +36,10 @@ jobs:
     # update the branch ruleset's required-check name to match or merges block.
     name: Typecheck & Test
     runs-on: ubuntu-latest
+    # Bound a genuinely wedged run (vitest open handle, npm registry stall). Normal
+    # run is ~45s; without this a hung run sits at GitHub's 6h default and reads as
+    # "stuck". Fail fast instead.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Why
"Typecheck & Test" is a **required** status check on PRs into `main` (the `Checks` ruleset gates `refs/heads/main`). It kept intermittently parking rollup PRs as `BLOCKED`. The job itself is healthy (~45s, passing) — the problem was the gate ending up in a non-success state.

## Root cause
1. **`cancel-in-progress: true`** on the CI concurrency group. This is a *required merge gate*, not a throwaway workflow. A cancelled run reports the required context as `cancelled` (≠ success), so when commits land on `development` in bursts while a `development → main` rollup PR is open, each `pull_request: synchronize` cancelled the in-flight gate run and left the PR blocked. The nightly docs-log automation pushing straight to `development` (3 bunched commits today: `625cb94`, `dc2d2b9`, `43cca8e`) is the main source of the bursts. Evidence: 3 back-to-back cancelled CI runs on 2026-07-30 for one commit.
2. **No `timeout-minutes`** on the test job. Normal run is ~45s but a 440s outlier exists; a genuinely wedged run (vitest open handle, npm stall) would sit at GitHub's **6h** default and read as "stuck".

## What
- `concurrency.cancel-in-progress: true → false` — never cancel a required merge-gate run. Costs a few redundant ~45s runs; guarantees every head SHA ends with a definitive pass/fail.
- Add `timeout-minutes: 10` to the `test` job — bound genuine hangs.

Both changes are commented inline explaining why.

## Test plan
- YAML parses; `jobs.test.timeout-minutes = 10`, `concurrency.cancel-in-progress = false`.
- CI runs on this PR (base `development`) exercise the workflow itself.
- No trigger changes, so no risk of the duplicate-check-name deadlock the file's header comment warns about.

## Follow-up (not in this PR)
Route the nightly docs-log through a normal PR instead of pushing raw to `development`, so it stops churning the rollup gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)