### PR TITLE
chore(quick-copy): promote polish — history delete + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 | 4 | Content Generator | ✅ LIVE | Claude Sonnet 4.6 — requires enriched brief, published briefs filtered |
 | 4.5 | Campaign Generator | ✅ LIVE | Claude Sonnet 4.6 |
 | 4.6 | Email Campaign Generator | ✅ LIVE | Mistral Large — inline edit + per-flag actions (resolve/cite/dismiss) + brain feedback loop on false-positive dismissals + render-side sanitization for P.S./CTA/proof-token leakage |
+| 4.8 | Quick Copy | ✅ LIVE (dev) | Claude Sonnet 4.6 — brand-voiced one-offs (replies/DMs/posts); variant picker; optional inline claim check; mark-as-used → weak brain_patterns; handoffs to Email/Social. See `docs/QUICK-COPY.md`. |
 | 5 | Compliance Gate | ✅ LIVE | Claude Sonnet 4.6 |
 | 6 | Publishing & Distribution | ✅ LIVE | Queue + multi-channel: LinkedIn (Zernio), X (OAuth2 — x.com migrated 2026-05-23), Facebook (Zernio + Pipedream), Reddit (Zernio), Medium, Ghost, WordPress, Webflow, **My Website (new — self-hosted webhook publisher, see `/docs/my-website`)** |
 | 7 | Performance Intelligence | ✅ LIVE | LinkedIn + X + Ghost + GSC + GEO + Facebook + Reddit. **All Zernio-routed channels (LinkedIn / Reddit / Facebook) use dual-ID sync** (zernioPostId for analytics lookup, platform URN for display); Facebook URN→_id backfill admin endpoint shipped 2026-05-22 |

--- a/WORKING-STATE.md
+++ b/WORKING-STATE.md
@@ -13,13 +13,18 @@ This is the _current pointer_ doc — the long-form retrospective archive lives 
 
 ---
 
-### 2026-08-05 — Quick Copy P1+P2 merged; Phase 3 handoffs + product surface
+### 2026-08-05 — Quick Copy P1–P4 merged to development (promote-ready)
 
-**#560 + #561 merged to `development`.** Brian holding a single promote to main.
+**#560–#563 all merged to `development`.** Brian holding a single promote to main.
 
-- **P1** Quick Copy core (`/app/quick-copy`, Sonnet, variants, inline claim check)
-- **P2** Soften / Find source / recent prompts / handoff buttons
-- **P3 (this PR)** Email + Social consume sessionStorage handoffs; `/product` tile + included list; onboarding step
+| PR | Phase | What shipped |
+|----|-------|--------------|
+| #560 | P1 | Core `/app/quick-copy` + `/api/quick-copy`, Sonnet, variants 1–4, inline claim check |
+| #561 | P2 | Soften / Find source / recent prompts / handoff buttons |
+| #562 | P3 | Email+Social handoff consumers, `/product` tile, onboarding step |
+| #563 | P4 | Mark as used → weak `brain_patterns` write-back |
+
+Docs: `docs/QUICK-COPY.md`. Surface: Stage 4.8 in README when polish lands.
 
 **Not promoting to main until Brian's batch.**
 

--- a/docs/QUICK-COPY.md
+++ b/docs/QUICK-COPY.md
@@ -71,3 +71,8 @@ Auth: `requireAuth` at mount. Brand access checked per request.
 - **Mark as used** — writes a weak `brain_patterns` row (`pattern_type=quick_copy_used`, `source_channel=quick_copy`, confidence ~0.25–0.55) and sets draft `status=used`
 - Idempotent: second click does not double-insert
 - Future Quick Copy gens already load top brain patterns, so used copy lightly conditions later one-offs
+
+## Phase 5 (promote polish)
+
+- History **delete** control (uses existing `DELETE /:id`)
+- README stage table row (4.8 Quick Copy)

--- a/src/pages/QuickCopyPage.css
+++ b/src/pages/QuickCopyPage.css
@@ -404,6 +404,12 @@
   max-height: 280px;
   overflow: auto;
 }
+.qc-history-row-wrap {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px;
+  align-items: stretch;
+}
 .qc-history-row {
   text-align: left;
   border: 1px solid transparent;
@@ -413,8 +419,25 @@
   cursor: pointer;
   font-family: inherit;
   color: inherit;
+  width: 100%;
 }
 .qc-history-row:hover { border-color: var(--color-border); }
+.qc-history-delete {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0 10px;
+  font-family: inherit;
+}
+.qc-history-delete:hover {
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.3);
+  background: rgba(239, 68, 68, 0.06);
+}
 .qc-history-meta {
   display: flex;
   justify-content: space-between;

--- a/src/pages/QuickCopyPage.tsx
+++ b/src/pages/QuickCopyPage.tsx
@@ -621,6 +621,30 @@ export default function QuickCopyPage() {
     }
   };
 
+  const deleteHistoryItem = async (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm('Delete this Quick Copy draft?')) return;
+    try {
+      const r = await fetch(`/api/quick-copy/${id}`, {
+        method: 'DELETE',
+        headers: ah,
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok || d.success === false) throw new Error(d.error || 'Delete failed');
+      setHistory((prev) => prev.filter((h) => h.id !== id));
+      if (draftId === id) {
+        setDraftId(null);
+        setVariants([]);
+        setCompliance(null);
+        setDraftStatus('draft');
+        setUsedMessage('');
+      }
+      fetchRecentPrompts();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
   const complianceApplies =
     compliance &&
     active &&
@@ -656,15 +680,25 @@ export default function QuickCopyPage() {
           <div className="qc-history">
             {!history.length && <div className="qc-muted">No Quick Copies yet for this brand.</div>}
             {history.map((h) => (
-              <button key={h.id} type="button" className="qc-history-row" onClick={() => openHistoryItem(h.id)}>
-                <div className="qc-history-meta">
-                  <span className="qc-chip-sm">{h.format.replace('_', ' ')}</span>
-                  {h.status === 'used' && <span className="qc-chip-sm">used</span>}
-                  <span className="qc-muted">{new Date(h.createdAt).toLocaleString()}</span>
-                </div>
-                <div className="qc-history-prompt">{h.prompt}</div>
-                {h.preview && <div className="qc-history-preview">{h.preview}</div>}
-              </button>
+              <div key={h.id} className="qc-history-row-wrap">
+                <button type="button" className="qc-history-row" onClick={() => openHistoryItem(h.id)}>
+                  <div className="qc-history-meta">
+                    <span className="qc-chip-sm">{h.format.replace('_', ' ')}</span>
+                    {h.status === 'used' && <span className="qc-chip-sm">used</span>}
+                    <span className="qc-muted">{new Date(h.createdAt).toLocaleString()}</span>
+                  </div>
+                  <div className="qc-history-prompt">{h.prompt}</div>
+                  {h.preview && <div className="qc-history-preview">{h.preview}</div>}
+                </button>
+                <button
+                  type="button"
+                  className="qc-history-delete"
+                  title="Delete draft"
+                  onClick={(ev) => deleteHistoryItem(h.id, ev)}
+                >
+                  ×
+                </button>
+              </div>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
Promote-readiness polish after #560–#563 (all on development):

- History **delete** control (uses existing `DELETE /api/quick-copy/:id`)
- README Stage **4.8 Quick Copy** row (marked LIVE on dev)
- WORKING-STATE summary of P1–P4 stack for the main promote batch

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual: history × deletes draft; active draft clears if it was open

## Note
Dev-only. No main promote in this PR.