### PR TITLE
feat(analytics): My Website SEO via GSC join

### DIFF
--- a/docs/MYWEBSITE.md
+++ b/docs/MYWEBSITE.md
@@ -13,6 +13,18 @@ This integration is built for teams who own their stack — custom sites on Reac
 
 Forge captures the response and surfaces a "View on site" link in the Publishing Queue.
 
+## Analytics
+
+My Website has no native analytics API (your site owns storage and rendering). Forge tracks organic search performance for these articles via **Google Search Console**:
+
+1. Connect GSC under **Integrations** (or the Performance Dashboard GSC tab).
+2. Publish articles through My Website so Forge has `channel=website` publish rows with your live URLs.
+3. Open **Performance → My Website** and hit **Sync Search Data**.
+
+Forge joins each My Website publish URL to GSC page metrics (impressions, clicks, CTR, position). Prefer returning `{ "url": "https://yoursite.com/articles/<slug>" }` from your receiver so matching hits your real public URLs — otherwise Forge falls back to the canonical article URL.
+
+GSC data usually lags 24–48 hours after publish. On-page engagement (pageviews, read time) is not part of this path yet.
+
 ## Setup in Forge
 
 1. **Brand Settings → Integrations → My Website**

--- a/server.js
+++ b/server.js
@@ -5798,6 +5798,7 @@ app.get('/auth/gsc/callback', async (req, res) => {
 // (analytics route/helper moved to src/server/routes/analytics.js)
 
 // GET /api/analytics/webflow-seo/:brandProfileId — Webflow content performance via GSC
+// GET /api/analytics/website-seo/:brandProfileId — My Website content performance via GSC
 // (analytics route/helper moved to src/server/routes/analytics.js)
 
 // GET /api/gsc/status/:brandProfileId — check connection status + verified sites

--- a/src/docs/my-website.md
+++ b/src/docs/my-website.md
@@ -13,6 +13,18 @@ This integration is built for teams who own their stack — custom sites on Reac
 
 Forge captures the response and surfaces a "View on site" link in the Publishing Queue.
 
+## Analytics
+
+My Website has no native analytics API (your site owns storage and rendering). Forge tracks organic search performance for these articles via **Google Search Console**:
+
+1. Connect GSC under **Integrations** (or the Performance Dashboard GSC tab).
+2. Publish articles through My Website so Forge has `channel=website` publish rows with your live URLs.
+3. Open **Performance → My Website** and hit **Sync Search Data**.
+
+Forge joins each My Website publish URL to GSC page metrics (impressions, clicks, CTR, position). Prefer returning `{ "url": "https://yoursite.com/articles/<slug>" }` from your receiver so matching hits your real public URLs — otherwise Forge falls back to the canonical article URL.
+
+GSC data usually lags 24–48 hours after publish. On-page engagement (pageviews, read time) is not part of this path yet.
+
 ## Setup in Forge
 
 1. **Brand Settings → Integrations → My Website**

--- a/src/pages/PerformanceDashboardPage.tsx
+++ b/src/pages/PerformanceDashboardPage.tsx
@@ -51,12 +51,13 @@ const CHANNELS = [
   { id: 'geo',   label: 'GEO',   live: true },
   { id: 'wordpress', label: 'WordPress', live: true },
   { id: 'webflow', label: 'Webflow', live: true },
+  { id: 'website', label: 'My Website', live: true },
   { id: 'campaigns', label: 'Campaigns', live: true },
 ];
 
 const CHANNEL_COLORS: Record<string, string> = {
   linkedin: '#0A66C2', x: '#000000', ghost: '#FF1A75', facebook: '#1877F2', gsc: '#4285F4',
-  reddit: '#FF4500', wordpress: '#3858E9', webflow: '#4353FF',
+  reddit: '#FF4500', wordpress: '#3858E9', webflow: '#4353FF', website: '#6366F1',
 };
 
 // Friendly display names for the GEO citation engines (stored ids are terse).
@@ -162,6 +163,8 @@ export default function PerformanceDashboardPage() {
   const [gscSyncing, setGscSyncing] = useState(false);
   const [wfSeo, setWfSeo] = useState<any>(null);
   const [wfSeoLoading, setWfSeoLoading] = useState(false);
+  const [websiteSeo, setWebsiteSeo] = useState<any>(null);
+  const [websiteSeoLoading, setWebsiteSeoLoading] = useState(false);
   const [geoCitations, setGeoCitations] = useState<any[]>([]);
   const [geoTracking, setGeoTracking] = useState(false);
   const [geoLoaded, setGeoLoaded] = useState(false);
@@ -237,6 +240,9 @@ export default function PerformanceDashboardPage() {
     }
     if (activeChannel === 'webflow' && brandProfileId) {
       fetchWebflowSeo();
+    }
+    if (activeChannel === 'website' && brandProfileId) {
+      fetchWebsiteSeo();
     }
     if (activeChannel === 'gsc' && brandProfileId) {
       fetch(`/api/gsc/status/${brandProfileId}`, { headers: ah }).then(r => r.json()).then(d => setGscStatus(d)).catch(() => {});
@@ -365,6 +371,19 @@ export default function PerformanceDashboardPage() {
     finally { setWfSeoLoading(false); }
   };
 
+  const fetchWebsiteSeo = async () => {
+    if (!brandProfileId) return;
+    setWebsiteSeoLoading(true);
+    try {
+      const token = authTokenRef.current || authToken || '';
+      const h: Record<string,string> = token ? { 'Authorization': `Bearer ${token}` } : {};
+      const r = await fetch(`/api/analytics/website-seo/${brandProfileId}`, { headers: h });
+      const d = await r.json();
+      if (d.success) setWebsiteSeo(d);
+    } catch(e) { console.error('Website SEO fetch error:', e); reportError(e, { area: 'performance' }); }
+    finally { setWebsiteSeoLoading(false); }
+  };
+
     const handleGscSync = async () => {
     if (!brandProfileId) return;
     setGscSyncing(true);
@@ -491,7 +510,7 @@ export default function PerformanceDashboardPage() {
             <p className="geo-description">Content analytics across all channels and campaigns.</p>
           </div>
           <div className="perf-header-right">
-            {!['geo', 'gsc', 'predictions', 'patterns', 'webflow'].includes(activeChannel) && <div className="perf-sync-wrap">
+            {!['geo', 'gsc', 'predictions', 'patterns', 'webflow', 'website'].includes(activeChannel) && <div className="perf-sync-wrap">
               <div className="perf-btn-group">
               <button className={`perf-sync-btn ${syncing ? 'syncing' : ''}`} onClick={handleSync} disabled={syncing || !brandProfileId}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={syncing ? 'spin' : ''}>
@@ -538,7 +557,7 @@ export default function PerformanceDashboardPage() {
         ) : (
           <>
             {/* ── KPI Cards ── */}
-            {activeChannel !== 'campaigns' && activeChannel !== 'gsc' && activeChannel !== 'geo' && activeChannel !== 'predictions' && activeChannel !== 'patterns' && activeChannel !== 'webflow' && <div className="perf-kpis">
+            {activeChannel !== 'campaigns' && activeChannel !== 'gsc' && activeChannel !== 'geo' && activeChannel !== 'predictions' && activeChannel !== 'patterns' && activeChannel !== 'webflow' && activeChannel !== 'website' && <div className="perf-kpis">
               {(activeChannel === 'ghost' ? [
                 { label: 'Link Clicks', value: fmt(data?.totals?.clicks || 0), sub: 'Total tracked clicks', icon: 'click', spark: false },
                 { label: 'Avg Read Time', value: data?.totals?.avgReadingTime ? `${data.totals.avgReadingTime} min` : '—', sub: 'Minutes per article', icon: 'eye', spark: false },
@@ -565,7 +584,7 @@ export default function PerformanceDashboardPage() {
             </div>}
 
             {/* ── 30-Day Trend ── */}
-            {activeChannel !== 'campaigns' && activeChannel !== 'gsc' && activeChannel !== 'geo' && activeChannel !== 'predictions' && activeChannel !== 'patterns' && activeChannel !== 'webflow' && activeChannel !== 'pipeline' && <div className="perf-section">
+            {activeChannel !== 'campaigns' && activeChannel !== 'gsc' && activeChannel !== 'geo' && activeChannel !== 'predictions' && activeChannel !== 'patterns' && activeChannel !== 'webflow' && activeChannel !== 'website' && activeChannel !== 'pipeline' && <div className="perf-section">
               <div className="perf-section-header">
                 <h2 className="perf-section-title">30-Day {activeChannel === 'reddit' ? 'Views' : 'Impressions'}</h2>
                 {(data?.trend?.length ?? 0) > 0 && (
@@ -578,7 +597,7 @@ export default function PerformanceDashboardPage() {
             </div>}
 
             {/* ── Posts Table ── */}
-            {activeChannel !== 'campaigns' && activeChannel !== 'gsc' && activeChannel !== 'geo' && activeChannel !== 'predictions' && activeChannel !== 'patterns' && activeChannel !== 'webflow' && <div className="perf-section">
+            {activeChannel !== 'campaigns' && activeChannel !== 'gsc' && activeChannel !== 'geo' && activeChannel !== 'predictions' && activeChannel !== 'patterns' && activeChannel !== 'webflow' && activeChannel !== 'website' && <div className="perf-section">
               <div className="perf-section-header">
                 <h2 className="perf-section-title">Published Posts</h2>
                 <span className="perf-section-meta">{data?.posts?.length || 0} tracked</span>
@@ -884,6 +903,103 @@ export default function PerformanceDashboardPage() {
                       {wfSeo.articles.some((a: any) => !a.hasGscData) && (
                         <p style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', marginTop: 8, fontStyle: 'italic' }}>
                           Articles showing — for search data need a GSC sync after publishing. GSC data typically takes 24-48 hours to populate.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {activeChannel === 'website' && (
+              <div className="perf-gsc-panel">
+                {websiteSeoLoading ? (
+                  <div className="perf-empty"><p>Loading My Website SEO data...</p></div>
+                ) : !websiteSeo?.articles?.length ? (
+                  <div className="perf-empty">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+                    <p>{!websiteSeo?.gscConnected
+                      ? 'Connect Google Search Console to see how your My Website articles perform in search.'
+                      : 'No articles published to My Website yet. Publish from the Publishing Queue to start tracking.'}</p>
+                    {!websiteSeo?.gscConnected && (
+                      <button className="perf-gsc-btn" onClick={handleGscConnect} disabled={!brandProfileId} style={{ marginTop: 12 }}>
+                        Connect GSC
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  <div className="perf-gsc-connected">
+                    <div className="perf-gsc-connected-header">
+                      <span className="perf-gsc-connected-label">My Website SEO Performance</span>
+                      <div className="perf-btn-group">
+                        <button className="perf-sync-btn" onClick={async () => { await handleGscSync(); await fetchWebsiteSeo(); }} disabled={gscSyncing || !brandProfileId}>
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={gscSyncing ? 'spin' : ''}>
+                            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/>
+                            <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/>
+                          </svg>
+                          {gscSyncing ? 'Syncing GSC...' : 'Sync Search Data'}
+                        </button>
+                        <span className="perf-section-meta">{websiteSeo.articles.length} articles · {websiteSeo.gscConnected ? 'GSC connected' : 'GSC not connected'}</span>
+                      </div>
+                    </div>
+
+                    <div className="perf-kpis" style={{ marginTop: '16px' }}>
+                      {[
+                        { label: 'Published', value: String(websiteSeo.totals?.published || 0), sub: 'Articles on your site', icon: 'eye' },
+                        { label: 'Search Impressions', value: fmt(websiteSeo.totals?.impressions || 0), sub: 'Google search appearances', icon: 'eye' },
+                        { label: 'Search Clicks', value: fmt(websiteSeo.totals?.clicks || 0), sub: 'Organic traffic', icon: 'click' },
+                        { label: 'Avg CTR', value: `${websiteSeo.totals?.avgCtr || 0}%`, sub: 'Click-through rate', icon: 'trend' },
+                        { label: 'Avg Position', value: websiteSeo.totals?.avgPosition ? String(websiteSeo.totals.avgPosition) : '—', sub: 'Search ranking', icon: 'trend' },
+                      ].map(kpi => (
+                        <div key={kpi.label} className="perf-kpi-card">
+                          <div className="perf-kpi-top"><span className="perf-kpi-label">{kpi.label}</span><KpiIcon type={kpi.icon} /></div>
+                          <div className="perf-kpi-value">{kpi.value}</div>
+                          <div className="perf-kpi-sub">{kpi.sub}</div>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div style={{ marginTop: '24px' }}>
+                      <div className="perf-section-header">
+                        <h2 className="perf-section-title">My Website Articles — Search Performance</h2>
+                        <span className="perf-section-meta">{websiteSeo.articles.filter((a: any) => a.hasGscData).length} with GSC data</span>
+                      </div>
+                      <div className="perf-table-wrap">
+                        <table className="perf-table">
+                          <thead>
+                            <tr>
+                              <th>Article</th>
+                              <th className="num">Impressions</th>
+                              <th className="num">Clicks</th>
+                              <th className="num">CTR</th>
+                              <th className="num">Position</th>
+                              <th>Published</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {websiteSeo.articles.map((a: any) => (
+                              <tr key={a.content_id}>
+                                <td className="perf-title-cell">
+                                  <div className="perf-title-cell-inner">
+                                    {a.hero_image_url && <img src={a.hero_image_url} alt="" className="perf-thumb" loading="lazy" width="40" height="28" />}
+                                    <span className="perf-post-title">
+                                      {a.url ? <a href={a.url} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>{a.title}</a> : a.title}
+                                    </span>
+                                  </div>
+                                </td>
+                                <td className="num">{a.hasGscData ? fmt(a.impressions) : '—'}</td>
+                                <td className="num">{a.hasGscData ? fmt(a.clicks) : '—'}</td>
+                                <td className="num">{a.hasGscData ? `${a.ctr}%` : '—'}</td>
+                                <td className="num">{a.hasGscData ? a.position : '—'}</td>
+                                <td>{a.published_at ? new Date(a.published_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '—'}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                      {websiteSeo.articles.some((a: any) => !a.hasGscData) && (
+                        <p style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', marginTop: 8, fontStyle: 'italic' }}>
+                          Articles showing — for search data need a GSC sync after publishing. GSC data typically takes 24-48 hours to populate. Matching uses the URL your receiver returned (or the Forge canonical fallback).
                         </p>
                       )}
                     </div>

--- a/src/server/routes/analytics.js
+++ b/src/server/routes/analytics.js
@@ -359,6 +359,83 @@ router.get('/webflow-seo/:brandProfileId', requireAuth, async (req, res) => {
   }
 });
 
+// GET /api/analytics/website-seo/:brandProfileId — My Website articles joined to GSC
+// Mirrors webflow-seo: publish_log channel=website × content_analytics channel=gsc.
+// My Website has no native analytics API (customer-hosted webhook), so organic
+// search performance via GSC is the primary owned-site signal.
+router.get('/website-seo/:brandProfileId', requireAuth, async (req, res) => {
+  const { brandProfileId } = req.params;
+  if (!(await verifyBrandAccess(brandProfileId, req.userId))) return res.status(403).json({ error: 'Access denied' });
+  try {
+    const siteRes = await pool.query(
+      `SELECT pl.content_id, pl.published_url, pl.attempted_at, pl.response_data,
+              ct.title, ct.hero_image_url
+       FROM publish_log pl
+       LEFT JOIN generated_content_${brandProfileId.replace(/-/g, '_')} ct ON ct.id::text = pl.content_id
+       WHERE pl.brand_profile_id = $1 AND pl.channel = 'website' AND pl.status = 'published'
+       ORDER BY pl.attempted_at DESC`,
+      [brandProfileId]
+    ).catch(() => ({ rows: [] }));
+
+    const gscCred = await pool.query(
+      'SELECT credentials FROM publishing_channels WHERE brand_profile_id = $1 AND channel = $2 AND is_active = true LIMIT 1',
+      [brandProfileId, 'gsc']
+    ).catch(() => ({ rows: [] }));
+    const gscConnected = gscCred.rows.length > 0;
+
+    if (!siteRes.rows.length) {
+      return res.json({ success: true, articles: [], totals: { published: 0, impressions: 0, clicks: 0, avgCtr: 0, avgPosition: 0 }, gscConnected });
+    }
+
+    const gscRes = await pool.query(
+      `SELECT content_id, post_id AS page_url, impressions, clicks, ctr, engagement_rate AS position, raw_data
+       FROM content_analytics
+       WHERE brand_profile_id = $1 AND channel = 'gsc'`,
+      [brandProfileId]
+    ).catch(() => ({ rows: [] }));
+
+    const gscByUrl = {};
+    for (const row of gscRes.rows) {
+      if (row.page_url) gscByUrl[row.page_url] = row;
+    }
+
+    const articles = siteRes.rows.map(row => {
+      const url = row.published_url || row.response_data?.url || '';
+      let gsc = gscByUrl[url] || gscByUrl[url.replace(/\/$/, '')] || null;
+      if (!gsc && url) {
+        const slug = url.replace(/\/$/, '').split('/').pop();
+        gsc = Object.values(gscByUrl).find(g => g.page_url && slug && g.page_url.includes(slug)) || null;
+      }
+      return {
+        content_id: row.content_id,
+        title: row.title || 'Untitled',
+        hero_image_url: row.hero_image_url || null,
+        url,
+        published_at: row.attempted_at,
+        impressions: gsc ? (gsc.impressions || 0) : 0,
+        clicks: gsc ? (gsc.clicks || 0) : 0,
+        ctr: gsc ? (gsc.ctr || 0) : 0,
+        position: gsc ? (gsc.position || 0) : 0,
+        hasGscData: !!gsc,
+      };
+    });
+
+    const withData = articles.filter(a => a.hasGscData);
+    const totals = {
+      published: articles.length,
+      impressions: articles.reduce((s, a) => s + a.impressions, 0),
+      clicks: articles.reduce((s, a) => s + a.clicks, 0),
+      avgCtr: withData.length ? parseFloat((withData.reduce((s, a) => s + a.ctr, 0) / withData.length).toFixed(2)) : 0,
+      avgPosition: withData.length ? parseFloat((withData.reduce((s, a) => s + a.position, 0) / withData.length).toFixed(1)) : 0,
+    };
+
+    res.json({ success: true, articles, totals, gscConnected });
+  } catch(e) {
+    console.error('[WEBSITE-SEO]', e.message);
+    res.status(500).json({ success: false, error: e.message });
+  }
+});
+
 router.post('/sync/:brandProfileId', async (req, res) => {
   const { brandProfileId } = req.params;
   // Allow cron/admin bypass with adminPassword, otherwise require Clerk JWT

--- a/test/routes.snapshot.json
+++ b/test/routes.snapshot.json
@@ -34,6 +34,7 @@
   "GET /api/analytics/decay/:brandProfileId",
   "GET /api/analytics/patterns/:brandProfileId",
   "GET /api/analytics/webflow-seo/:brandProfileId",
+  "GET /api/analytics/website-seo/:brandProfileId",
   "GET /api/articles/:brandSlug/:articleSlug",
   "GET /api/assets/:filename",
   "GET /api/auth/me",


### PR DESCRIPTION
## Summary
- Adds `GET /api/analytics/website-seo/:brandProfileId` — joins My Website `publish_log` rows to existing GSC `content_analytics` (same pattern as Webflow SEO).
- Performance Dashboard gets a **My Website** tab with KPIs + article table + Sync Search Data (reuses GSC connector).
- Docs (`/docs/my-website` + `docs/MYWEBSITE.md`) explain GSC as the analytics path and why returning `{url}` from the receiver improves matching.
- Route inventory snapshot updated (+1 route).

## Why
My Website publishes fine but had no analytics surface. No native site API exists; GSC is already connected and is the right owned-site signal.

## Test plan
- [ ] Route inventory green (`npm run routes:snapshot` already committed; inventory check matches 267).
- [ ] Brand with My Website publishes + GSC connected: Performance → My Website shows articles + GSC metrics after sync.
- [ ] Brand without GSC: empty state offers Connect GSC.
- [ ] Brand with GSC but no website publishes: empty state says publish first.
- [ ] URL matching works on receiver-returned `url` and falls back to slug/canonical.