### PR TITLE
feat(compliance+the-post): reject requires reason; brain feeds card-gen

### DIFF
--- a/src/pages/ComplianceGatePage.tsx
+++ b/src/pages/ComplianceGatePage.tsx
@@ -9,6 +9,17 @@ import '../components/GateModal.css';
 type ReviewMode = 'auto-ship' | 'approve-to-ship' | 'full-review';
 type ComplianceStatus = 'pending' | 'reviewed' | 'approved' | 'rejected';
 
+const REJECT_REASON_OPTIONS: { code: string; label: string }[] = [
+  { code: 'invented_claim', label: 'Invented or unsupported claim' },
+  { code: 'wrong_voice', label: 'Off-brand voice / tone' },
+  { code: 'nda_risk', label: 'NDA / naming risk' },
+  { code: 'off_thesis', label: 'Off thesis / wrong framing' },
+  { code: 'too_salesy', label: 'Too salesy / hype' },
+  { code: 'factual_error', label: 'Factual error' },
+  { code: 'legal_risk', label: 'Legal / compliance risk' },
+  { code: 'other', label: 'Other' },
+];
+
 const IconInfo = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/>
@@ -163,6 +174,7 @@ function ComplianceGateContent() {
   const [manualEditSections, setManualEditSections] = useState<Record<number, boolean>>({});
   const [dismissedFlags, setDismissedFlags] = useState<Record<number, boolean>>({});
   const [decisions, setDecisions] = useState<Record<number, 'approved' | 'rejected'>>({});
+  const [rejectReasons, setRejectReasons] = useState<Record<number, { code: string; note?: string }>>({});
   // FAQ edits — parallel structure to editedSections. Each FAQ entry can have its question
   // and/or answer overridden. Empty fields default to the LLM-generated original on submit.
   const [editedFaqs, setEditedFaqs] = useState<Record<number, { question?: string; answer?: string }>>({});
@@ -384,6 +396,23 @@ function ComplianceGateContent() {
         ...(qa.question !== undefined ? { question: qa.question } : {}),
         ...(qa.answer !== undefined ? { answer: qa.answer } : {})
       }));
+      // Reject without typed reason is not allowed (server also enforces)
+      const rejectedIdxs = Object.entries(decisions)
+        .filter(([, v]) => v === 'rejected')
+        .map(([k]) => Number(k));
+      for (const ri of rejectedIdxs) {
+        const rr = rejectReasons[ri];
+        if (!rr?.code) {
+          setError(`Section ${ri + 1}: pick a reject reason before submitting`);
+          setSubmitLoading(false);
+          return;
+        }
+        if (rr.code === 'other' && !(rr.note || '').trim()) {
+          setError(`Section ${ri + 1}: "Other" requires a short note`);
+          setSubmitLoading(false);
+          return;
+        }
+      }
       const r = await authFetch('/api/compliance/approve', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -394,7 +423,8 @@ function ComplianceGateContent() {
           editedSections: edits,
           editedFaqs: faqEdits,
           ...(editedKeyTakeaway !== null ? { keyTakeaway: editedKeyTakeaway } : {}),
-          decisions
+          decisions,
+          rejectReasons,
         })
       });
       const d = await r.json();
