### PR TITLE
feat(quick-copy): Phase 3 handoff consumers + product surface

### DIFF
--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -13,18 +13,15 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
-### 2026-08-05 — Quick Copy Phase 1 (PR #560) → awaiting merge to development
+### 2026-08-05 — Quick Copy P1+P2 merged; Phase 3 handoffs + product surface
 
-**Headline: Quick Copy is built and up as PR #560.** Brand-voiced one-offs (email replies, DMs, posts, notes) without the full pipeline. Locked with Brian: name=Quick Copy; variant picker 1–4; copy/paste only; Sonnet; P1; optional inline claim check (red underline + superscript ¹ ² ³ + notes list — not a tab).
+**#560 + #561 merged to `development`.** Brian holding a single promote to main.
 
-- **API** `/api/quick-copy` — generate (SSE), refine, check, history, CRUD. Module: `src/server/routes/quick-copy.js` + pure helpers `src/server/quick-copy.js` / `src/lib/quick-copy.js`.
-- **UI** `/app/quick-copy` — `QuickCopyPage.tsx` + Sidebar/TopBar. Paid gate. History drawer. Refine chips. Check claims stays on the same card; clipboard is always clean text.
-- **Docs** `docs/QUICK-COPY.md`. Agent prompt `src/agents/stage4_quick_copy/system_prompt.md`.
-- **Verify** unit tests + route snapshot + `tsc` clean locally. CI *Typecheck & Test* was in progress at open.
+- **P1** Quick Copy core (`/app/quick-copy`, Sonnet, variants, inline claim check)
+- **P2** Soften / Find source / recent prompts / handoff buttons
+- **P3 (this PR)** Email + Social consume sessionStorage handoffs; `/product` tile + included list; onboarding step
 
-**PR:** https://github.com/Sandbox-Group-LLC/Forge-Intelligence/pull/560 (`agent/forge-intelligence` → `development`). Brian reviews/merges.
-
-**Not in v1:** publish/queue, auto-compliance on generate, multi-email sequences, full Compliance Gate handoff.
+**Not promoting to main until Brian's batch.**
 
 ---
 

--- a/docs/QUICK-COPY.md
+++ b/docs/QUICK-COPY.md
@@ -58,3 +58,9 @@ Auth: `requireAuth` at mount. Brand access checked per request.
 - **Find source** — reuses `findCitationSources` (Perplexity); lists links under the flag
 - **Recent prompts** — deduped strip above the prompt box
 - **Handoffs** — "Open in Email Campaign" / "Open in Social" via sessionStorage prefill keys (`forge_quick_copy_handoff`, `forge_quick_copy_social_handoff`)
+
+## Phase 3
+
+- **Handoff consumers** — Email Campaign reads `forge_quick_copy_handoff`; Social Generator reads `forge_quick_copy_social_handoff` (one-shot sessionStorage, then clear)
+- **Product** — Quick Copy tile on `/product` formats grid + included list
+- **Onboarding** — step pointing at `/app/quick-copy`

