### PR TITLE
the-post: apply-suggestion endpoint for compliance flags

### DIFF
--- a/src/server/routes/the-post-card-gen.js
+++ b/src/server/routes/the-post-card-gen.js
@@ -1411,4 +1411,89 @@ router.put('/factual-ground', async (req, res) => {
   }
 });
 
+// ── Apply a compliance-flag suggestion (The Post review UI) ──────────────────
+// Contract: The Post docs/contracts/longform-compliance.md
+// inventory: POST /api/external/the-post/apply-suggestion
+// Minimal-diff rewrite: the writer model applies EXACTLY the critic's suggested
+// fix to one section body and touches nothing else. Same UX as FI's own
+// apply-suggestion flow.
+const APPLY_SUGGESTION_MODEL =
+  process.env.THE_POST_APPLY_SUGGESTION_MODEL || 'claude-haiku-4-5-20251001';
+
+router.post('/apply-suggestion', async (req, res) => {
+  const auth = serviceTokenOk(req);
+  if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return res.status(503).json({ error: 'ANTHROPIC_API_KEY not configured' });
+  }
+
+  const body = req.body || {};
+  const sectionBody = String(body.section_body || body.sectionBody || '').trim();
+  const suggestion = String(body.suggestion || '').trim();
+  if (!sectionBody || !suggestion) {
+    return res.status(400).json({ error: 'section_body and suggestion required' });
+  }
+  const heading = clip(body.section_heading || body.sectionHeading || '', 200);
+  const excerpt = clip(body.flagged_excerpt || body.flaggedExcerpt || '', 600);
+  const reason = clip(body.reason || '', 500);
+
+  const prompt = `You are applying a single editorial fix to one section of a longform article.
+
+SECTION${heading ? ` ("${heading}")` : ''}:
+${sectionBody}
+
+COMPLIANCE FLAG:
+${excerpt ? `Flagged excerpt: "${excerpt}"\n` : ''}${reason ? `Why flagged: ${reason}\n` : ''}Suggested fix: ${suggestion}
+
+Rules:
+- Apply the suggested fix. The INTENT of the fix is mandatory; adapt its exact wording only as needed to flow naturally.
+- Change NOTHING else — no restyling, no reordering, no added or removed content beyond what the fix requires.
+- Preserve paragraph breaks and formatting.
+- Sentence case. No emoji. ZERO em dashes (U+2014).
+
+Return ONLY valid JSON: {"body": "<the full revised section body>"}`;
+
+  try {
+    const msg = await anthropic.messages.create({
+      model: APPLY_SUGGESTION_MODEL,
+      max_tokens: 4096,
+      temperature: 0,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const text = (msg.content || [])
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n')
+      .trim();
+    let parsed = safeParseLLM(text, 'object', 'the-post-apply-suggestion');
+    if (!parsed || typeof parsed !== 'object') {
+      const m = text.match(/\{[\s\S]*\}/);
+      if (m) {
+        try {
+          parsed = JSON.parse(m[0]);
+        } catch {
+          parsed = null;
+        }
+      }
+    }
+    const revised = String(parsed?.body || '').trim();
+    // Sanity: non-empty, actually changed, and not a wild rewrite.
+    if (!revised || revised === sectionBody) {
+      return res.status(502).json({ error: 'apply produced no change' });
+    }
+    if (revised.length < sectionBody.length * 0.5 || revised.length > sectionBody.length * 2) {
+      return res.status(502).json({ error: 'apply produced an implausible rewrite — rejected' });
+    }
+    return res.json({
+      success: true,
+      body: revised,
+      model: APPLY_SUGGESTION_MODEL,
+      usage: msg.usage || null,
+    });
+  } catch (err) {
+    console.error('[the-post/apply-suggestion]', err.message);
+    return res.status(500).json({ error: err.message || 'apply-suggestion failed' });
+  }
+});
+
 export default router;

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -190,6 +190,7 @@
   "POST /api/email-campaign/email/:id/resolve-flag",
   "POST /api/email-campaign/save-brief-template",
   "POST /api/external/analyze",
+  "POST /api/external/the-post/apply-suggestion",
   "POST /api/external/the-post/card-gen",
   "POST /api/external/the-post/critique",
   "POST /api/external/the-post/decision",


### PR DESCRIPTION
The Post's longform review gets the same **Apply suggestion** capability FI's own UI has. `POST /api/external/the-post/apply-suggestion` takes `{section_heading, section_body, flagged_excerpt, reason, suggestion}` and returns a minimal-diff revised body (Haiku, temp 0) with guards: must actually change, and rejects implausible rewrites (<0.5× or >2× original length). Route snapshot updated; inventory guard green. Companion Post PR: Sandbox-Group-LLC/The-Post#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)