### PR TITLE
apply-suggestion: already-satisfied is success, stale excerpts still fixed

### DIFF
--- a/src/server/routes/the-post-card-gen.js
+++ b/src/server/routes/the-post-card-gen.js
@@ -1447,11 +1447,13 @@ ${excerpt ? `Flagged excerpt: "${excerpt}"\n` : ''}${reason ? `Why flagged: ${re
 
 Rules:
 - Apply the suggested fix. The INTENT of the fix is mandatory; adapt its exact wording only as needed to flow naturally.
+- The flagged excerpt may be stale (the section may have been edited since the flag was raised). If the UNDERLYING ISSUE still appears ANYWHERE in the section — even partially, even reworded — fix every remaining instance.
+- Only report changed:false when the section ALREADY fully satisfies the fix and there is genuinely nothing left to change.
 - Change NOTHING else — no restyling, no reordering, no added or removed content beyond what the fix requires.
 - Preserve paragraph breaks and formatting.
 - Sentence case. No emoji. ZERO em dashes (U+2014).
 
-Return ONLY valid JSON: {"body": "<the full revised section body>"}`;
+Return ONLY valid JSON: {"changed": true|false, "body": "<the full revised section body (or the original if changed:false)>", "note": "<if changed:false, one sentence on why the fix is already satisfied>"}`;
 
   try {
     const msg = await anthropic.messages.create({
@@ -1477,9 +1479,17 @@ Return ONLY valid JSON: {"body": "<the full revised section body>"}`;
       }
     }
     const revised = String(parsed?.body || '').trim();
-    // Sanity: non-empty, actually changed, and not a wild rewrite.
-    if (!revised || revised === sectionBody) {
-      return res.status(502).json({ error: 'apply produced no change' });
+    // Already satisfied (e.g. a sibling flag's apply incidentally covered this
+    // fix): success with unchanged:true so the caller can resolve the flag
+    // instead of surfacing an error to the reviewer.
+    if (parsed?.changed === false || !revised || revised === sectionBody) {
+      return res.json({
+        success: true,
+        unchanged: true,
+        note: clip(parsed?.note || 'section already satisfies the suggested fix', 300),
+        model: APPLY_SUGGESTION_MODEL,
+        usage: msg.usage || null,
+      });
     }
     if (revised.length < sectionBody.length * 0.5 || revised.length > sectionBody.length * 2) {
       return res.status(502).json({ error: 'apply produced an implausible rewrite — rejected' });


### PR DESCRIPTION
Live failure on the Sovereign Data card: **'apply produced no change' ×2**. Data showed the earlier sibling apply had already introduced the suggested replacements ('ruggedized server', 'vehicle-mounted') while the flagged phrase partially remained — the model concluded nothing to do and echoed the body; our guard turned that into a reviewer-facing error.

Two changes:
1. Prompt: flagged excerpts may be stale — if the underlying issue persists **anywhere** in the section, fix every remaining instance; report `changed:false` only when the fix is genuinely fully satisfied.
2. Response: `changed:false`/echo now returns `{success:true, unchanged:true, note}` instead of 502 — The Post resolves the flag as applied (companion: Sandbox-Group-LLC/The-Post#10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)