@@ -664,12 +694,66 @@ function ComplianceGateContent() {
                         <div className="comp-decision-btns">
                           <button
                             className={`comp-decision-btn approve ${decisions[idx] === 'approved' ? 'active' : ''}`}
-                            onClick={() => setDecisions(p => ({ ...p, [idx]: 'approved' }))}
+                            onClick={() => {
+                              setDecisions(p => ({ ...p, [idx]: 'approved' }));
+                              setRejectReasons(p => {
+                                const n = { ...p };
+                                delete n[idx];
+                                return n;
+                              });
+                            }}
                           >Approve</button>
                           <button
                             className={`comp-decision-btn reject ${decisions[idx] === 'rejected' ? 'active' : ''}`}
-                            onClick={() => setDecisions(p => ({ ...p, [idx]: 'rejected' }))}
+                            onClick={() => {
+                              setDecisions(p => ({ ...p, [idx]: 'rejected' }));
+                              setRejectReasons(p => (p[idx] ? p : { ...p, [idx]: { code: '', note: '' } }));
+                            }}
                           >Reject</button>
+                        </div>
+                      )}
+                      {decisions[idx] === 'rejected' && (
+                        <div className="comp-reject-reason" style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--color-text-muted)' }}>
+                            Reject reason (required)
+                          </label>
+                          <select
+                            className="comp-reject-reason-select"
+                            value={rejectReasons[idx]?.code || ''}
+                            onChange={(e) => setRejectReasons(p => ({
+                              ...p,
+                              [idx]: { ...(p[idx] || {}), code: e.target.value },
+                            }))}
+                            style={{
+                              fontSize: 12,
+                              padding: '6px 8px',
+                              borderRadius: 6,
+                              border: '1px solid var(--color-border, #e5e7eb)',
+                              background: 'var(--color-surface, #fff)',
+                            }}
+                          >
+                            <option value="">Select a reason…</option>
+                            {REJECT_REASON_OPTIONS.map((o) => (
+                              <option key={o.code} value={o.code}>{o.label}</option>
+                            ))}
+                          </select>
+                          {(rejectReasons[idx]?.code === 'other' || (rejectReasons[idx]?.code && rejectReasons[idx]?.code !== '')) && (
+                            <input
+                              className="comp-reject-reason-note"
+                              placeholder={rejectReasons[idx]?.code === 'other' ? 'Brief note (required for Other)…' : 'Optional note…'}
+                              value={rejectReasons[idx]?.note || ''}
+                              onChange={(e) => setRejectReasons(p => ({
+                                ...p,
+                                [idx]: { ...(p[idx] || { code: '' }), note: e.target.value },
+                              }))}
+                              style={{
+                                fontSize: 12,
+                                padding: '6px 8px',
+                                borderRadius: 6,
+                                border: '1px solid var(--color-border, #e5e7eb)',
+                              }}
+                            />
+                          )}
                         </div>
                       )}
                     </div>

--- a/src/server/reject-reasons.js
+++ b/src/server/reject-reasons.js
@@ -1,0 +1,80 @@
+// Shared reject / editorial-signal taxonomy for Compliance Gate + The Post.
+// Rejecting a compliance warning WITHOUT a reason is not allowed.
+
+export const REJECT_REASON_CODES = Object.freeze([
+  'invented_claim',
+  'wrong_voice',
+  'nda_risk',
+  'off_thesis',
+  'too_salesy',
+  'factual_error',
+  'legal_risk',
+  'other',
+]);
+
+export const REJECT_REASON_LABELS = Object.freeze({
+  invented_claim: 'Invented or unsupported claim',
+  wrong_voice: 'Off-brand voice / tone',
+  nda_risk: 'NDA / naming risk',
+  off_thesis: 'Off thesis / wrong framing',
+  too_salesy: 'Too salesy / hype',
+  factual_error: 'Factual error',
+  legal_risk: 'Legal / compliance risk',
+  other: 'Other',
+});
+
+export function isValidRejectReason(code) {
+  return REJECT_REASON_CODES.includes(String(code || '').trim());
+}
+
+/**
+ * Normalize decisions + rejectReasons from the client.
+ * decisions: { [sectionIdx]: 'approved' | 'rejected' }
+ * rejectReasons: { [sectionIdx]: { code, note? } }
+ * Returns { ok, error?, rejected: [{ idx, code, note, label }] }
+ */
+export function validateRejectReasons(decisions = {}, rejectReasons = {}) {
+  const rejected = [];
+  const entries = Object.entries(decisions || {});
+  for (const [key, value] of entries) {
+    if (value !== 'rejected') continue;
+    const idx = String(key);
+    const rr = rejectReasons?.[key] || rejectReasons?.[idx] || {};
+    const code = String(rr.code || rr.reason || '').trim();
+    if (!isValidRejectReason(code)) {
+      return {
+        ok: false,
+        error: `Reject of section ${idx} requires a reason code (${REJECT_REASON_CODES.join(', ')})`,
+        code: 'reject_reason_required',
+        sectionIndex: Number.isFinite(Number(idx)) ? Number(idx) : idx,
+      };
+    }
+    const note = rr.note != null ? String(rr.note).trim().slice(0, 500) : '';
+    if (code === 'other' && note.length < 3) {
+      return {
+        ok: false,
+        error: `Reject reason "other" on section ${idx} requires a short note`,
+        code: 'reject_note_required',
+        sectionIndex: Number.isFinite(Number(idx)) ? Number(idx) : idx,
+      };
+    }
+    rejected.push({
+      idx: Number.isFinite(Number(idx)) ? Number(idx) : idx,
+      code,
+      note,
+      label: REJECT_REASON_LABELS[code] || code,
+    });
+  }
+  return { ok: true, rejected };
+}
+
+export function formatRejectBrainFeedback({ code, label, note, flagReason, sectionHeading }) {
+  const bits = [
+    `REJECT reason: ${label || code}`,
+    note ? `Operator note: ${note}` : null,
+    flagReason ? `Flag context: ${String(flagReason).slice(0, 280)}` : null,
+    sectionHeading ? `Section: ${sectionHeading}` : null,
+    'Do NOT regenerate similar content for this brand.',
+  ].filter(Boolean);
+  return bits.join(' — ').slice(0, 900);
+}

