### PR TITLE
feat(quick-copy): Phase 4 mark-as-used brain write-back

### DIFF
--- a/docs/QUICK-COPY.md
+++ b/docs/QUICK-COPY.md
@@ -34,6 +34,7 @@ Brand-voiced one-off copy for replies, DMs, posts, and notes — without the ful
 | POST | `/:id/resolve-flag` | Soften/rewrite flagged span in-place |
 | POST | `/:id/find-sources` | Citation lookup for a flag/claim |
 | GET | `/recent-prompts/:brandProfileId` | Unique recent prompts for reuse |
+| POST | `/:id/mark-used` | Human "I used this" → weak `brain_patterns` row + `status=used` |
 
 Auth: `requireAuth` at mount. Brand access checked per request.
 
@@ -64,3 +65,9 @@ Auth: `requireAuth` at mount. Brand access checked per request.
 - **Handoff consumers** — Email Campaign reads `forge_quick_copy_handoff`; Social Generator reads `forge_quick_copy_social_handoff` (one-shot sessionStorage, then clear)
 - **Product** — Quick Copy tile on `/product` formats grid + included list
 - **Onboarding** — step pointing at `/app/quick-copy`
+
+## Phase 4
+
+- **Mark as used** — writes a weak `brain_patterns` row (`pattern_type=quick_copy_used`, `source_channel=quick_copy`, confidence ~0.25–0.55) and sets draft `status=used`
+- Idempotent: second click does not double-insert
+- Future Quick Copy gens already load top brain patterns, so used copy lightly conditions later one-offs

--- a/src/pages/QuickCopyPage.tsx
+++ b/src/pages/QuickCopyPage.tsx
@@ -226,6 +226,9 @@ export default function QuickCopyPage() {
   const [resolvingFlag, setResolvingFlag] = useState<number | null>(null);
   const [sourcingFlag, setSourcingFlag] = useState<number | null>(null);
   const [flagSources, setFlagSources] = useState<Record<number, FlagSource[]>>({});
+  const [draftStatus, setDraftStatus] = useState<string>('draft');
+  const [markingUsed, setMarkingUsed] = useState(false);
+  const [usedMessage, setUsedMessage] = useState('');
 
   const active = variants[activeIdx] || null;
   const displayBody = editing ? editBody : (active?.body || '');
@@ -324,6 +327,8 @@ export default function QuickCopyPage() {
           setDraftId(parsed.id);
           setVariants(parsed.variants || []);
           setActiveIdx(0);
+          setDraftStatus('draft');
+          setUsedMessage('');
           setStatus('');
           fetchHistory();
           fetchRecentPrompts();
@@ -393,6 +398,30 @@ export default function QuickCopyPage() {
       setTimeout(() => setCopied(false), 1400);
     } catch {
       setError('Clipboard blocked — select and copy manually.');
+    }
+  };
+
+  const markUsed = async () => {
+    if (!draftId || markingUsed || draftStatus === 'used') return;
+    if (editing) await saveEdit();
+    setMarkingUsed(true);
+    setError('');
+    setUsedMessage('');
+    try {
+      const r = await fetch(`/api/quick-copy/${draftId}/mark-used`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...ah },
+        body: JSON.stringify({ variantIdx: activeIdx }),
+      });
+      const d = await r.json();
+      if (!r.ok || !d.success) throw new Error(d.error || 'Mark used failed');
+      setDraftStatus('used');
+      setUsedMessage(d.alreadyUsed ? 'Already in brain' : 'Saved to brand brain');
+      fetchHistory();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setMarkingUsed(false);
     }
   };
 
