### PR TITLE
chore(deps): Batch 4 react-router-dom v7.18.2 (#614)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.20.0",
+        "react-router-dom": "^7.18.2",
         "react-syntax-highlighter": "^16.1.1",
         "remark-gfm": "^4.0.1",
         "turndown": "^7.2.0"
@@ -2179,15 +2179,6 @@
         "proxy-agent": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
-      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@remotion/bundler": {
@@ -9044,35 +9035,54 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
-      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
-      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4",
-        "react-router": "6.30.6"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-syntax-highlighter": {
@@ -9466,6 +9476,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.20.0",
+    "react-router-dom": "^7.18.2",
     "react-syntax-highlighter": "^16.1.1",
     "remark-gfm": "^4.0.1",
     "turndown": "^7.2.0"


### PR DESCRIPTION
## Summary
Batch 4 from #614. Bumps `react-router-dom` `^6.20.0` → **`^7.18.2`** (resolves `react-router@7.18.2`).

Closes the last Dependabot alerts on root: GHSA-jjmj / GHSA-wrjc / GHSA-337j. No v6 patch exists.

**Into `development` only.** Soak on `dev.forgeintelligence.ai` before promoting to `main`.

## Why this is bounded (not a rewrite)
| Check | Result |
|---|---|
| Import style | Declarative only — `BrowserRouter`, `Routes`, `Route`, `Navigate`, `Link`, `useNavigate`, `useParams` |
| Import sites | **13** (listed below) |
| Data router | **None** — no `createBrowserRouter` / `RouterProvider` |
| Deprecated helpers | **None** — no router `json()` / `defer()` |
| `unstable_*` | **None** |
| Multi-segment splats | `/app/context-hub/*` + legacy `/context-hub/*` only; **no nested relative links** under them → `v7_relativeSplatPath` no-op |
| Node | Dockerfile `node:22.12-bookworm-slim`; v7 wants `>=20` ✅ |
| React | `^18.2.0`; v7 peers `react/react-dom >=18` ✅ |

### Import sites
```
src/main.tsx
src/About.tsx
src/Product.tsx
src/marketing/MarketingShell.tsx
src/pages/QuickStartPage.tsx
src/pages/PublicArticlesLibraryPage.tsx
src/pages/PublicArticlePage.tsx
src/pages/BrandIntelligenceBriefPage.tsx
src/pages/DocsPage.tsx
src/pages/ContentGeneratorPage.tsx
src/components/OnboardingBot.tsx
src/components/NoBrandEmpty.tsx
src/components/views/BrandProfile.tsx
```

## Code changes
**Package bump only.** No source edits. Left imports on `react-router-dom` (still the supported DOM entry in v7). Optional follow-up: swap package name to `react-router` + rewrite imports — not required for the CVE close.

## Gate
```
npm ci && npm run typecheck && npm run test && npm run lint && npm run build
npm audit   # → 0 vulnerabilities
```
- typecheck ✅
- test ✅ 25 files / 250 tests
- lint ✅
- build ✅
- audit ✅ **0**

## Consumer / routes
Client routing only — no server serialization/validation/API shape change. `routes:snapshot` N/A. `cross-service-impact.yml` does not fire on package.json (as noted in #614); this does not touch brand-profile output.

## Manual soak (please, on dev after merge)
1. `/` marketing + `/product` / `/about` / `/docs/:slug`
2. `/app/quick-start` → navigate into `/app/context-hub`
3. God-mode / onboard redirects that rewrite to `/app/context-hub`
4. Public `/articles/:brandSlug/:articleSlug` + `/brand-intelligence/:token` + `/review/:token`
5. In-app `useNavigate` paths (brand settings, onboarding bot links)

## Deliberately not in this PR
- Package rename `react-router-dom` → `react-router`
- Data-router adoption
- Future-flag staging on v6 first (already on latest v6.30.x pre-bump; declarative surface has nothing to opt into that needed a code change)

Closes the remaining #614 alerts once this merges + Dependabot re-scans.