--- a/src/server/routes/compliance.js
+++ b/src/server/routes/compliance.js
@@ -13,6 +13,11 @@ import { finalizeArticleForStorage } from '../text.js';
 import { verifyBrandAccess } from '../auth.js';
 import { normalizeNarrativeIdentity, lintNarrativePerspective } from '../narrative-identity.js';
 import { findCitationSources } from '../citations.js';
+import {
+  validateRejectReasons,
+  formatRejectBrainFeedback,
+  REJECT_REASON_CODES,
+} from '../reject-reasons.js';
 
 const router = express.Router();
 
@@ -500,9 +505,30 @@ router.post('/dismiss-flag', async (req, res) => {
 // POST approve — save human edits, write mistakes to brain, mark approved
 router.post('/approve', async (req, res) => {
   const startTime = Date.now();
-  const { brandProfileId, contentId, reviewMode, editedSections, decisions, editedFaqs, keyTakeaway } = req.body;
+  const {
+    brandProfileId,
+    contentId,
+    reviewMode,
+    editedSections,
+    decisions,
+    rejectReasons,
+    editedFaqs,
+    keyTakeaway,
+  } = req.body;
   if (!brandProfileId || !contentId) return res.status(400).json({ error: 'brandProfileId and contentId required' });
   try {
+    // Hard rule: any rejected compliance section MUST carry a typed reason
+    const rejectCheck = validateRejectReasons(decisions || {}, rejectReasons || {});
+    if (!rejectCheck.ok) {
+      return res.status(400).json({
+        success: false,
+        error: rejectCheck.error,
+        code: rejectCheck.code || 'reject_reason_required',
+        sectionIndex: rejectCheck.sectionIndex,
+        allowedReasons: REJECT_REASON_CODES,
+      });
+    }
+
     const safeId = brandProfileId.replace(/-/g, '_');
     const tableName = `generated_content_${safeId}`;
 
@@ -586,6 +612,36 @@ router.post('/approve', async (req, res) => {
     // Handle red section decisions
     const finalStatus = reviewMode === 'auto-ship' ? 'approved' :
       decisions && Object.values(decisions).some(d => d === 'rejected') ? 'rejected' : 'approved';
+
+    // Write typed reject signals to brain (classy Towanda — reasons required)
+    const reportFlags = Array.isArray(article.compliance_report?.flags)
+      ? article.compliance_report.flags
+      : Array.isArray(articleJson?.compliance_report?.flags)
+        ? articleJson.compliance_report.flags
+        : [];
+    for (const rej of rejectCheck.rejected || []) {
+      const section = articleJson?.sections?.[rej.idx] || {};
+      const heading = section.heading || `section ${rej.idx}`;
+      const flag = reportFlags.find((f) => Number(f.sectionIndex) === Number(rej.idx)) || reportFlags[rej.idx];
+      const bodySnippet = String(section.body || section.content || '').slice(0, 220);
+      await pool.query(
+        `INSERT INTO brain_mistakes (brand_profile_id, mistake_type, description, human_feedback, severity)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          brandProfileId,
+          `compliance_reject:${rej.code}`,
+          `Compliance Gate REJECT on "${heading}"${bodySnippet ? `: "${bodySnippet}"` : ''}`,
+          formatRejectBrainFeedback({
+            code: rej.code,
+            label: rej.label,
+            note: rej.note,
+            flagReason: flag?.reason || '',
+            sectionHeading: heading,
+          }),
+          rej.code === 'legal_risk' || rej.code === 'nda_risk' ? 'high' : 'medium',
+        ]
+      ).catch((e) => console.error('[COMPLIANCE] reject brain write error:', e.message));
+    }
 
     // Final safety net — strip LLM scaffolding AND em dashes that slipped past
     // human review. The human reviewer edits in this gate, so this is the LAST

--- a/src/server/routes/the-post-card-gen.js
+++ b/src/server/routes/the-post-card-gen.js
@@ -112,6 +112,50 @@ async function loadBrandBrainForCardGen(brandProfileId, { limit = 12 } = {}) {
   }
 }
 
+
+function formatPreferenceExamples(pref) {
+  if (!pref || typeof pref !== 'object') return '';
+  const good = Array.isArray(pref.good) ? pref.good : [];
+  const bad = Array.isArray(pref.bad) ? pref.bad : [];
+  const edits = Array.isArray(pref.edits) ? pref.edits : [];
+  const rules = Array.isArray(pref.rules) ? pref.rules : [];
+  if (!good.length && !bad.length && !edits.length && !rules.length) return '';
+
+  const lines = [
+    'POST ORGANIZER PREFERENCES (org-scoped human judgments — highest priority after session truth):',
+    'These are from THIS client\'s approve/reject/edit history. Obey them for this generation.',
+  ];
+  if (rules.length) {
+    lines.push('Active rules:');
+    for (const r of rules.slice(0, 6)) {
+      lines.push(`- [${r.code || 'rule'}] ${clip(r.guidance || '', 200)}`);
+    }
+  }
+  if (good.length) {
+    lines.push('Write MORE like these approved cards:');
+    for (const g of good.slice(0, 5)) {
+      lines.push(`- TITLE: ${clip(g.title || '', 120)}`);
+      if (g.summary) lines.push(`  SUMMARY: ${clip(g.summary, 280)}`);
+    }
+  }
+  if (bad.length) {
+    lines.push('Do NOT write like these rejected cards:');
+    for (const b of bad.slice(0, 5)) {
+      const why = [b.reason_code, b.reason_note].filter(Boolean).join(' — ');
+      lines.push(`- TITLE: ${clip(b.title || '', 120)}${why ? ` (${clip(why, 120)})` : ''}`);
+      if (b.summary) lines.push(`  SUMMARY: ${clip(b.summary, 220)}`);
+    }
+  }
+  if (edits.length) {
+    lines.push('When you see avoid→prefer edits, match the prefer side:');
+    for (const e of edits.slice(0, 4)) {
+      lines.push(`- AVOID summary: ${clip(e.before_summary || '', 160)}`);
+      lines.push(`  PREFER summary: ${clip(e.after_summary || '', 160)}`);
+    }
+  }
+  return lines.join('\n');
+}
+
 function formatBrainBlock(brain) {
   const patterns = brain?.patterns || [];
   const mistakes = brain?.mistakes || [];
@@ -154,8 +198,19 @@ router.post('/card-gen', async (req, res) => {
     eventContext?.brand_profile_id ||
     eventContext?.brand_profile?.id ||
     null;
-  const brain = await loadBrandBrainForCardGen(brandProfileId);
-  const brainBlock = formatBrainBlock(brain);
+  // Post-owned learnings (preferred). FI brand brain is optional fallback only.
+  const preferenceExamples =
+    body.preference_examples || body.preferenceExamples || null;
+  const prefBlock = formatPreferenceExamples(preferenceExamples);
+  const useFiBrain =
+    !prefBlock &&
+    brandProfileId &&
+    String(process.env.THE_POST_USE_FI_BRAIN || '').trim() === '1';
+  const brain = useFiBrain
+    ? await loadBrandBrainForCardGen(brandProfileId)
+    : { patterns: [], mistakes: [] };
+  const brainBlock = useFiBrain ? formatBrainBlock(brain) : '';
+  const learningBlock = [prefBlock, brainBlock].filter(Boolean).join('\n\n');
 
   if (!session.title && !session.abstract && excerpts.length === 0) {
     return res.status(400).json({ error: 'session or source_excerpts required' });
@@ -225,7 +280,8 @@ Rules:
 - confidence: 0-1 reflecting source richness + factual grounding + context completeness. Be honest; thin input or thin event context must stay lower.
 - Sentence case. No emoji. No markdown.
 - Do NOT invent speakers, stats, or claims absent from the input + event context.
-- When ACTIVE BRAND BRAIN is present: follow Patterns; never repeat Mistakes/rejects (especially compliance_reject:*).
+- When POST ORGANIZER PREFERENCES are present: they outrank generic style; match approved examples; never repeat rejected patterns/reasons.
+- When ACTIVE BRAND BRAIN is present (legacy): follow Patterns; never repeat Mistakes/rejects.
 Desired fields: ${desired.join(', ')}.
 Prompt version: ${PROMPT_VERSION}.`;
 
@@ -241,7 +297,7 @@ Abstract/notes: ${clip(session.abstract || session.notes || '', 2500)}
 Source excerpts:
 ${excerptBlock || '(none)'}
 
-${brainBlock ? brainBlock + '\n\n' : ''}Produce the JSON card now.`;
+${learningBlock ? learningBlock + '\n\n' : ''}Produce the JSON card now.`;
 
   try {
     const msg = await anthropic.messages.create({
@@ -285,8 +341,18 @@ ${brainBlock ? brainBlock + '\n\n' : ''}Produce the JSON card now.`;
       prompt_version: PROMPT_VERSION,
       usage: msg.usage || null,
       event_context_thin: thinContext,
+      preferences: preferenceExamples
+        ? {
+            good: (preferenceExamples.good || []).length,
+            bad: (preferenceExamples.bad || []).length,
+            edits: (preferenceExamples.edits || []).length,
+            rules: (preferenceExamples.rules || []).length,
+            meta: preferenceExamples.meta || null,
+          }
+        : null,
       brain: {
         brand_profile_id: brandProfileId || null,
+        used: !!useFiBrain,
         patterns: (brain.patterns || []).length,
         mistakes: (brain.mistakes || []).length,
       },

--- a/src/server/routes/the-post-card-gen.js
+++ b/src/server/routes/the-post-card-gen.js
@@ -5,6 +5,13 @@ import express from 'express';
 import { timingSafeEqual } from 'crypto';
 import { anthropic } from '../llm.js';
 import { safeParseLLM } from '../llm-json.js';
+import { pool } from '../db.js';
+import {
+  validateRejectReasons,
+  formatRejectBrainFeedback,
+  REJECT_REASON_CODES,
+  REJECT_REASON_LABELS,
+} from '../reject-reasons.js';
 
 const router = express.Router();
 const PROMPT_VERSION = 'the-post-card-gen-v2';
@@ -76,6 +83,56 @@ function heuristicConfidence(session, excerpts, out) {
   return Math.max(0.15, Math.min(0.95, Math.round(c * 100) / 100));
 }
 
+
+async function loadBrandBrainForCardGen(brandProfileId, { limit = 12 } = {}) {
+  if (!brandProfileId || !pool) return { patterns: [], mistakes: [] };
+  try {
+    const [pRes, mRes] = await Promise.all([
+      pool.query(
+        `SELECT pattern_type, description, confidence_score, success_rate
+           FROM brain_patterns
+          WHERE brand_profile_id = $1
+          ORDER BY COALESCE(success_rate, 0) DESC, COALESCE(confidence_score, 0) DESC, created_at DESC
+          LIMIT $2`,
+        [brandProfileId, limit]
+      ),
+      pool.query(
+        `SELECT mistake_type, description, human_feedback, severity
+           FROM brain_mistakes
+          WHERE brand_profile_id = $1
+          ORDER BY created_at DESC
+          LIMIT $2`,
+        [brandProfileId, limit]
+      ),
+    ]);
+    return { patterns: pRes.rows || [], mistakes: mRes.rows || [] };
+  } catch (e) {
+    console.warn('[the-post/card-gen] brain load failed', e.message);
+    return { patterns: [], mistakes: [] };
+  }
+}
+
+function formatBrainBlock(brain) {
+  const patterns = brain?.patterns || [];
+  const mistakes = brain?.mistakes || [];
+  if (!patterns.length && !mistakes.length) return '';
+  const lines = ['ACTIVE BRAND BRAIN (editorial signals — obey these):'];
+  if (patterns.length) {
+    lines.push('Patterns / writing rules (prefer):');
+    for (const p of patterns.slice(0, 8)) {
+      lines.push(`- [${p.pattern_type || 'pattern'}] ${clip(p.description || '', 220)}`);
+    }
+  }
+  if (mistakes.length) {
+    lines.push('Mistakes / rejects (avoid):');
+    for (const m of mistakes.slice(0, 10)) {
+      const fb = m.human_feedback ? ` → ${clip(m.human_feedback, 180)}` : '';
+      lines.push(`- [${m.mistake_type || 'mistake'}] ${clip(m.description || '', 160)}${fb}`);
+    }
+  }
+  return lines.join('\n');
+}
+
 router.post('/card-gen', async (req, res) => {
   const auth = serviceTokenOk(req);
   if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
@@ -91,6 +148,14 @@ router.post('/card-gen', async (req, res) => {
     ? body.desired
     : ['title', 'summary', 'quotes', 'tags', 'qna'];
   const excerpts = Array.isArray(body.source_excerpts) ? body.source_excerpts.slice(0, 8) : [];
+  const brandProfileId =
+    body.brand_profile_id ||
+    body.brandProfileId ||
+    eventContext?.brand_profile_id ||
+    eventContext?.brand_profile?.id ||
+    null;
+  const brain = await loadBrandBrainForCardGen(brandProfileId);
+  const brainBlock = formatBrainBlock(brain);
 
   if (!session.title && !session.abstract && excerpts.length === 0) {
     return res.status(400).json({ error: 'session or source_excerpts required' });
@@ -160,6 +225,7 @@ Rules:
 - confidence: 0-1 reflecting source richness + factual grounding + context completeness. Be honest; thin input or thin event context must stay lower.
 - Sentence case. No emoji. No markdown.
 - Do NOT invent speakers, stats, or claims absent from the input + event context.
+- When ACTIVE BRAND BRAIN is present: follow Patterns; never repeat Mistakes/rejects (especially compliance_reject:*).
 Desired fields: ${desired.join(', ')}.
 Prompt version: ${PROMPT_VERSION}.`;
 
@@ -175,7 +241,7 @@ Abstract/notes: ${clip(session.abstract || session.notes || '', 2500)}
 Source excerpts:
 ${excerptBlock || '(none)'}
 
-Produce the JSON card now.`;
+${brainBlock ? brainBlock + '\n\n' : ''}Produce the JSON card now.`;
 
   try {
     const msg = await anthropic.messages.create({
@@ -219,11 +285,108 @@ Produce the JSON card now.`;
       prompt_version: PROMPT_VERSION,
       usage: msg.usage || null,
       event_context_thin: thinContext,
+      brain: {
+        brand_profile_id: brandProfileId || null,
+        patterns: (brain.patterns || []).length,
+        mistakes: (brain.mistakes || []).length,
+      },
     });
   } catch (err) {
     console.error('[the-post/card-gen]', err.message);
     return res.status(500).json({ error: err.message || 'card-gen failed' });
   }
+});
+
+
+// POST /decision — The Post (or other M2M) writes approve/reject into brand brain.
+// Reject requires a typed reason code (same taxonomy as Compliance Gate).
+router.post('/decision', async (req, res) => {
+  const auth = serviceTokenOk(req);
+  if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+
+  const body = req.body || {};
+  const brandProfileId = body.brand_profile_id || body.brandProfileId;
+  const decision = String(body.decision || '').toLowerCase();
+  if (!brandProfileId) return res.status(400).json({ error: 'brand_profile_id required' });
+  if (!['approved', 'rejected', 'approve', 'reject'].includes(decision)) {
+    return res.status(400).json({ error: 'decision must be approved|rejected' });
+  }
+  const isReject = decision === 'rejected' || decision === 'reject';
+
+  let reasonCode = body.reason_code || body.reasonCode || body.reason || '';
+  let reasonNote = body.reason_note || body.reasonNote || body.note || '';
+  if (isReject) {
+    const check = validateRejectReasons(
+      { 0: 'rejected' },
+      { 0: { code: reasonCode, note: reasonNote } }
+    );
+    if (!check.ok) {
+      return res.status(400).json({
+        error: check.error,
+        code: check.code,
+        allowedReasons: REJECT_REASON_CODES,
+      });
+    }
+    reasonCode = check.rejected[0].code;
+    reasonNote = check.rejected[0].note;
+  }
+
+  const title = clip(body.title || body.card?.title || 'card', 200);
+  const summary = clip(body.summary || body.card?.summary || '', 400);
+  const source = clip(body.source_label || body.event_id || body.eventId || 'the-post', 120);
+  const confidence = body.confidence != null ? Number(body.confidence) : null;
+
+  try {
+    if (isReject) {
+      const label = REJECT_REASON_LABELS[reasonCode] || reasonCode;
+      await pool.query(
+        `INSERT INTO brain_mistakes (brand_profile_id, mistake_type, description, human_feedback, severity)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          brandProfileId,
+          `post_reject:${reasonCode}`,
+          `The Post REJECT "${title}"${summary ? `: "${summary}"` : ''} [${source}]`,
+          formatRejectBrainFeedback({
+            code: reasonCode,
+            label,
+            note: reasonNote,
+            flagReason: confidence != null ? `model confidence ${confidence}` : '',
+            sectionHeading: title,
+          }),
+          reasonCode === 'legal_risk' || reasonCode === 'nda_risk' ? 'high' : 'medium',
+        ]
+      );
+      return res.json({ success: true, wrote: 'brain_mistakes', reason_code: reasonCode });
+    }
+
+    // approve → positive pattern (light signal)
+    await pool.query(
+      `INSERT INTO brain_patterns (brand_profile_id, pattern_type, description, confidence_score, tags)
+       VALUES ($1, $2, $3, $4, $5::jsonb)`,
+      [
+        brandProfileId,
+        'post_approved_card',
+        `Approved card style: "${title}"${summary ? ` — ${summary}` : ''}`,
+        Number.isFinite(confidence) ? confidence : 0.7,
+        JSON.stringify({ source: 'the-post', event_id: body.event_id || body.eventId || null }),
+      ]
+    );
+    return res.json({ success: true, wrote: 'brain_patterns' });
+  } catch (e) {
+    console.error('[the-post/decision]', e.message);
+    return res.status(500).json({ error: e.message || 'decision write failed' });
+  }
+});
+
+router.get('/reject-reasons', (req, res) => {
+  const auth = serviceTokenOk(req);
+  if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+  res.json({
+    reasons: REJECT_REASON_CODES.map((code) => ({
+      code,
+      label: REJECT_REASON_LABELS[code],
+    })),
+  });
 });
 
 export default router;

--- a/test/reject-reasons.test.js
+++ b/test/reject-reasons.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateRejectReasons,
+  isValidRejectReason,
+  REJECT_REASON_CODES,
+} from '../src/server/reject-reasons.js';
+
+describe('reject reasons taxonomy', () => {
+  it('lists expected codes', () => {
+    expect(REJECT_REASON_CODES).toContain('invented_claim');
+    expect(REJECT_REASON_CODES).toContain('other');
+  });
+
+  it('allows approve-only decisions without reasons', () => {
+    const r = validateRejectReasons({ 0: 'approved' }, {});
+    expect(r.ok).toBe(true);
+    expect(r.rejected).toEqual([]);
+  });
+
+  it('requires reason on reject', () => {
+    const r = validateRejectReasons({ 2: 'rejected' }, {});
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('reject_reason_required');
+  });
+
+  it('accepts valid reject reason', () => {
+    const r = validateRejectReasons(
+      { 1: 'rejected' },
+      { 1: { code: 'too_salesy', note: 'hype abstract' } }
+    );
+    expect(r.ok).toBe(true);
+    expect(r.rejected[0].code).toBe('too_salesy');
+  });
+
+  it('requires note for other', () => {
+    const r = validateRejectReasons({ 0: 'rejected' }, { 0: { code: 'other', note: '' } });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe('reject_note_required');
+  });
+
+  it('validates codes', () => {
+    expect(isValidRejectReason('nda_risk')).toBe(true);
+    expect(isValidRejectReason('nope')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Compliance Gate reject now **requires** a typed reason (and note for `other`)
- Rejects write `brain_mistakes` as `compliance_reject:<code>`
- The Post card-gen injects active brand Patterns + Mistakes into the prompt
- New M2M `POST /api/external/the-post/decision` so Post queue approve/reject trains the same brain

## Why
Classy Towanda: human decisions become editorial signals, not silent shrugs. Same FI Patterns/pre-cog religion — no second pgvector cult.

## Test plan
- [x] vitest reject-reasons taxonomy
- [ ] Compliance Gate: reject red section without reason → blocked
- [ ] Reject with `too_salesy` → brain_mistakes row
- [ ] card-gen with brand_profile_id returns `brain.patterns/mistakes` counts
- [ ] external `/decision` reject without reason → 400