### PR TITLE
Cross-service impact check: auto-answer "does this break another service?" on every PR

### DIFF
--- a/.github/scripts/impact-check.mjs
+++ b/.github/scripts/impact-check.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Cross-service impact check.
+// Compares the base branch's route snapshot against the PR's, and joins removed
+// or changed routes against test/consumer-map.json to name the external services
+// a change would break. Exits 1 (fails the PR) when a consumer is impacted.
+//
+// Usage: impact-check.mjs <base-snapshot.json> <head-snapshot.json> <consumer-map.json>
+//
+// Route params are normalized (:id and {id} -> {}) so a param RENAME is not a
+// false removal, while a real path/method removal is.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [, , baseFile, headFile, mapFile] = process.argv;
+
+const norm = (route) =>
+  route
+    .replace(/:[A-Za-z0-9_]+\??/g, "{}")
+    .replace(/\{[^}]+\}/g, "{}")
+    .replace(/\/+$/, "");
+
+const load = (f) => new Map(JSON.parse(readFileSync(f, "utf8")).map((r) => [norm(r), r]));
+
+const base = load(baseFile);
+const head = load(headFile);
+const map = JSON.parse(readFileSync(mapFile, "utf8"));
+
+const removed = [...base.entries()].filter(([n]) => !head.has(n));
+const added = [...head.entries()].filter(([n]) => !base.has(n));
+
+const matches = (routePath, pattern) => {
+  const p = norm("X " + pattern).slice(2); // normalize pattern path the same way
+  if (pattern.endsWith("*")) return routePath.startsWith(p.slice(0, -1));
+  return routePath === p;
+};
+
+const impacts = [];
+for (const [n, original] of removed) {
+  const path = n.split(" ").slice(1).join(" ");
+  for (const c of map.consumers) {
+    if (c.paths.some((pat) => matches(path, pat))) {
+      impacts.push({ route: original, service: c.service, repo: c.repo, contact: c.contact, sources: c.sources });
+    }
+  }
+}
+
+let report = "## Cross-service impact report\n\n";
+if (!removed.length && !added.length) {
+  report += "No route-surface changes.\n";
+} else {
+  if (removed.length) {
+    report += `**Removed/renamed routes (${removed.length}):**\n` +
+      removed.map(([, r]) => `- \`${r}\``).join("\n") + "\n\n";
+  }
+  if (added.length) {
+    report += `**Added routes (${added.length}):**\n` +
+      added.map(([, r]) => `- \`${r}\``).join("\n") + "\n\n";
+  }
+  if (impacts.length) {
+    report += "### 🚨 BREAKS EXTERNAL CONSUMERS\n\n";
+    for (const i of impacts) {
+      report += `- \`${i.route}\` → **${i.service}** (\`${i.repo}\`)\n` +
+        `  - call sites: ${i.sources.map((s) => `\`${s}\``).join(", ")}\n` +
+        `  - blast radius: ${i.contact}\n`;
+    }
+    report += "\nCoordinate with the consumer (deprecate + migrate) before merging, " +
+      "or keep the old route as an alias. If the consumer has already migrated, " +
+      "update `test/consumer-map.json` in this PR.\n";
+  } else {
+    report += "✅ No external consumers impacted (per `test/consumer-map.json`).\n";
+  }
+}
+
+writeFileSync("impact-report.md", report);
+console.log(report);
+process.exit(impacts.length ? 1 : 0);

--- a/.github/workflows/cross-service-impact.yml
+++ b/.github/workflows/cross-service-impact.yml
@@ -1,0 +1,49 @@
+name: Cross-service impact
+
+# Answers "does this break another service?" on every PR automatically.
+# Producer surface = test/routes.snapshot.json (kept honest by the existing
+# route-inventory guard). Consumers = test/consumer-map.json.
+# Red X + PR comment naming the broken consumer when a route they call is
+# removed or renamed.
+
+on:
+  pull_request:
+    paths:
+      - "server.js"
+      - "src/server/**"
+      - "test/routes.snapshot.json"
+      - "test/consumer-map.json"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  impact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch base route snapshot
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/contents/test/routes.snapshot.json?ref=${{ github.event.pull_request.base.sha }}" \
+            -H "Accept: application/vnd.github.raw" > base.snapshot.json
+
+      - name: Impact check
+        id: check
+        run: |
+          node .github/scripts/impact-check.mjs base.snapshot.json test/routes.snapshot.json test/consumer-map.json
+
+      - name: Comment on PR
+        if: always() && steps.check.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -f impact-report.md ]; then
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --edit-last --create-if-none \
+              --body-file impact-report.md
+          fi

--- a/test/consumer-map.json
+++ b/test/consumer-map.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Cross-service consumer map: which external services call which FI routes. Used by .github/scripts/impact-check.mjs on every PR to answer 'does this break another service?'. Paths support a trailing * prefix-wildcard. Keep sources honest — every entry should be traceable to a real call site. Regenerate hints: grep consumer repos for /api/external.",
+  "consumers": [
+    {
+      "service": "The Post",
+      "repo": "Sandbox-Group-LLC/The-Post",
+      "paths": [
+        "/api/external/the-post/*",
+        "/api/external/brand-profile",
+        "/api/external/analyze"
+      ],
+      "sources": [
+        "lib/forge_card_gen.js",
+        "lib/factual_ground.js",
+        "lib/fi_brand.js",
+        "lib/fi_decisions.js",
+        "lib/longform.js",
+        "lib/regenerate.js"
+      ],
+      "contact": "thepost.events prod — breaks card-gen, learning loop, brand bootstrap"
+    },
+    {
+      "service": "SYSOI.ai",
+      "repo": "Sandbox-Group-LLC/SYSOI.ai",
+      "paths": [
+        "/api/external/brand-profile",
+        "/api/external/analyze"
+      ],
+      "sources": [
+        "src/lib/forgeIntel.ts"
+      ],
+      "contact": "SYSOI dossier path — breaks audience-profile build"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Every PR touching \`server.js\` / \`src/server/**\` now gets an automatic **cross-service impact report**: the route snapshot (already kept honest by the route-inventory guard) is diffed against base, removed/renamed routes are joined against \`test/consumer-map.json\`, and if an external service consumes an affected route the PR **fails with a comment naming the consumer, its call sites, and the blast radius**.

## Why

The Post is actively driving FI changes, and "is this going to break another service?" is currently answered by asking Brian. This makes CI answer it instead.

## Verified behaviors (simulated locally)

1. Removing \`POST /api/external/the-post/card-gen\` → ❌ red X, comment names **The Post**, 6 call sites, blast radius (card-gen, learning loop, brand bootstrap)
2. Param rename \`:id\` → \`:itemId\` → ✅ no false positive (params normalized)
3. Removing an internal route no consumer uses → ✅ passes, removal listed for visibility

## Consumer map (v1, verified against real call sites)

- **The Post** → \`/api/external/the-post/*\`, \`/api/external/brand-profile\`, \`/api/external/analyze\` (from \`lib/forge_card_gen.js\`, \`lib/fi_brand.js\`, et al.)
- **SYSOI.ai** → \`/api/external/brand-profile\`, \`/api/external/analyze\` (from \`src/lib/forgeIntel.ts\`)

Map maintenance is part of the workflow: a PR that intentionally retires a route after consumer migration updates the map in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)