--- a/src/Product.tsx
+++ b/src/Product.tsx
@@ -91,7 +91,8 @@ const formats = [
   { icon: 'message-square', tag: 'Stage 4.6', name: 'Email Sequences', desc: 'Brief-driven, voice-matched email sequences. Copy each one out HubSpot-ready.' },
   { icon: 'chart-column', tag: 'Stage 4.7', name: 'Google Ads Packs', desc: '15 headlines, 4 descriptions, sitelinks, callouts, and match-typed keywords. Paste into Google Ads or export CSV.' },
   { icon: 'sparkles', tag: 'Short-form', name: 'Social Generator', desc: 'Four posts at four angles for X and Instagram, each with a social-tuned image.' },
-  { icon: 'pen-tool', tag: 'Video', name: 'Video Reels', desc: 'A brief becomes a branded product reel: storyboard, voiceover, and render, all automatic.' },
+  { icon: 'pen-tool', tag: 'One-off', name: 'Quick Copy', desc: 'Brand-voiced replies, DMs, and posts without the full pipeline. Optional claim check inline.' },
+  { icon: 'layers', tag: 'Video', name: 'Video Reels', desc: 'A brief becomes a branded product reel: storyboard, voiceover, and render, all automatic.' },
 ];
 
 const timeline = [
@@ -116,6 +117,7 @@ const included = [
   'Email Sequences',
   'Google Ads Packs',
   'Social Post Generator',
+  'Quick Copy',
   'Video Reels',
   'Confidence Scoring',
   'Compliance Gate',
@@ -297,7 +299,7 @@ export default function Product() {
           align="center"
           eyebrow="One brain"
           title="One Brain, Every Format"
-          description="The same intelligence layer that writes articles also builds campaigns, emails, ads, social, and video."
+          description="The same intelligence layer that writes articles also builds campaigns, emails, ads, social, one-off copy, and video."
         />
         <div className="fi-grid-cards">
           {formats.map((f, i) => (

--- a/src/components/OnboardingBot.tsx
+++ b/src/components/OnboardingBot.tsx
@@ -98,6 +98,13 @@ const STEPS: Step[] = [
     cta: { label: "Generate your first article →", href: "/app/content-generator" }
   },
   {
+    id: 'quick-copy',
+    icon: <IconZap />,
+    title: "One-offs without the pipeline",
+    body: "Not every ask is an article. Quick Copy writes brand-voiced email replies, DMs, and posts from the same Brain — variant picker, copy-out, optional inline claim check. When a one-off needs to grow, hand it to Email Campaign or Social.",
+    cta: { label: "Try Quick Copy →", href: "/app/quick-copy" }
+  },
+  {
     id: 'compliance',
     icon: <IconShield />,
     title: "Every edit trains your Brain",

--- a/src/pages/EmailCampaignPage.tsx
+++ b/src/pages/EmailCampaignPage.tsx
@@ -474,6 +474,7 @@ export default function EmailCampaignPage() {
   const esRef = useRef<EventSource | null>(null);
 
   const personas = (activeBrand as any)?.personas || [];
+  const [handoffBanner, setHandoffBanner] = useState<string | null>(null);
 
   useEffect(() => {
     if (!activeBrandId) return;
@@ -484,6 +485,36 @@ export default function EmailCampaignPage() {
       if (d.success) setTemplates(d.templates);
     }).catch(() => {});
   }, [activeBrandId]);
+
+  // Quick Copy handoff — prefill brief from sessionStorage once, then clear.
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem('forge_quick_copy_handoff');
+      if (!raw) return;
+      sessionStorage.removeItem('forge_quick_copy_handoff');
+      const data = JSON.parse(raw);
+      if (!data || !data.fromQuickCopy) return;
+      const body = typeof data.body === 'string' ? data.body.trim() : '';
+      const subject = typeof data.subject === 'string' ? data.subject.trim() : '';
+      const prompt = typeof data.prompt === 'string' ? data.prompt.trim() : '';
+      const sourceText = typeof data.sourceText === 'string' ? data.sourceText.trim() : '';
+      setBrief((prev) => ({
+        ...prev,
+        campaign_type: prev.campaign_type || 'nurture',
+        business_problem: prompt || prev.business_problem,
+        smart_goal: prev.smart_goal || (prompt ? `Expand this one-off into a short sequence: ${prompt.slice(0, 160)}` : prev.smart_goal),
+        smp: prev.smp || body.slice(0, 220),
+        mandatories: [
+          prev.mandatories,
+          body ? `Seed copy from Quick Copy (keep voice; expand into sequence):\n${body.slice(0, 1200)}` : '',
+          subject ? `Preferred subject angle: ${subject}` : '',
+          sourceText ? `Original inbound/context:\n${sourceText.slice(0, 600)}` : '',
+        ].filter(Boolean).join('\n\n'),
+      }));
+      setStep('brief');
+      setHandoffBanner('Prefilled from Quick Copy — review the brief, then generate a sequence.');
+    } catch { /* ignore bad payload */ }
+  }, []);
 
   const handleGenerate = async () => {
     if (!activeBrandId) return;
@@ -756,6 +787,12 @@ export default function EmailCampaignPage() {
           </div>
         </div>
 
+        {handoffBanner && (
+          <div className="ec-error" style={{ background: 'rgba(79,70,229,0.08)', borderColor: 'rgba(79,70,229,0.25)', color: 'var(--color-accent)' }}>
+            <span>{handoffBanner}</span>
+            <button type="button" onClick={() => setHandoffBanner(null)} style={{ color: 'inherit' }}>×</button>
+          </div>
+        )}
         {error && <div className="ec-error">{error} <button onClick={() => setError('')}>✕</button></div>}
 
         {/* ── HISTORY ── */}

--- a/src/pages/SocialGeneratorPage.tsx
+++ b/src/pages/SocialGeneratorPage.tsx
@@ -204,6 +204,27 @@ function SocialGeneratorContent() {
     localStorage.setItem('forge_social_platform', platform);
   }, [platform]);
 
+  // Quick Copy handoff — prefill topic + platform once.
+  const [handoffBanner, setHandoffBanner] = useState<string | null>(null);
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem('forge_quick_copy_social_handoff');
+      if (!raw) return;
+      sessionStorage.removeItem('forge_quick_copy_social_handoff');
+      const data = JSON.parse(raw);
+      if (!data || !data.fromQuickCopy) return;
+      const topic = (typeof data.topicPrompt === 'string' && data.topicPrompt.trim())
+        || (typeof data.body === 'string' ? data.body.trim().slice(0, 280) : '');
+      if (topic) setTopicPrompt(topic);
+      if (data.platform === 'instagram' || data.platform === 'x') setPlatform(data.platform);
+      if (typeof data.body === 'string' && data.body.trim()) {
+        setMandatories((m) => m || `Seed angle from Quick Copy:\n${data.body.trim().slice(0, 500)}`);
+        setAdvancedOpen(true);
+      }
+      setHandoffBanner('Prefilled from Quick Copy — pick an arc, then generate.');
+    } catch { /* ignore */ }
+  }, []);
+
   // Load arcs when brand changes
   useEffect(() => {
     if (!selectedBrainId || !authToken) { setArcs([]); setArcsLoading(false); return; }
@@ -660,6 +681,12 @@ function SocialGeneratorContent() {
         </div>
       )}
 
+      {handoffBanner && (
+        <div className="sg-error" style={{ background: 'rgba(79,70,229,0.08)', borderColor: 'rgba(79,70,229,0.25)', color: 'var(--color-accent)', marginBottom: 12 }}>
+          <span>{handoffBanner}</span>
+          <button type="button" onClick={() => setHandoffBanner(null)} style={{ marginLeft: 8, background: 'none', border: 'none', color: 'inherit', cursor: 'pointer' }}>×</button>
+        </div>
+      )}
       {error && <div className="sg-error">{error}</div>}
 
       {posts.length > 0 && (


### PR DESCRIPTION
## Summary
Phase 3 after #560/#561 (merged on development; single promote-to-main later):

- **Email Campaign** consumes `forge_quick_copy_handoff` (one-shot sessionStorage) and prefills the brief + banner
- **Social Generator** consumes `forge_quick_copy_social_handoff` (topic/platform/seed mandatories + banner)
- **`/product`** Quick Copy tile in One Brain / Every Format + included list
- **Onboarding** step: Try Quick Copy → `/app/quick-copy`

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual: Quick Copy → Open in Email Campaign → brief prefilled
- [ ] Manual: Quick Copy → Open in Social → topic/platform prefilled
- [ ] Spot-check `/product` formats grid

## Note
Stays on `development` only — no main promote in this PR.