@@ -583,6 +612,8 @@ export default function QuickCopyPage() {
       setVariants(vs);
       setActiveIdx(draft.active_variant_idx || 0);
       setCompliance(draft.compliance_json || null);
+      setDraftStatus(draft.status || 'draft');
+      setUsedMessage(draft.status === 'used' ? 'Already in brain' : '');
       setEditing(false);
       setHistoryOpen(false);
     } catch (e) {
@@ -628,6 +659,7 @@ export default function QuickCopyPage() {
               <button key={h.id} type="button" className="qc-history-row" onClick={() => openHistoryItem(h.id)}>
                 <div className="qc-history-meta">
                   <span className="qc-chip-sm">{h.format.replace('_', ' ')}</span>
+                  {h.status === 'used' && <span className="qc-chip-sm">used</span>}
                   <span className="qc-muted">{new Date(h.createdAt).toLocaleString()}</span>
                 </div>
                 <div className="qc-history-prompt">{h.prompt}</div>
@@ -836,7 +868,19 @@ export default function QuickCopyPage() {
                   >
                     <Shield /> {checking ? 'Checking…' : 'Check claims'}
                   </button>
+                  <button
+                    type="button"
+                    className="qc-btn-ghost-sm"
+                    onClick={markUsed}
+                    disabled={!draftId || markingUsed || draftStatus === 'used'}
+                    title="Tell the Brain you used this copy — weak pattern write-back"
+                  >
+                    {draftStatus === 'used' ? (usedMessage || 'Used ✓') : (markingUsed ? 'Saving…' : 'Mark as used')}
+                  </button>
                 </div>
+                {usedMessage && draftStatus === 'used' && (
+                  <div className="qc-muted">{usedMessage} — future Quick Copy gens will lean on it lightly.</div>
+                )}
 
                 <div className="qc-refine">
                   <span className="qc-muted">Refine:</span>

--- a/src/server/routes/quick-copy.js
+++ b/src/server/routes/quick-copy.js
@@ -734,6 +734,114 @@ router.post('/:id/find-sources', async (req, res) => {
   }
 });
 
+// POST /api/quick-copy/:id/mark-used — human says "I used this" → weak brain_pattern + status=used
+// Idempotent: if already used, returns existing pattern id without double-inserting.
+router.post('/:id/mark-used', async (req, res) => {
+  const { variantIdx, note = '' } = req.body || {};
+  try {
+    await ensureQuickCopyTable();
+    const draftRes = await pool.query(`SELECT * FROM quick_copy_drafts WHERE id = $1`, [req.params.id]);
+    if (!draftRes.rows.length) return res.status(404).json({ success: false, error: 'Draft not found' });
+    const draft = draftRes.rows[0];
+    if (!(await verifyBrandAccess(draft.brand_profile_id, req.userId))) {
+      return res.status(403).json({ success: false, error: 'Access denied' });
+    }
+
+    const variants = Array.isArray(draft.variants_json) ? draft.variants_json : [];
+    const idx = Number.isInteger(variantIdx) ? variantIdx : (draft.active_variant_idx || 0);
+    const variant = variants[idx] || variants[0];
+    if (!variant?.body?.trim()) {
+      return res.status(400).json({ success: false, error: 'No body on active variant to mark used' });
+    }
+
+    // Already used — return without double-writing patterns
+    if (draft.status === 'used') {
+      const existing = draft.notes && String(draft.notes).startsWith('brain_pattern:')
+        ? String(draft.notes).slice('brain_pattern:'.length)
+        : null;
+      return res.json({
+        success: true,
+        alreadyUsed: true,
+        status: 'used',
+        patternId: existing,
+        message: 'Already marked used',
+      });
+    }
+
+    const body = String(variant.body).trim();
+    const subject = variant.subject ? String(variant.subject).trim() : '';
+    const format = draft.format || 'custom';
+    const platform = draft.platform || 'generic';
+    const prompt = String(draft.prompt || '').trim();
+
+    // Weak pattern — low confidence so it informs future gens without overpowering measured ones
+    const description = [
+      `Successful Quick Copy (${format}/${platform}).`,
+      prompt ? `Ask: ${prompt.slice(0, 240)}` : null,
+      subject ? `Subject: ${subject.slice(0, 120)}` : null,
+      `Copy:\n${body.slice(0, 700)}`,
+      note && String(note).trim() ? `Human note: ${String(note).trim().slice(0, 200)}` : null,
+    ].filter(Boolean).join('\n');
+
+    const tags = JSON.stringify([
+      'source:quick_copy',
+      `format:${format}`,
+      `platform:${platform}`,
+      'human_used',
+    ]);
+
+    const conf = typeof variant.confidence === 'number'
+      ? Math.min(0.55, Math.max(0.25, variant.confidence / 100))
+      : 0.35;
+
+    const ins = await pool.query(
+      `INSERT INTO brain_patterns (
+         brand_profile_id, pattern_type, description, confidence_score, success_rate,
+         tags, source_channel, example_titles, created_at, updated_at
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
+       RETURNING id`,
+      [
+        draft.brand_profile_id,
+        'quick_copy_used',
+        description.slice(0, 1500),
+        conf,
+        0.5,
+        tags,
+        'quick_copy',
+        JSON.stringify([prompt.slice(0, 120) || `${format} one-off`].filter(Boolean)),
+      ]
+    );
+    const patternId = ins.rows[0]?.id || null;
+
+    await pool.query(
+      `UPDATE quick_copy_drafts
+          SET status = 'used',
+              active_variant_idx = $1,
+              notes = $2,
+              updated_at = NOW()
+        WHERE id = $3`,
+      [idx, patternId ? `brain_pattern:${patternId}` : draft.notes, draft.id]
+    );
+
+    await pool.query(
+      `INSERT INTO agent_activity_log (agent_name, brand_profile_id, status, tokens_used, latency_ms)
+       VALUES ($1, $2, $3, $4, $5)`,
+      ['stage4_quick_copy_mark_used', draft.brand_profile_id, 'success', 0, 0]
+    ).catch(() => {});
+
+    res.json({
+      success: true,
+      alreadyUsed: false,
+      status: 'used',
+      patternId,
+      message: 'Saved to brand brain as a weak pattern',
+    });
+  } catch (err) {
+    console.error('[QUICK-COPY] mark-used error:', err.message);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
 // GET /api/quick-copy/recent-prompts/:brandProfileId — unique recent prompts for reuse
 router.get('/recent-prompts/:brandProfileId', async (req, res) => {
   const { brandProfileId } = req.params;

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -224,6 +224,7 @@
   "POST /api/publishing/unpublish",
   "POST /api/quick-copy/:id/check",
   "POST /api/quick-copy/:id/find-sources",
+  "POST /api/quick-copy/:id/mark-used",
   "POST /api/quick-copy/:id/refine",
   "POST /api/quick-copy/:id/resolve-flag",
   "POST /api/quick-copy/generate",


### PR DESCRIPTION
## Summary
Phase 4 after #560–#562 (all on development; single main promote later):

- **Mark as used** button on Quick Copy output
- `POST /api/quick-copy/:id/mark-used` → weak `brain_patterns` row (`quick_copy_used`, low confidence, `source_channel=quick_copy`) + draft `status=used`
- Idempotent (second click does not double-insert)
- History shows a `used` chip

Future Quick Copy gens already load top brain patterns, so used one-offs lightly condition later drafts.

## Test plan
- [x] `tsc --noEmit` clean
- [x] unit + route inventory tests
- [ ] Manual: generate → Mark as used → button locks → history chip → reload draft stays used

## Note
Stays on `development` only.