### PR TITLE
build: pinned Dockerfile for the DigitalOcean/Coolify migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Keep the build context small and keep local junk out of the image.
+node_modules
+dist
+.git
+.github
+.env
+.env.*
+*.log
+npm-debug.log*
+.DS_Store
+coverage
+test-results
+docs
+memory
+scripts/*.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Forge Intelligence — container image for Coolify / DigitalOcean.
+#
+# Why a Dockerfile instead of nixpacks (added 2026-08-16 during the Render -> DO migration):
+#
+#   `rolldown@1.1.3` (pulled in by vite ^8) declares `engines.node: ^20.19.0 || >=22.12.0`.
+#   Nixpacks' Node 22 resolves to **22.11.0** — one patch below that floor — so npm skips
+#   rolldown's platform-specific optional dependency and the build dies with the misleading
+#   "Cannot find native binding" error (npm/cli#4828). Nixpacks' pinned nixpkgs snapshot has
+#   no Node 24 to escape to.
+#
+#   The repo declares no `engines` field, so nothing recorded that floor anywhere. This image
+#   pins it explicitly. If you bump vite/rolldown, check their engines before changing the tag.
+#
+# Build context note: `npm ci` is used here (not `npm install`, and not the `yarn install`
+# the old Render service ran against a repo that has no yarn.lock — that combination silently
+# ignored package-lock.json and resolved fresh on every build).
+
+FROM node:22.12-bookworm-slim
+
+WORKDIR /app
+
+# System deps: the app shells out for image/media work and needs CA certs for outbound TLS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+# Dependency layer — cached unless the lockfile changes.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Application source, then the vite build (emits ./dist, which server.js serves).
+COPY . .
+RUN npm run build
+
+ENV NODE_ENV=production
+ENV PORT=3000
+EXPOSE 3000
+
+# dumb-init so SIGTERM reaches node and the container stops cleanly on redeploy.
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
First code change of the Forge Intelligence migration. **No application code touched** — one Dockerfile, one .dockerignore.

## Why nixpacks can't build this app

`rolldown@1.1.3` (pulled in by `vite ^8`) declares `engines.node: ^20.19.0 || >=22.12.0`. Nixpacks' Node 22 resolves to **22.11.0** — one patch below the floor. npm then skips rolldown's platform-specific optional dependency, and the build dies with the famously misleading:

```
Cannot find native binding. npm has a bug related to optional dependencies (npm/cli#4828)
```

`NIXPACKS_NODE_VERSION=24` doesn't rescue it either — nixpacks' pinned nixpkgs snapshot has no Node 24, so it fails earlier at `nix-env`.

**The repo declares no `engines` field**, so that Node floor was recorded nowhere. This image pins `node:22.12-bookworm-slim` and documents the reason inline, so the next person who bumps vite knows to check.

## Also fixed: builds were never reproducible

The Render service ran **`yarn install`** against a repo that contains **no `yarn.lock`** — only `package-lock.json`. Yarn ignores an npm lockfile, so every production build re-resolved dependencies from `package.json` fresh. This switches to `npm ci` against the lockfile that actually exists.

## Contents

- `node:22.12-bookworm-slim`, `npm ci`, `npm run build` (vite emits `./dist`, which `server.js` serves), `node server.js` on `PORT` (default 3000)
- `dumb-init` as PID 1 so `SIGTERM` reaches node and containers stop cleanly on redeploy
- `.dockerignore` to keep `node_modules`, `dist`, `.git` and local scratch out of the build context

## Testing

Targets `development`, which deploys to the new **forge-dev** Coolify app on forge-b — a fresh environment with its **own Neon branch**, so this cannot touch production data. Verification happens there before anything is proposed for `main`.