### PR TITLE
the-post factual-ground: field parity with FI's FG form

### DIFF
--- a/src/server/routes/the-post-card-gen.js
+++ b/src/server/routes/the-post-card-gen.js
@@ -1265,12 +1265,17 @@ router.post('/critique', async (req, res) => {
 // source of truth the longform writer AND critic both consume). redactedFacts
 // is NOT editable here — it is populated only by the verified_unnameable
 // dismiss taxonomy, and trueReferent is write-only and must NEVER leave FI.
+// Field parity with FI's own Factual Ground form (BrandSettingsPage) —
+// everything editable there is editable here, minus brandName (identity).
 const FG_EDITABLE_FIELDS = [
   'whatWeDo',
   'whatWeDontDo',
   'companyFacts',
   'foundingStory',
   'methodology',
+  'teamComposition',
+  'quotablePositions',
+  'competitors',
   'authors',
 ];
 const FG_FIELD_MAX = 6000;


### PR DESCRIPTION
Follow-up to #595. The Post's editor is supposed to be the SAME form as FI's Factual Ground (BrandSettingsPage), which has 9 fields — #595 only whitelisted 6. Adds `teamComposition`, `quotablePositions`, `competitors` to `FG_EDITABLE_FIELDS`. Same merge/caps/redactedFacts-protection semantics; no route changes (inventory guard untouched). Companion Post UI PR: Sandbox-Group-LLC/The-Post#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)