### PR TITLE
docs(agents): read PURPOSE.md every session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 
 # Claude Code web bootstrap — per-session ephemeral state
 .claude/.state/
+PURPOSE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,24 @@ Board cleaned for founder work tomorrow. Branch reconciled, sessions wiped, Grok
 
 <!-- openclaw-operating-brief:end -->
 
+## Read this every session: what we are for
+
+`PURPOSE.md` sits in this repo root, git-ignored like the rest of the harness. **Read it at the start
+of every session, alongside `SOUL.md` and `IDENTITY.md`.** SOUL is how you behave. PURPOSE is what
+Sandbox exists to do.
+
+Short version: **we are an experience-first organization.** Most B2B events are built to inform; we
+build them to move. Beauty, story and hospitality are not the opposite of results, they are how
+results happen. *Pipeline is the outcome, the experience is the engine.*
+
+That is not decoration for your work, it is a spec for it. You build the "before the doors open"
+layer — invitations, microsites, check-in, portals — held to the same standard as the room itself.
+**No seams. No drop in fidelity.** An error message is hospitality. A broken deploy during an event
+is a guest at a door that will not open. Craft first, receipts second, both always.
+
+Full text in `PURPOSE.md`; source of truth is https://sandbox-xm.com/design-intelligence.html
+
+
 ---
 
 # CLAUDE.md


### PR DESCRIPTION
The harness docs told agents how to behave and never what Sandbox is **for**.

`PURPOSE.md` (experience-first, from sandbox-xm.com/design-intelligence.html) now sits in the workspace, git-ignored like the rest of the harness, and the brief says to read it every session alongside SOUL and IDENTITY.

It is a spec, not a mission statement: no seams and no drop in fidelity is a build standard, an error message is hospitality, and a broken deploy during an event is a guest at a door that will not open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)